### PR TITLE
Decode run info to DST

### DIFF
--- a/macros/prototype2/Fun4All_TestBeam.C
+++ b/macros/prototype2/Fun4All_TestBeam.C
@@ -17,6 +17,50 @@ Fun4All_TestBeam(int nEvents = 100,
   recoConsts *rc = recoConsts::instance();
   //rc->set_IntFlag("RUNNUMBER",0);
 
+  // ------------------- Run info -> RUN node -------------------
+  RunInfoUnpackPRDF *unpack_run = new RunInfoUnpackPRDF();
+//  unpack_run->Verbosity(RunInfoUnpackPRDF::VERBOSITY_SOME);
+
+  int i_offset = 0;
+
+  //    rcdaq_client create_device device_filenumbers_delete 9 911 "$HOME/beam_values.txt"
+  //  S:MTNRG  =  120   GeV
+  //  F:MT6SC1 =  11127     Cnts
+  //  F:MT6SC2 =  10585     Cnts
+  //  F:MT6SC3 =  10442     Cnts
+  //  F:MT6SC4 =  0         Cnts
+  //  F:MT6SC5 =  20251     Cnts
+  //  E:2CH    =  981.9 mm
+  //  E:2CV    =  93.17 mm
+  //  E:2CMT6T =  76.11 F
+  //  E:2CMT6H =  18.09 %Hum
+  //  F:MT5CP2 =  .0301 Psia
+  //  F:MT6CP2 =  .6905 Psia
+  i_offset = 0;
+  unpack_run->add_channel("beam_MTNRG_GeV", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6SC1_Cnts", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6SC2_Cnts", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6SC3_Cnts", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6SC4_Cnts", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6SC5_Cnts", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_2CH_mm", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_2CV_mm", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_2CMT6T_F", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_2CMT6H_RH", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT5CP2_Psia", 911, i_offset++, 1e-4);
+  unpack_run->add_channel("beam_MT6CP2_Psia", 911, i_offset++, 1e-4);
+
+//  rcdaq_client create_device device_filenumbers_delete 9 984 "$HOME/DB_LOGGER_EMCAL_A0_values.txt"
+  unpack_run->add_channel("EMCAL_A0_HighGain", 984, 0, 1); // 1: pre-amp high gain, 0: nominal gain
+
+  //  rcdaq_client create_device device_filenumbers_delete 9 983 "$HOME/DB_LOGGER_EMCAL_GR0.txt"
+  unpack_run->add_channel("EMCAL_GR0_BiasOffset_Tower21", 983, 21-1, 1); // bias offset in mV for tower 21
+
+    // rcdaq_client create_device device_filenumbers_delete 9 982 "$HOME/DB_LOGGER_EMCAL_T0_values.txt"
+  unpack_run->add_channel("EMCAL_T0_Tower21", 982, 21-1, 1e-3); // temperature reading in C for tower 21
+
+  se->registerSubsystem(unpack_run);
+
   // ------------------- HCal and EMcal -------------------
   SubsysReco *unpack = new CaloUnpackPRDF();
 // unpack->Verbosity(1);
@@ -176,6 +220,14 @@ Fun4All_TestBeam(int nEvents = 100,
   //alternatively, fast check on DST using DST Reader:
   Prototype2DSTReader *reader = new Prototype2DSTReader(
       string(output_file) + string("_DSTReader.root"));
+
+  reader->AddRunInfo("beam_MTNRG_GeV");
+  reader->AddRunInfo("beam_2CH_mm");
+  reader->AddRunInfo("beam_2CV_mm");
+  reader->AddRunInfo("EMCAL_A0_HighGain");
+  reader->AddRunInfo("EMCAL_GR0_BiasOffset_Tower21");
+  reader->AddRunInfo("EMCAL_T0_Tower21");
+
   reader->AddTower("RAW_LG_HCALIN");
   reader->AddTower("RAW_HG_HCALIN");
   reader->AddTower("RAW_LG_HCALOUT");


### PR DESCRIPTION
Decode test beam run info to the DST/RUN/RUN_INFO node, including beam parameter, temperature and DAQ settings in the begin run event. Default macros includes producing the follow observables and example reading:

* EMCal gain, ```EMCAL_A0_HighGain```: 1
* EMCal bias, ```EMCAL_GR0_BiasOffset_Tower21```: 227
* EMCal temperature, ```EMCAL_T0_Tower21```: 30.42
* Motion table position ```beam_2CH_mm```: 1058, ```beam_2CV_mm```: 133.2
* Cherenkov pressure, ```beam_MT5CP2_Psia```: 0.4444, ```beam_MT6CP2_Psia```: 0.6783
* Beam counter, ```beam_MT6SC1_Cnts```: 12787, ```beam_MT6SC2_Cnts```: 11283, ```beam_MT6SC3_Cnts```: 10062, ```beam_MT6SC4_Cnts```: 0, ```beam_MT6SC5_Cnts```: 62529
* Beam momentum, ```beam_MTNRG_GeV```: -12

To retrieve this information via DST analysis module:

```c++

#include <pdbcalbase/PdbParameterMap.h>
#include <g4detectors/PHG4Parameters.h>
...
Prototype2DSTReader::process_event(PHCompositeNode* topNode)
{
...

          PdbParameterMap *info = findNode::getClass<PdbParameterMap>(topNode,
              "RUN_INFO");
          PHG4Parameters run_info_copy("RunInfo");
          run_info_copy.FillFrom(info);

          run_info_copy.print(); // show what is in there
          const double dvalue = run_info_copy.get_double_param("name");
...
}

```

Require https://github.com/sPHENIX-Collaboration/coresoftware/pull/140 in the nightly build to work. 