### PR TITLE
Enable Calorimeter Truth Compression

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -77,6 +77,8 @@ int Fun4All_G4_fsPHENIX(
   bool do_FHCAL_twr = true; 
   bool do_FHCAL_cluster = true; 
 
+  bool do_dst_compress = true;
+  
   //Option to convert DST to human command readable TTree for quick poke around the outputs
   bool do_DSTReader = true;
   //---------------

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -233,6 +233,8 @@ int Fun4All_G4_fsPHENIX(
   if (do_FHCAL_twr) FHCAL_Towers();
   if (do_FHCAL_cluster) FHCAL_Clusters();
 
+  if (do_dst_compress) G4Compress();
+  
   //--------------
   // SVTX tracking
   //--------------

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -235,7 +235,7 @@ int Fun4All_G4_fsPHENIX(
   if (do_FHCAL_twr) FHCAL_Towers();
   if (do_FHCAL_cluster) FHCAL_Clusters();
 
-  if (do_dst_compress) G4Compress();
+  if (do_dst_compress) ShowerCompress();
   
   //--------------
   // SVTX tracking
@@ -324,6 +324,7 @@ int Fun4All_G4_fsPHENIX(
     }
 
   //Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outputFile);
+  //if (do_dst_compress) DstCompress(out);
   //se->registerOutputManager(out);
 
   if (nEvents == 0 && !readhits && !readhepmc)

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -77,7 +77,7 @@ int Fun4All_G4_fsPHENIX(
   bool do_FHCAL_twr = true; 
   bool do_FHCAL_cluster = true; 
 
-  bool do_dst_compress = true;
+  bool do_dst_compress = false;
   
   //Option to convert DST to human command readable TTree for quick poke around the outputs
   bool do_DSTReader = true;

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -286,6 +286,7 @@ int Fun4All_G4_sPHENIX(
     }
 
   // Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outputFile);
+  // if (do_dst_compress) DstCompress(out);
   // se->registerOutputManager(out);
 
   //-----------------

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -62,7 +62,7 @@ int Fun4All_G4_sPHENIX(
   bool do_jet_reco = true;
   bool do_jet_eval = true;
 
-  bool do_dst_compress = true;
+  bool do_dst_compress = false;
 
   //Option to convert DST to human command readable TTree for quick poke around the outputs
   bool do_DSTReader = false;

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -62,6 +62,8 @@ int Fun4All_G4_sPHENIX(
   bool do_jet_reco = true;
   bool do_jet_eval = true;
 
+  bool do_dst_compress = true;
+
   //Option to convert DST to human command readable TTree for quick poke around the outputs
   bool do_DSTReader = false;
   //---------------
@@ -202,6 +204,8 @@ int Fun4All_G4_sPHENIX(
 
   if (do_hcalout_twr) HCALOuter_Towers();
   if (do_hcalout_cluster) HCALOuter_Clusters();
+
+  if (do_dst_compress) G4Compress();
 
   //--------------
   // SVTX tracking

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -205,7 +205,7 @@ int Fun4All_G4_sPHENIX(
   if (do_hcalout_twr) HCALOuter_Towers();
   if (do_hcalout_cluster) HCALOuter_Clusters();
 
-  if (do_dst_compress) G4Compress();
+  if (do_dst_compress) ShowerCompress();
 
   //--------------
   // SVTX tracking

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -230,3 +230,40 @@ int G4Setup(const int absorberactive = 0,
   g4Reco->registerSubsystem(truth);
   se->registerSubsystem( g4Reco );
 }
+
+void G4Compress(int verbosity = 0) {
+
+  gSystem->Load("libg4eval.so");
+
+  PHG4DstCompressReco* compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_SVTXSUPPORT");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+  se->registerSubsystem(compress);
+  
+  return; 
+}

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -231,10 +231,14 @@ int G4Setup(const int absorberactive = 0,
   se->registerSubsystem( g4Reco );
 }
 
-void G4Compress(int verbosity = 0) {
 
+void ShowerCompress(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
   gSystem->Load("libg4eval.so");
 
+  Fun4AllServer *se = Fun4AllServer::instance();
+  
   PHG4DstCompressReco* compress = new PHG4DstCompressReco("PHG4DstCompressReco");
   compress->AddHitContainer("G4HIT_PIPE");
   compress->AddHitContainer("G4HIT_SVTXSUPPORT");
@@ -263,7 +267,52 @@ void G4Compress(int verbosity = 0) {
   compress->AddTowerContainer("TOWER_SIM_HCALOUT");
   compress->AddTowerContainer("TOWER_RAW_HCALOUT");
   compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL"); 
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+  
   se->registerSubsystem(compress);
   
   return; 
 }
+
+void DstCompress(Fun4AllDstOutputManager* out) {
+  if (out) {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_FHCAL"); 
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+  }
+}
+

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -179,3 +179,40 @@ int G4Setup(const int absorberactive = 0,
   g4Reco->registerSubsystem(truth);
   se->registerSubsystem( g4Reco );
 }
+
+void G4Compress(int verbosity = 0) {
+
+  gSystem->Load("libg4eval.so");
+
+  PHG4DstCompressReco* compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_SVTXSUPPORT");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+  se->registerSubsystem(compress);
+  
+  return; 
+}

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -180,10 +180,13 @@ int G4Setup(const int absorberactive = 0,
   se->registerSubsystem( g4Reco );
 }
 
-void G4Compress(int verbosity = 0) {
+void ShowerCompress(int verbosity = 0) {
 
+  gSystem->Load("libfun4all.so");
   gSystem->Load("libg4eval.so");
 
+  Fun4AllServer *se = Fun4AllServer::instance();
+  
   PHG4DstCompressReco* compress = new PHG4DstCompressReco("PHG4DstCompressReco");
   compress->AddHitContainer("G4HIT_PIPE");
   compress->AddHitContainer("G4HIT_SVTXSUPPORT");
@@ -215,4 +218,27 @@ void G4Compress(int verbosity = 0) {
   se->registerSubsystem(compress);
   
   return; 
+}
+
+void DstCompress(Fun4AllDstOutputManager* out) {
+  if (out) {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+  }
 }


### PR DESCRIPTION
I add 2 function calls to the setup macros to run the removal of compressed information and the removal of redundant nodes during the DST output.