### PR TITLE
Spacal test beam 2016

### DIFF
--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -21,7 +21,7 @@ int Fun4All_G4_Prototype2(
   PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
   gen->add_particles("pi-", 1); // mu-,e-,anti_proton,pi-
   gen->set_vertex_distribution_mean(0.0, 0.0, 0);
-  gen->set_vertex_distribution_width(0.0, .3, 0.3); // 3x3 mm beam spot as measured in Si-telescope
+  gen->set_vertex_distribution_width(0.0, .3/2, .3/2); // 3x3 mm beam spot as measured in Si-telescope
   gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,
       PHG4SimpleEventGenerator::Gaus, PHG4SimpleEventGenerator::Gaus); // Gauss beam profile
   gen->set_eta_range(-.001, .001); // 1mrad angular divergence

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -16,18 +16,21 @@ int Fun4All_G4_Prototype2(
   //  se->Verbosity(1);
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RANDOMSEED",12345);
-  PHG4ParticleGenerator *gen = new PHG4ParticleGenerator();
-  gen->set_name("geantino");
-  //  gen->set_name("proton");
-  gen->set_vtx(0, 0, 0);
-  //  gen->set_eta_range(0.297, 0.303);
-  gen->set_eta_range(-0.2, 0.2);
-  gen->set_mom_range(1.0, 1.0);
-  gen->set_z_range(0.,0.);
-  gen->set_phi_range(18/180.*TMath::Pi(), -16/180.*TMath::Pi());
-  //    gen->set_phi_range(-17./180.*TMath::Pi(),-7./180.*TMath::Pi());
-  //  se->registerSubsystem(gen);
 
+  // Test beam generator
+  PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
+  gen->add_particles("pi-", 1); // mu-,e-,anti_proton,pi-
+  gen->set_vertex_distribution_mean(0.0, 0.0, 0);
+  gen->set_vertex_distribution_width(0.0, .3, 0.3); // 3x3 mm beam spot as measured in Si-telescope
+  gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,
+      PHG4SimpleEventGenerator::Gaus, PHG4SimpleEventGenerator::Gaus); // Gauss beam profile
+  gen->set_eta_range(-.001, .001); // 1mrad angular divergence
+  gen->set_phi_range(-.001, .001); // 1mrad angular divergence
+  const double momentum = 32;
+  gen->set_p_range(momentum,momentum, momentum*2e-2); // 2% momentum smearing
+  se->registerSubsystem(gen);
+
+  // Simple single particle generator
   PHG4ParticleGun *gun = new PHG4ParticleGun();
   //  gun->set_name("anti_proton");
   //  gun->set_name("geantino");
