### PR TITLE
updated to allow PbSc tower type in n ew mapping file

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -364,6 +364,22 @@ int Fun4All_G4_fsPHENIX(
 
       se->End();
       std::cout << "All done" << std::endl;
+
+
+      std::cout << "==== Useful display commands ==" << std::endl;
+      cout << "draw axis: " << endl;
+      cout << " G4Cmd(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
+      cout << "zoom" << endl;
+      cout << " G4Cmd(\"/vis/viewer/zoom 1\")" << endl;
+      cout << "viewpoint:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
+      cout << "panTo:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/panTo 0 0 cm\")" << endl;
+      cout << "print to eps:" << endl;
+      cout << " G4Cmd(\"/vis/ogl/printEPS\")" << endl;
+      cout << "set background color:" << endl;
+      cout << " G4Cmd(\"/vis/viewer/set/background white\")" << endl;
+      std::cout << "===============================" << std::endl;
     }
   else
     {
@@ -376,4 +392,13 @@ int Fun4All_G4_fsPHENIX(
       gSystem->Exit(0);
     }
 
+}
+
+
+void
+G4Cmd(const char * cmd)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->ApplyCommand(cmd);
 }

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -104,7 +104,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration2->TowerType(2);
   TowerCalibration2->Verbosity(verbosity);
   TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.2949);  // sampling fraction = 0.2949
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
   TowerCalibration2->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration2 );
 

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -75,7 +75,7 @@ void FEMC_Towers(int verbosity = 0) {
   // PbW crystals
   RawTowerDigitizer *TowerDigitizer1 = new RawTowerDigitizer("FEMCRawTowerDigitizer1");
   TowerDigitizer1->Detector("FEMC");
-  TowerDigitizer1->TowerType(1.0); 
+  TowerDigitizer1->TowerType(1); 
   TowerDigitizer1->Verbosity(verbosity);
   TowerDigitizer1->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
   se->registerSubsystem( TowerDigitizer1 );
@@ -83,7 +83,7 @@ void FEMC_Towers(int verbosity = 0) {
   // PbSc towers
   RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
   TowerDigitizer2->Detector("FEMC");
-  TowerDigitizer2->TowerType(2.0); 
+  TowerDigitizer2->TowerType(2); 
   TowerDigitizer2->Verbosity(verbosity);
   TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
   se->registerSubsystem( TowerDigitizer2 );
@@ -91,7 +91,7 @@ void FEMC_Towers(int verbosity = 0) {
   // PbW crystals
   RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
   TowerCalibration1->Detector("FEMC");
-  TowerCalibration1->TowerType(1.0);
+  TowerCalibration1->TowerType(1);
   TowerCalibration1->Verbosity(verbosity);
   TowerCalibration1->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
   TowerCalibration1->set_calib_const_GeV_ADC(1.0);  // sampling fraction = 1.0
@@ -101,7 +101,7 @@ void FEMC_Towers(int verbosity = 0) {
   // PbSc towers
   RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
   TowerCalibration2->Detector("FEMC");
-  TowerCalibration2->TowerType(2.0);
+  TowerCalibration2->TowerType(2);
   TowerCalibration2->Verbosity(verbosity);
   TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
   TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.2949);  // sampling fraction = 0.2949

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -40,7 +40,7 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   // fsPHENIX ECAL
   femc->SetfsPHENIXDetector(); 
-  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
+  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v002.txt";
 
   cout << mapping_femc.str() << endl;
 
@@ -66,7 +66,7 @@ void FEMC_Towers(int verbosity = 0) {
 
   // fsPHENIX ECAL
   mapping_femc << getenv("OFFLINE_MAIN") <<
-   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
+   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v002.txt";
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -72,43 +72,41 @@ void FEMC_Towers(int verbosity = 0) {
 
   se->registerSubsystem(tower_FEMC);
 
-  // const double FEMC_photoelectron_per_GeV = 500; //500 photon per total GeV deposition
+  // PbW crystals
+  RawTowerDigitizer *TowerDigitizer1 = new RawTowerDigitizer("FEMCRawTowerDigitizer1");
+  TowerDigitizer1->Detector("FEMC");
+  TowerDigitizer1->TowerType(1.0); 
+  TowerDigitizer1->Verbosity(verbosity);
+  TowerDigitizer1->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
+  se->registerSubsystem( TowerDigitizer1 );
 
-  // RawTowerDigitizer *TowerDigitizer_FEMC = new RawTowerDigitizer("FEMCRawTowerDigitizer");
-  // TowerDigitizer_FEMC->Detector("FEMC");
-  // TowerDigitizer_FEMC->Verbosity(verbosity);
-  // TowerDigitizer_FEMC->set_raw_tower_node_prefix("RAW");
-  // TowerDigitizer_FEMC->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
-  // TowerDigitizer_FEMC->set_pedstal_central_ADC(0);
-  // TowerDigitizer_FEMC->set_pedstal_width_ADC(8);// eRD1 test beam setting
-  // TowerDigitizer_FEMC->set_photonelec_ADC(1);//not simulating ADC discretization error
-  // TowerDigitizer_FEMC->set_photonelec_yield_visible_GeV( FEMC_photoelectron_per_GeV );
-  // TowerDigitizer_FEMC->set_zero_suppression_ADC(16); // eRD1 test beam setting
+  // PbSc towers
+  RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  TowerDigitizer2->Detector("FEMC");
+  TowerDigitizer2->TowerType(2.0); 
+  TowerDigitizer2->Verbosity(verbosity);
+  TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
+  se->registerSubsystem( TowerDigitizer2 );
 
-  // se->registerSubsystem( TowerDigitizer_FEMC );
+  // PbW crystals
+  RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
+  TowerCalibration1->Detector("FEMC");
+  TowerCalibration1->TowerType(1.0);
+  TowerCalibration1->Verbosity(verbosity);
+  TowerCalibration1->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration1->set_calib_const_GeV_ADC(1.0);  // sampling fraction = 1.0
+  TowerCalibration1->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration1 );
 
-  // RawTowerCalibration *TowerCalibration_FEMC = new RawTowerCalibration("FEMCRawTowerCalibration");
-  // TowerCalibration_FEMC->Detector("FEMC");
-  // TowerCalibration_FEMC->Verbosity(verbosity);
-  // TowerCalibration_FEMC->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  // TowerCalibration_FEMC->set_calib_const_GeV_ADC( 1. / FEMC_photoelectron_per_GeV );
-  // TowerCalibration_FEMC->set_pedstal_ADC( 0 );
-
-  // se->registerSubsystem( TowerCalibration_FEMC );
-
-  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FEMCRawTowerDigitizer");
-  TowerDigitizer->Detector("FEMC");
-  TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
-  se->registerSubsystem( TowerDigitizer );
-
-  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FEMCRawTowerCalibration");
-  TowerCalibration->Detector("FEMC");
-  TowerCalibration->Verbosity(verbosity);
-  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1.0);  // sanpling fraction = 1.0
-  TowerCalibration->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration );
+  // PbSc towers
+  RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  TowerCalibration2->Detector("FEMC");
+  TowerCalibration2->TowerType(2.0);
+  TowerCalibration2->Verbosity(verbosity);
+  TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.2949);  // sampling fraction = 0.2949
+  TowerCalibration2->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration2 );
 
 }
 

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -34,11 +34,15 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   ostringstream mapping_femc;
 
