### PR TITLE
Merge everything together including forward GEM and piston magnets

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -364,6 +364,22 @@ int Fun4All_G4_fsPHENIX(
 
       se->End();
       std::cout << "All done" << std::endl;
+
+
+      std::cout << "==== Useful display commands ==" << std::endl;
+      cout << "draw axis: " << endl;
+      cout << " G4Cmd(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
+      cout << "zoom" << endl;
+      cout << " G4Cmd(\"/vis/viewer/zoom 1\")" << endl;
+      cout << "viewpoint:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
+      cout << "panTo:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/panTo 0 0 cm\")" << endl;
+      cout << "print to eps:" << endl;
+      cout << " G4Cmd(\"/vis/ogl/printEPS\")" << endl;
+      cout << "set background color:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/set/background white\")" << endl;
+      std::cout << "===============================" << std::endl;
     }
   else
     {
@@ -376,4 +392,13 @@ int Fun4All_G4_fsPHENIX(
       gSystem->Exit(0);
     }
 
+}
+
+
+void
+G4Cmd(const char * cmd)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->ApplyCommand(cmd);
 }

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -157,7 +157,7 @@ int Fun4All_G4_fsPHENIX(
       PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
       //gen->add_particles("e-",5); // mu+,e+,proton,pi+,Upsilon
       //gen->add_particles("e+",5); // mu-,e-,anti_proton,pi-
-      gen->add_particles("mu-",1); // mu-,e-,anti_proton,pi-
+      gen->add_particles("pi-",1); // mu-,e-,anti_proton,pi-
       if (readhepmc) {
 	gen->set_reuse_existing_vertex(true);
 	gen->set_existing_vertex_offset_vector(0.0,0.0,0.0);

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -1,6 +1,6 @@
 
 int Fun4All_G4_fsPHENIX(
-		       const int nEvents = 10,
+		       const int nEvents = 2,
 		       const char * inputFile = "/gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal1d/fieldmap/G4Hits_sPHENIX_e-_eta0_16GeV.root",
 		       const char * outputFile = "G4fsPHENIX.root"
 		       )
@@ -62,8 +62,8 @@ int Fun4All_G4_fsPHENIX(
   bool do_jet_reco = false;
   bool do_jet_eval = false; 
 
-  bool do_fwd_jet_reco = false;
-  bool do_fwd_jet_eval = false; 
+  bool do_fwd_jet_reco = true;
+  bool do_fwd_jet_eval = true;
 
   // fsPHENIX geometry
 
@@ -107,7 +107,8 @@ int Fun4All_G4_fsPHENIX(
   //---------------
 
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(0); 
+//  se->Verbosity(0); // uncomment for batch production running with minimal output messages
+  se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // uncomment for some info for interactive running
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();
   // By default every random number generator uses
@@ -167,7 +168,7 @@ int Fun4All_G4_fsPHENIX(
       }
       gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
       gen->set_vertex_size_parameters(0.0,0.0);
-      gen->set_eta_range(1.4, 4.0);
+      gen->set_eta_range(1.4, 3.0);
       //gen->set_eta_range(3.0, 3.0); //fsPHENIX FWD
       gen->set_phi_range(-1.0*TMath::Pi(), 1.0*TMath::Pi());
       //gen->set_phi_range(TMath::Pi()/2-0.1, TMath::Pi()/2-0.1);

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -341,14 +341,13 @@ void DstCompress(Fun4AllDstOutputManager* out) {
   }
 }
 
-
 int
 make_piston(string name, PHG4Reco* g4Reco)
 {
-  const double zpos0 = 120.0;     // first large GEM station
-  const double zpos1 = 305 - 20;  // front of forward ECal/MPC
-  const double zpos2 = 335.9 - 10.2/2.; // front of the forward field endcap
-  const double calorimeter_hole_diamater =  2.2 * 4; // side length of the middle hole of MPC that can hold the piston. Also the max diameter of the piston in that region
+  const double zpos0 = 120.0; // first large GEM station
+  const double zpos1 = 305 - 20; // front of forward ECal/MPC
+  const double zpos2 = 335.9 - 10.2 / 2.; // front of the forward field endcap
+  const double calorimeter_hole_diamater = 9.92331 *2; // side length of the middle hole of MPC that can hold the piston. Also the max diameter of the piston in that region
 
   const double beampipe_radius = 2.1;
 
@@ -394,20 +393,41 @@ make_piston(string name, PHG4Reco* g4Reco)
       magpiston->SuperDetector(name);
       magpiston->SetZlength(teeth_thickness / 2);
       magpiston->SetPlaceZ(pos);
-      magpiston->SetR1(//
-          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01 )) * (pos - teeth_thickness / 2),//
-          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_teeth_outter)) * (pos - teeth_thickness / 2) //
-          );
-      magpiston->SetR2(//
-          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01 )) * (pos + teeth_thickness / 2),//
-          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01 )) * (pos + teeth_thickness / 2) + .1//
+      magpiston->SetR1(
+          //
+          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01))
+              * (pos - teeth_thickness / 2), //
+          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_teeth_outter))
+              * (pos - teeth_thickness / 2) //
+              );
+      magpiston->SetR2(
+          //
+          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01))
+              * (pos + teeth_thickness / 2), //
+          tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(eta_outter - .01))
+              * (pos + teeth_thickness / 2) + .1 //
               );
       magpiston->SetMaterial("G4_W");
       magpiston->SuperDetector(name.c_str());
       magpiston->SetActive(false);
       magpiston->OverlapCheck(overlapcheck);
       g4Reco->registerSubsystem(magpiston);
