### PR TITLE
Enable light yield collection for 1D spacal

### DIFF
--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -382,7 +382,9 @@ void CEMC_Cells(int verbosity = 0) {
       cemc_cells->Detector("CEMC");
       cemc_cells->Verbosity(verbosity);
       for (int i = Min_cemc_layer; i <= Max_cemc_layer; i++) {
-        cemc_cells->etaphisize(i, 0.024, 0.024);
+//          cemc_cells->etaphisize(i, 0.024, 0.024);
+          const double radius = 95;
+          cemc_cells->cellsize(i,  2*TMath::Pi()/256. * radius, 2*TMath::Pi()/256. * radius);
       }
       se->registerSubsystem(cemc_cells);
 
@@ -417,13 +419,29 @@ void CEMC_Towers(int verbosity = 0) {
   RawTowerBuilder *TowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
   TowerBuilder->Detector("CEMC");
   TowerBuilder->set_sim_tower_node_prefix("SIM");
-  if (Cemc_spacal_configuration
-      == PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal)
-    TowerBuilder->set_tower_energy_src(RawTowerBuilder::kEnergyDeposition);
   TowerBuilder->Verbosity(verbosity);
   se->registerSubsystem( TowerBuilder );
 
-  static const double sampling_fraction = 0.02244;//from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.3/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
+  double sampling_fraction = 1;
+  if (Cemc_spacal_configuration
+      == PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal)
+    {
+      sampling_fraction = 0.0234335; //from production:/gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.3/single_particle/spacal1d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
+    }
+  else if (Cemc_spacal_configuration
+      == PHG4CylinderGeom_Spacalv1::k2DProjectiveSpacal)
+    {
+      sampling_fraction = 0.02244; //from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.3/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
+    }
+  else
+    {
+      std::cout
+          << "G4_CEmc_Spacal.C::G4_CEmc_Spacal - Fatal Error - unrecognized SPACAL configuration #"
+          << Cemc_spacal_configuration<<". Force exiting..." << std::endl;
+      exit(-1);
+      return ;
+    }
+
   static const double photoelectron_per_GeV = 500;//500 photon per total GeV deposition
 
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");


### PR DESCRIPTION
As light collection being fixed in https://github.com/sPHENIX-Collaboration/coresoftware/pull/56 , enable visible energy use for the 1D calorimeter analysis. Also calibrate 1D/2D SPACAL with different calibration constant. 