### PR TITLE
Sync more reality into prototype simulations

### DIFF
--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -13,7 +13,7 @@ int Fun4All_G4_Prototype2(
   // Make the Server
   //////////////////////////////////////////
   Fun4AllServer *se = Fun4AllServer::instance();
-  //  se->Verbosity(1);
+//    se->Verbosity(1);
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RANDOMSEED",12345);
 
@@ -59,8 +59,8 @@ int Fun4All_G4_Prototype2(
   cemc->GetParameters().ReadFromFile("xml", string(getenv("OFFLINE_MAIN")) + string("/share/calibrations/Prototype2/Geometry/") ); // geometry database
 //  cemc->GetParameters().set_double_param("z_rotation_degree", 15); // rotation around CG
   cemc->GetParameters().set_double_param("xpos", 105); // location in cm of EMCal CG. Update with final positioning of EMCal
-//  cemc->GetParameters().set_double_param("ypos", 0); // vertical shift
-//  cemc->GetParameters().set_double_param("zpos", 0); // horizontal shift
+  cemc->GetParameters().set_double_param("ypos", 5.5); // put it some where in UIUC blocks
+  cemc->GetParameters().set_double_param("zpos", 5.5); // put it some where in UIUC blocks
   g4Reco->registerSubsystem(cemc);
 
   //----------------------------------------

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -314,9 +314,9 @@ int Fun4All_G4_Prototype2(
   //----------------------------------------
   // HCal calibration
   //----------------------------------------
-  // 32 GeV Muon scan
-  const double visible_sample_fraction_HCALIN = 0.0782311; //   +/-   0.0212201
-  const double visible_sample_fraction_HCALOUT = 0.0305822; //  +/-   0.00714456
+  // 32 GeV Pi+ scan
+  const double visible_sample_fraction_HCALIN = 7.19505e-02 ;  1.34152e-02
+  const double visible_sample_fraction_HCALOUT = 0.0313466 ; //  +/-   0.0067744
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration(
       "EmcRawTowerCalibration");

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -19,9 +19,9 @@ int Fun4All_G4_Prototype2(
 
   // Test beam generator
   PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-  gen->add_particles("pi-", 1); // mu-,e-,anti_proton,pi-
+  gen->add_particles("mu-", 1); // mu-,e-,anti_proton,pi-
   gen->set_vertex_distribution_mean(0.0, 0.0, 0);
-  gen->set_vertex_distribution_width(0.0, .3/2, .3/2); // 3x3 mm beam spot as measured in Si-telescope
+  gen->set_vertex_distribution_width(0.0, .7, .7); // Rough beam profile size @ 16 GeV measured by Abhisek
   gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,
       PHG4SimpleEventGenerator::Gaus, PHG4SimpleEventGenerator::Gaus); // Gauss beam profile
   gen->set_eta_range(-.001, .001); // 1mrad angular divergence
@@ -58,9 +58,9 @@ int Fun4All_G4_Prototype2(
   cemc->OverlapCheck(true);
   cemc->GetParameters().ReadFromFile("xml", string(getenv("OFFLINE_MAIN")) + string("/share/calibrations/Prototype2/Geometry/") ); // geometry database
 //  cemc->GetParameters().set_double_param("z_rotation_degree", 15); // rotation around CG
-  cemc->GetParameters().set_double_param("xpos", 105); // location in cm of EMCal CG. Update with final positioning of EMCal
-  cemc->GetParameters().set_double_param("ypos", 5.5); // put it some where in UIUC blocks
-  cemc->GetParameters().set_double_param("zpos", 5.5); // put it some where in UIUC blocks
+  cemc->GetParameters().set_double_param("xpos", (116.77 + 137.0)*.5 - 26.5 - 10.2); // location in cm of EMCal CG. Updated with final positioning of EMCal
+  cemc->GetParameters().set_double_param("ypos", 4); // put it some where in UIUC blocks
+  cemc->GetParameters().set_double_param("zpos", 4); // put it some where in UIUC blocks
   g4Reco->registerSubsystem(cemc);
 
   //----------------------------------------
@@ -70,12 +70,14 @@ int Fun4All_G4_Prototype2(
   PHG4Prototype2InnerHcalSubsystem *innerhcal = new PHG4Prototype2InnerHcalSubsystem("HCalIn");
   innerhcal->SetActive();
   innerhcal->SetAbsorberActive();
+  innerhcal->SetAbsorberTruth(1);
   innerhcal->OverlapCheck(true);
   innerhcal->SuperDetector("HCALIN");
   g4Reco->registerSubsystem(innerhcal);
   PHG4Prototype2OuterHcalSubsystem *outerhcal = new PHG4Prototype2OuterHcalSubsystem("HCalOut");
   outerhcal->SetActive();
   outerhcal->SetAbsorberActive();
+  outerhcal->SetAbsorberTruth(1);
   outerhcal->OverlapCheck(true);
   outerhcal->SuperDetector("HCALOUT");
   g4Reco->registerSubsystem(outerhcal);
@@ -272,8 +274,8 @@ int Fun4All_G4_Prototype2(
   ana->AddTower("CALIB_LG_CEMC");// Low gain CEMC
   ana->AddTower("RAW_HG_CEMC");
   ana->AddTower("CALIB_HG_CEMC");// High gain CEMC
-  ana->AddTower("SIM_HCALOUT");
-  ana->AddTower("SIM_HCALIN");
+  ana->AddTower("HCALOUT");
+  ana->AddTower("HCALIN");
 
   ana->AddNode("BlackHole");// add a G4Hit node
 

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -1,5 +1,5 @@
 int Fun4All_G4_Prototype2(
-			  int nEvents = 100
+			  int nEvents = 1
 			  )
 {
 
@@ -14,13 +14,13 @@ int Fun4All_G4_Prototype2(
   // Make the Server
   //////////////////////////////////////////
   Fun4AllServer *se = Fun4AllServer::instance();
-    se->Verbosity(1);
+  //  se->Verbosity(1);
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RANDOMSEED",12345);
 
   // Test beam generator
   PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-  gen->add_particles("mu-", 1); // mu-,e-,anti_proton,pi-
+  gen->add_particles("pi-", 1); // mu-,e-,anti_proton,pi-
   gen->set_vertex_distribution_mean(0.0, 0.0, 0);
   gen->set_vertex_distribution_width(0.0, .7, .7); // Rough beam profile size @ 16 GeV measured by Abhisek
   gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -223,19 +223,19 @@ int Fun4All_G4_Prototype2(
   // HCal digitization
   //----------------------------------------
   PHG4Prototype2HcalCellReco *hccell = new PHG4Prototype2HcalCellReco();
-  hccell->Detector("INNERHCAL");
+  hccell->Detector("HCALIN");
   se->registerSubsystem(hccell);
 
   hccell = new PHG4Prototype2HcalCellReco();
-  hccell->Detector("OUTERHCAL");
+  hccell->Detector("HCALOUT");
   se->registerSubsystem(hccell);
 
   Prototype2RawTowerBuilder *hcaltwr = new Prototype2RawTowerBuilder();
-  hcaltwr->Detector("INNERHCAL");
+  hcaltwr->Detector("HCALIN");
   se->registerSubsystem(hcaltwr);
 
   hcaltwr = new Prototype2RawTowerBuilder();
-  hcaltwr->Detector("OUTERHCAL");
+  hcaltwr->Detector("HCALOUT");
 //  hcaltwr->Verbosity(2);
   se->registerSubsystem(hcaltwr);
 
@@ -243,8 +243,8 @@ int Fun4All_G4_Prototype2(
   // G4HitNtuple
   //----------------------
   G4HitNtuple *hit = new G4HitNtuple("G4HitNtuple","g4hitntuple.root");
-  hit->AddNode("INNERHCAL", 0);
-  hit->AddNode("OUTERHCAL", 1);
+  hit->AddNode("HCALIN", 0);
+  hit->AddNode("HCALOUT", 1);
   hit->AddNode("CRYO", 2);
   hit->AddNode("BlackHole", 3);
   hit->AddNode("ABSORBER_INNERHCAL", 10);
@@ -272,8 +272,8 @@ int Fun4All_G4_Prototype2(
   ana->AddTower("CALIB_LG_CEMC");// Low gain CEMC
   ana->AddTower("RAW_HG_CEMC");
   ana->AddTower("CALIB_HG_CEMC");// High gain CEMC
-  ana->AddTower("OUTERHCAL");
-  ana->AddTower("INNERHCAL");
+  ana->AddTower("SIM_HCALOUT");
+  ana->AddTower("SIM_HCALIN");
 
   ana->AddNode("BlackHole");// add a G4Hit node
 

--- a/macros/prototype2/Fun4All_G4_Prototype2.C
+++ b/macros/prototype2/Fun4All_G4_Prototype2.C
@@ -13,7 +13,7 @@ int Fun4All_G4_Prototype2(
   // Make the Server
   //////////////////////////////////////////
   Fun4AllServer *se = Fun4AllServer::instance();
-//    se->Verbosity(1);
+    se->Verbosity(1);
   recoConsts *rc = recoConsts::instance();
   rc->set_IntFlag("RANDOMSEED",12345);
 
@@ -71,13 +71,13 @@ int Fun4All_G4_Prototype2(
   innerhcal->SetActive();
   innerhcal->SetAbsorberActive();
   innerhcal->OverlapCheck(true);
-  innerhcal->SuperDetector("INNERHCAL");
+  innerhcal->SuperDetector("HCALIN");
   g4Reco->registerSubsystem(innerhcal);
   PHG4Prototype2OuterHcalSubsystem *outerhcal = new PHG4Prototype2OuterHcalSubsystem("HCalOut");
   outerhcal->SetActive();
   outerhcal->SetAbsorberActive();
   outerhcal->OverlapCheck(true);
-  outerhcal->SuperDetector("OUTERHCAL");
+  outerhcal->SuperDetector("HCALOUT");
   g4Reco->registerSubsystem(outerhcal);
 
   // Cryostat from engineering drawing


### PR DESCRIPTION
## Introduction

This pull request adds following updates to the prototype simulation :
1. Final location of the EMCal in the joint setup, measured by Eric Mannel and John Haggerty today
2. Tower setup for HCal as developed by @pinkenburg 
3. HCal digitization parameter as collected by Abhisek Sen and John Haggerty
4. Secondary beam profile as measured by Abhisek Sen

##  Final location of the EMCal relative to HCal

Measurement by Eric: 

![image](https://cloud.githubusercontent.com/assets/7947083/14694834/6f6563f8-073a-11e6-80c0-0dd9994b8521.png)

Photo by John:

![img_2346](https://cloud.githubusercontent.com/assets/7947083/14695021/fd14bd7e-073b-11e6-85ce-a32fde79ce4e.JPG)

New simulation with 32 GeV pion:

<img width="482" alt="2016-04-20 16_30_18-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14694956/8a1e0c58-073b-11e6-8414-93ceac626401.png">

## Beam centering for EMCal in default UIUC setting

Photo by Eric:

![image](https://cloud.githubusercontent.com/assets/7947083/14695047/38530602-073c-11e6-9d5f-d1933bd67d2b.png)

Simulation of muon beam after EMCal moved so that beam center hits UIUC module Col3 Row3:

<img width="329" alt="2016-04-20 15_42_27-nomachine - nx07" src="https://cloud.githubusercontent.com/assets/7947083/14695039/27a657be-073c-11e6-9bb7-5fa618a7beb0.png">

## HCal digitization parameter

From: Abhisek Sen [mailto:sen.abhisek@gmail.com] 
Sent: Tuesday, April 19, 2016 10:55 PM
To: Huang, Jin <jhuang@bnl.gov>; Haggerty, John <haggerty@bnl.gov>

HCALIN:
   1/5 pixel / HG ADC channel 
   32/5 pixel / LG ADC channel
   0.4 MeV/ LG ADC
   0.4/32 MeV/ HG ADC


HCALOUT:
   1/5 pixel / HG ADC channel 
   16/5 pixel / LG ADC channel
   0.2 MeV/ LG ADC
   0.2/16 MeV/ HG ADC

These does not include sampling fractions.

## Beam profile from Abhisek 

![image](https://cloud.githubusercontent.com/assets/7947083/14695145/447db3a4-073d-11e6-86cc-669172ac7984.png)

Now use default beam of 7mm in Gauss sigma

## New DST nodes

```
TOP (PHCompositeNode)/
   DST (PHCompositeNode)/
      G4HIT_CRYO (PHIODataNode)
      G4HIT_BlackHole (PHIODataNode)
      PHG4INEVENT (PHDataNode)
      G4HIT_CEMC (PHIODataNode)
      G4HIT_ABSORBER_CEMC (PHIODataNode)
      HCALIN (PHCompositeNode)/
         G4HIT_ABSORBER_HCALIN (PHIODataNode)
         G4HIT_HCALIN (PHIODataNode)
         G4CELL_HCALIN (PHIODataNode)
         TOWER_SIM_HCALIN (PHIODataNode)
         TOWER_RAW_LG_HCALIN (PHIODataNode)
         TOWER_RAW_HG_HCALIN (PHIODataNode)
         TOWER_CALIB_LG_HCALIN (PHIODataNode)
         TOWER_CALIB_HG_HCALIN (PHIODataNode)
      HCALOUT (PHCompositeNode)/
         G4HIT_ABSORBER_HCALOUT (PHIODataNode)
         G4HIT_HCALOUT (PHIODataNode)
         G4CELL_HCALOUT (PHIODataNode)
         TOWER_SIM_HCALOUT (PHIODataNode)
         TOWER_RAW_LG_HCALOUT (PHIODataNode)
         TOWER_RAW_HG_HCALOUT (PHIODataNode)
         TOWER_CALIB_LG_HCALOUT (PHIODataNode)
         TOWER_CALIB_HG_HCALOUT (PHIODataNode)
      G4TruthInfo (PHIODataNode)
      CEMC (PHCompositeNode)/
         G4CELL_CEMC (PHIODataNode)
         TOWER_SIM_CEMC (PHIODataNode)
         TOWER_RAW_LG_CEMC (PHIODataNode)
         TOWER_CALIB_LG_CEMC (PHIODataNode)
         TOWER_RAW_HG_CEMC (PHIODataNode)
         TOWER_CALIB_HG_CEMC (PHIODataNode)
   RUN (PHCompositeNode)/
      BLOCKGEOM_CRYO (PHIODataNode)
      BLOCKGEOM_BlackHole (PHIODataNode)
      G4GEO_CEMC (PHDataNode)
      G4GEOPARAM_CEMC (PHIODataNode)
      G4GEO_HCALIN (PHDataNode)
      G4GEOPARAM_HCALIN (PHIODataNode)
      G4GEO_HCALOUT (PHDataNode)
      G4GEOPARAM_HCALOUT (PHIODataNode)
      CYLINDERGEOM_CEMC (PHIODataNode)
      CYLINDERGEOM_ABSORBER_CEMC (PHIODataNode)
      CYLINDERCELLGEOM_CEMC (PHIODataNode)
      TOWERGEOM_CEMC (PHIODataNode)
      TOWERGEOM_HCALIN (PHIODataNode)
      TOWERGEOM_HCALOUT (PHIODataNode)
   PAR (PHCompositeNode)/
```