-      pos += ((320 - zpos0) / number_of_wteeth);
+      pos += ((zpos1 - zpos0) / number_of_wteeth);
     }
+
+  // last piece connect to the field return
+  PHG4CylinderSubsystem *magpiston2 = new PHG4CylinderSubsystem(
+      "Piston_EndSection", 0);
+  magpiston2->SetLength(zpos2 - zpos1);
+  magpiston2->SuperDetector(name);
+  magpiston2->SetPosition(0, 0, (zpos2 + zpos1) / 2.);
+  magpiston2->SetRadius(beampipe_radius);
+  magpiston2->SetLengthViaRapidityCoverage(false);
+  magpiston2->SetThickness(calorimeter_hole_diamater / 2. - beampipe_radius);
+  magpiston2->SetMaterial("G4_Fe");
+  magpiston2->SetActive(false);
+  magpiston2->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(magpiston2);
+
   return 0;
 }

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -185,7 +185,7 @@ int G4Setup(const int absorberactive = 0,
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
   flux_return_plus->SetLength(10.2);
   flux_return_plus->SetPosition(0,0,335.9);
-  flux_return_plus->SetRadius(5.0);
+  flux_return_plus->SetRadius(2.1);
   flux_return_plus->SetLengthViaRapidityCoverage(false);
   flux_return_plus->SetThickness(263.5-5.0);
   flux_return_plus->SetMaterial("G4_Fe");
@@ -197,7 +197,7 @@ int G4Setup(const int absorberactive = 0,
   PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
   flux_return_minus->SetLength(10.2);
   flux_return_minus->SetPosition(0,0,-335.9);
-  flux_return_minus->SetRadius(5.0);
+  flux_return_minus->SetRadius(2.1);
   flux_return_minus->SetLengthViaRapidityCoverage(false);
   flux_return_minus->SetThickness(263.5-5.0);
   flux_return_minus->SetMaterial("G4_Fe");

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -344,12 +344,20 @@ void DstCompress(Fun4AllDstOutputManager* out) {
 int
 make_piston(string name, PHG4Reco* g4Reco)
 {
-  const double zpos0 = 120.0; // first large GEM station
+  double be_pipe_radius    = 2.16;   // 2.16 cm based on spec sheet
+  double be_pipe_thickness = 0.0760; // 760 um based on spec sheet
+  double be_pipe_length    = 80.0;   // +/- 40 cm
+
+  double al_pipe_radius    = 2.16;   // same as Be pipe
+  double al_pipe_thickness = 0.1600; // 1.6 mm based on spec
+  double al_pipe_length    = 88.3;   // extension beyond +/- 40 cm
+
+  const double zpos0 = al_pipe_length + be_pipe_length * 0.5; // first large GEM station
   const double zpos1 = 305 - 20; // front of forward ECal/MPC
   const double zpos2 = 335.9 - 10.2 / 2.; // front of the forward field endcap
   const double calorimeter_hole_diamater = 9.92331 *2; // side length of the middle hole of MPC that can hold the piston. Also the max diameter of the piston in that region
 
-  const double beampipe_radius = 2.1;
+  const double beampipe_radius = be_pipe_radius;
 
   // teeth cone section specific
   const double number_of_wteeth = 100;
@@ -358,8 +366,8 @@ make_piston(string name, PHG4Reco* g4Reco)
   const double eta_outter = 4.2;
   const double eta_teeth_outter = 4.05;
   double pos = zpos0 + (zpos1 - zpos0) / 2;
-  cout << "MAGNETIC PISTON:" << eta_inner << " " << eta_outter << " " << pos
-      << endl;
+//  cout << "MAGNETIC PISTON:" << eta_inner << " " << eta_outter << " " << pos
+//      << endl;
 
   PHG4ConeSubsystem *magpiston = new PHG4ConeSubsystem("Piston", 0);
   magpiston->SetZlength((zpos1 - zpos0) / 2);
@@ -412,7 +420,7 @@ make_piston(string name, PHG4Reco* g4Reco)
       magpiston->SetActive(false);
       magpiston->OverlapCheck(overlapcheck);
       g4Reco->registerSubsystem(magpiston);
-      pos += ((zpos1 - zpos0) / number_of_wteeth);
+      pos += ((zpos1 - zpos0 - 10) / number_of_wteeth);
     }
 
   // last piece connect to the field return
@@ -431,3 +439,4 @@ make_piston(string name, PHG4Reco* g4Reco)
 
   return 0;
 }
+

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -1,8 +1,5 @@
 using namespace std;
 
-// global macro parameters
-bool overlapcheck = false; // set to true if you want to check for overlaps
-
 void
 FEMCInit()
 {

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -34,11 +34,15 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   ostringstream mapping_femc;
 
-  /* path to central copy of calibrations repositry */
-  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations";
-  mapping_femc << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+  // EIC ECAL
+  //femc->SetEICDetector(); 
+  //mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+
+  // fsPHENIX ECAL
+  femc->SetfsPHENIXDetector(); 
+  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
+
   cout << mapping_femc.str() << endl;
-  //mapping_femc << "towerMap_FEMC_latest.txt";
 
   femc->SetTowerMappingFile( mapping_femc.str() );
   femc->OverlapCheck(overlapcheck);
@@ -56,9 +60,13 @@ void FEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_femc;
+  // EIC ECAL
+  //mapping_femc << getenv("OFFLINE_MAIN") <<
+  // 	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+
+  // fsPHENIX ECAL
   mapping_femc << getenv("OFFLINE_MAIN") <<
-   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
-  //mapping_femc << "towerMap_FEMC_latest.txt";
+   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -101,7 +109,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration->Detector("FEMC");
   TowerCalibration->Verbosity(verbosity);
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1.0/0.2949);  // calibrated with muons
+  TowerCalibration->set_calib_const_GeV_ADC(1.0);  // sanpling fraction = 1.0
   TowerCalibration->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration );
 

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -205,9 +205,9 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
     double etamax,  const int N_Sector = 8)
 {
 
-  cout
-      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
-      << name << endl;
+//  cout
+//      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+//      << name << endl;
 
   double polar_angle = 0;
 

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -1,8 +1,5 @@
 using namespace std;
 
-// global macro parameters
-bool overlapcheck = false; // set to true if you want to check for overlaps
-
 void
 FHCALInit()
 {

--- a/macros/g4simulations/G4_FwdJets.C
+++ b/macros/g4simulations/G4_FwdJets.C
@@ -11,9 +11,9 @@ void Jet_FwdReco(int verbosity = 0) {
   //truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Truth_r02");
   truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.3),"AntiKt_Truth_r03");
   // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.4),"AntiKt_Truth_r04");
-  // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.5),"AntiKt_Truth_r05");
+   truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.5),"AntiKt_Truth_r05");
   // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.6),"AntiKt_Truth_r06");
