### PR TITLE
Spacal test beam 2016 - update

### DIFF
--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -268,8 +268,10 @@ int Fun4All_G4_Prototype2(
 //      ana->AddNode("ABSORBER_CEMC");
 //    }
   ana->AddTower("SIM_CEMC");
-  ana->AddTower("RAW_CEMC");
-  ana->AddTower("CALIB_CEMC");
+  ana->AddTower("RAW_LG_CEMC");
+  ana->AddTower("CALIB_LG_CEMC");// Low gain CEMC
+  ana->AddTower("RAW_HG_CEMC");
+  ana->AddTower("CALIB_HG_CEMC");// High gain CEMC
   ana->AddTower("OUTERHCAL");
   ana->AddTower("INNERHCAL");
 


### PR DESCRIPTION
## Overview

Hopefully last update on SPACAL prototype setup, with dimensions and digitalziation parameter as measured by Sean Stoll and John Haggerty. Specifically
* Tower dimension, assembly spacing as measured by Sean. 
* Two tower output streams includes High gain and Low gain channels. Pixel yield, Pixel -> ADC conversion as measured by Sean. Pedstal noise as measured by John. 

Related updates include:
* Geometry database: https://github.com/sPHENIX-Collaboration/calibrations/pull/9
* G4 simulation macro: this pull request
* Plot macro: https://github.com/sPHENIX-Collaboration/analysis/tree/master/Prototype2/EMCal/macros
* 5k event / setting production set at sPHENIX user disk, available for anyone to look at it with the above plot macros: RCF:/phenix/u/jinhuang/links/sPHENIX_work/Prototype_2016/EMCal_sim/

## Fine inspection

Side view with 12 GeV electron shower
<img width="449" alt="2016-04-04 17_20_19-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14288976/e66e3d64-fb26-11e5-8447-cd3a419a2753.png">

Front view into the fiber matrix in the center, showing
* 18 mil W shell outside the fiber matrix due to machining residual
* Diameter-470um fibers in 1mm triangle matrix and protective in the vertical direction
* 0.1 mm horizontal assembly spacing
* 0.33 mm vertical assembly spacing
<img width="588" alt="2016-04-04 18_06_37-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14288991/f4985c4e-fb26-11e5-8463-0394be3a6dce.png">

## Calibration data simulations

Planned calibration with 120 GeV beam and 90 degree rotation on the SPACAL:
<img width="503" alt="2016-04-05 11_19_39-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14288958/cf8e24a6-fb26-11e5-8955-6b4570948cc2.png">

Also in tower-by-tower energy spectrum in the High Gain mode: 
![prototype_proton_120_segall_dstreader root_drawemcaltower_emcdistribution_hg_all_event](https://cloud.githubusercontent.com/assets/7947083/14289138/890708c6-fb27-11e5-974c-af271d0fd257.png)

And in Low Gain mode, we can see many proton showered:
![prototype_proton_120_segall_dstreader root_drawemcaltower_emcdistribution_lg_log_all_event](https://cloud.githubusercontent.com/assets/7947083/14289418/b00b9706-fb28-11e5-9591-38cf20ba607c.png)


As well as the summed energy spectrum in the High Gain or Low Gain mode: 

![prototype_proton_120_segall_dstreader root_drawemcaltower_emcdistribution_sum_all_event](https://cloud.githubusercontent.com/assets/7947083/14289172/b0063410-fb27-11e5-9e40-1efb47f0c06c.png)

## Performance data simulations

Baseline performance data via calorimeter tilted by 15 Degree to simulate eta = 0.3 tracks. 
<img width="529" alt="2016-04-05 10_11_07-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14289362/75fa6f7e-fb28-11e5-992f-4019a0aa1ddb.png">


The electron resolution and linearity is similar to the full SPACAL in sPHENIX (12% / sqrt[E]):
Note the \Delta E part included 2% beam momentum spread that goes to the constant term.  

![drawemcaltower_resolution](https://cloud.githubusercontent.com/assets/7947083/14289243/e922b0e8-fb27-11e5-8795-6268c4cf5e7e.png)

And the stack of shower line shape for various particles:
![drawemcaltower_lineshape_4](https://cloud.githubusercontent.com/assets/7947083/14289266/069e38f4-fb28-11e5-9e9b-d4ce3487ee03.png)
![drawemcaltower_lineshape_8](https://cloud.githubusercontent.com/assets/7947083/14289267/06ac515a-fb28-11e5-9072-1674ae6f50e9.png)


## Merge with Hcal

Available with this pull request. An event display with 120 GeV proton beam: 
<img width="467" alt="2016-04-04 23_50_06-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14288869/7d52e898-fb26-11e5-8eb7-f72d1b46aca8.png">


Hcal digitization need to follow up for joint analysis