@@ -38,7 +41,7 @@ int Fun4All_G4_Prototype2(
   // gun->AddParticle("geantino",1.7709,-0.4598,0.);
   // gun->AddParticle("geantino",2.5621,0.60964,0.);
   // gun->AddParticle("geantino",1.8121,0.253,0.);
-  se->registerSubsystem(gun);
+//  se->registerSubsystem(gun);
 
   PHG4Reco* g4Reco = new PHG4Reco();
   g4Reco->set_field(0);
@@ -53,9 +56,11 @@ int Fun4All_G4_Prototype2(
   cemc->SuperDetector("CEMC");
   cemc->SetAbsorberActive();
   cemc->OverlapCheck(true);
-  cemc->GetParameters().ReadFromFile("root", "./test_geom/");
+  cemc->GetParameters().ReadFromFile("xml", string(getenv("OFFLINE_MAIN")) + string("/share/calibrations/Prototype2/Geometry/") ); // geometry database
 //  cemc->GetParameters().set_double_param("z_rotation_degree", 15); // rotation around CG
   cemc->GetParameters().set_double_param("xpos", 105); // location in cm of EMCal CG. Update with final positioning of EMCal
+//  cemc->GetParameters().set_double_param("ypos", 0); // vertical shift
+//  cemc->GetParameters().set_double_param("zpos", 0); // horizontal shift
   g4Reco->registerSubsystem(cemc);
 
   //----------------------------------------

--- a/macros/prototype2/vis_prototype2.mac
+++ b/macros/prototype2/vis_prototype2.mac
@@ -28,7 +28,7 @@
 #/vis/open OGLIX
 /vis/open OGLSX 1200x900-0+0
 /vis/viewer/set/viewpointThetaPhi 0 0
-/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+# /vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
 /vis/viewer/zoom 1.5

--- a/macros/prototype2/vis_prototype2.mac
+++ b/macros/prototype2/vis_prototype2.mac
@@ -1,0 +1,80 @@
+# $Id: vis.mac,v 1.4 2010/04/14 18:32:59 lindenle Exp $
+#
+# Macro file for the initialization phase of "exampleN03.cc"
+# when running in interactive mode
+#
+# Sets some default verbose
+#
+/control/verbose 2
+/control/saveHistory
+/run/verbose 2
+#
+# create empty scene
+#
+/vis/scene/create
+#
+# Create a scene handler for a specific graphics system
+# (Edit the next line(s) to choose another graphic system)
+#
+# Use this open statement to get an .eps and .prim files
+# suitable for viewing in DAWN.
+###/vis/open DAWNFILE
+#
+# Use this open statement instead for OpenGL in immediate mode.
+# OGLIX works on the desktops in 1008 while OGLSX terminates
+# the X server. I've heard similar stories about OGLIX on other
+# machines. You might have to play with it. GEANT prints out a
+# list of available graphics systems at some point.
+#/vis/open OGLIX
+/vis/open OGLSX 1200x900-0+0
+/vis/viewer/set/viewpointThetaPhi 0 0
+/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+# our world is 4x4 meters, the detector is about 1m across
+# zooming by 4 makes it fill the display
+/vis/viewer/zoom 1.5
+#
+# Use this open statement instead to get a HepRep version 1 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepFile
+#
+# Use this open statement instead to get a HepRep version 2 file
+# suitable for viewing in WIRED.
+#/vis/open HepRepXML
+#
+# Output an empty detector
+# /vis/viewer/flush
+#
+# Draw trajectories at end of event, showing trajectory points as
+# markers of size 2 pixels
+/vis/scene/add/trajectories smooth
+/vis/modeling/trajectories/create/drawByCharge
+/vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
+/vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
+# (if too many tracks cause core dump => /tracking/storeTrajectory 0)
+#
+# To draw gammas only
+#/vis/filtering/trajectories/create/particleFilter
+#/vis/filtering/trajectories/particleFilter-0/add gamma
+#
+# To draw charged particles only
+#/vis/filtering/trajectories/particleFilter-0/invert true
+#
+# Many other options available with /vis/modeling and /vis/filtering.
+# For example, select colour by particle ID
+#/vis/modeling/trajectories/create/drawByParticleID
+#/vis/modeling/trajectories/drawByParticleID-0/set e- red
+# remove low energy stuff
+/vis/filtering/trajectories/create/attributeFilter
+/vis/filtering/trajectories/attributeFilter-0/setAttribute IMag
+/vis/filtering/trajectories/attributeFilter-0/addInterval 50 MeV 1000 GeV
+#
+/vis/scene/endOfEventAction accumulate
+#
+# At end of each run, an automatic flush causes graphical output.
+#/run/beamOn 1
+# When you exit Geant4, you will find a file called scene-0.heprep.zip.
+# Unzipping this will give you three separate HepRep files suitable for
+# viewing in WIRED.
+# The first file will contain just detector geometry.
+# The second file will contain the detector plus one event.
+# The third file will contain the detector plus ten events.


### PR DESCRIPTION
Merge SPACAL and HCals: 
* Add a particle generator more compatible with test beam profile
* Add EMCal in simulation. More discussion on https://github.com/sPHENIX-Collaboration/coresoftware/pull/121 . The default geometry is loaded via calibration database in XML form: https://github.com/sPHENIX-Collaboration/calibrations/pull/8
* Add EMCal digitization
* Add DST reader which output an ROOT CINT friendly TTree with hits and towers

Example setup with 32 GeV pi- shower:
<img width="464" alt="2016-03-28 21_59_29-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14097822/8a571af2-f543-11e5-9f00-4f4b2e153338.png">