-  /* path to central copy of calibrations repositry */
-  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations";
-  mapping_femc << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+  // EIC ECAL
+  //femc->SetEICDetector(); 
+  //mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+
+  // fsPHENIX ECAL
+  femc->SetfsPHENIXDetector(); 
+  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
+
   cout << mapping_femc.str() << endl;
-  //mapping_femc << "towerMap_FEMC_latest.txt";
 
   femc->SetTowerMappingFile( mapping_femc.str() );
   femc->OverlapCheck(overlapcheck);
@@ -56,9 +60,13 @@ void FEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_femc;
+  // EIC ECAL
+  //mapping_femc << getenv("OFFLINE_MAIN") <<
+  // 	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+
+  // fsPHENIX ECAL
   mapping_femc << getenv("OFFLINE_MAIN") <<
-   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
-  //mapping_femc << "towerMap_FEMC_latest.txt";
+   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v001.txt";
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -101,7 +109,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration->Detector("FEMC");
   TowerCalibration->Verbosity(verbosity);
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1.0/0.2949);  // calibrated with muons
+  TowerCalibration->set_calib_const_GeV_ADC(1.0);  // sanpling fraction = 1.0
   TowerCalibration->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration );
 

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -63,6 +63,10 @@
 # For example, select colour by particle ID
 #/vis/modeling/trajectories/create/drawByParticleID
 #/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 2 MeV 1000 GeV
 #
 /vis/scene/endOfEventAction accumulate
 #


### PR DESCRIPTION
Use new tower mapping file that generates combined PbSc/MPC forward ECAL for fsPHENIX.  There are corresponding pull requests in coresoftware and calibrations. 