### PR TITLE
Fix inner radii of the beampipes based on engineering drawing.

### DIFF
--- a/macros/g4simulations/G4_Pipe.C
+++ b/macros/g4simulations/G4_Pipe.C
@@ -6,11 +6,11 @@ double Pipe(PHG4Reco* g4Reco,
 	    const int absorberactive = 0,
 	    int verbosity = 0) {
 
-  double be_pipe_radius    = 2.16;   // 2.16 cm based on spec sheet
+  double be_pipe_radius    = 2.0005; // 4.001 cm inner diameter from spec sheet
   double be_pipe_thickness = 0.0760; // 760 um based on spec sheet
   double be_pipe_length    = 80.0;   // +/- 40 cm
 
-  double al_pipe_radius    = 2.16;   // same as Be pipe
+  double al_pipe_radius    = 2.0005; // same as Be pipe
   double al_pipe_thickness = 0.1600; // 1.6 mm based on spec
   double al_pipe_length    = 88.3;   // extension beyond +/- 40 cm
   


### PR DESCRIPTION
Change the inner radii of the beam pipes to match the engineering diagram. Both the Be and Al beam pipes should have inner radii of 2.0005 cm
[22906rB_PHENIX_(v2)_Beam_Pipe_Asm_CAP.pdf](https://github.com/sPHENIX-Collaboration/macros/files/199925/22906rB_PHENIX_.v2._Beam_Pipe_Asm_CAP.pdf)