-  // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.7),"AntiKt_Truth_r07");
+   truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.7),"AntiKt_Truth_r07");
   // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.8),"AntiKt_Truth_r08");
   truthjetreco->set_algo_node("ANTIKT");
   truthjetreco->set_input_node("TRUTH");
@@ -27,9 +27,9 @@ void Jet_FwdReco(int verbosity = 0) {
   // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Tower_r02");
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.3),"AntiKt_Tower_r03");
   // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.4),"AntiKt_Tower_r04");
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.5),"AntiKt_Tower_r05");
+   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.5),"AntiKt_Tower_r05");
   // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.6),"AntiKt_Tower_r06");
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.7),"AntiKt_Tower_r07");
+   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.7),"AntiKt_Tower_r07");
   // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.8),"AntiKt_Tower_r08");
   towerjetreco->set_algo_node("ANTIKT");
   towerjetreco->set_input_node("TOWER");
@@ -47,8 +47,8 @@ void Jet_FwdEval(std::string outfilename = "g4fwdjets_eval.root",
   Fun4AllServer *se = Fun4AllServer::instance();
 
   JetEvaluator* eval = new JetEvaluator("JETEVALUATOR",
-   					"AntiKt_Tower_r03",
-   					"AntiKt_Truth_r03",
+   					"AntiKt_Tower_r05",
+   					"AntiKt_Truth_r05",
    					outfilename);
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -26,8 +26,9 @@
 # machines. You might have to play with it. GEANT prints out a
 # list of available graphics systems at some point.
 #/vis/open OGLIX
-/vis/open OGLSX
-/vis/viewer/set/viewpointThetaPhi 20 0
+/vis/open OGLSX 1200x900-0+0
+/vis/viewer/set/viewpointThetaPhi 240 -10
+/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
 /vis/viewer/zoom 1.5

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -63,6 +63,10 @@
 # For example, select colour by particle ID
 #/vis/modeling/trajectories/create/drawByParticleID
 #/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 2 MeV 1000 GeV
 #
 /vis/scene/endOfEventAction accumulate
 #


### PR DESCRIPTION
Merge everything together for the fsPHENIX simulation including John's forward calorimeters, Cesar's new field map, updated GEM and piston magnet. Passed geometry checks. More details see wiki: 
https://wiki.bnl.gov/sPHENIX/index.php/Tutorial/fsPHENIX_simulation 

Example event display from the macro: 

* 30 GeV negatively charged pion in the forward calorimeters
<img width="565" alt="2016-03-22 19_09_55-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/13971940/9973bc94-f06a-11e5-8843-bb2e295875fa.png">

* \sqrt{s} = 510 GeV p + p collision with two ET ~ 20-30 GeV jets measured in the forward (eta=1.5) and central (eta=0.17) calorimeters 
<img width="484" alt="2016-03-22 19_33_13-nomachine - nx06 eta0 17 1 54" src="https://cloud.githubusercontent.com/assets/7947083/13971985/0d0a6306-f06b-11e5-89b7-79382d62fa84.png">
 


