### PR TITLE
move to flat plates, 4 scint per tower

### DIFF
--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -43,6 +43,10 @@ double HCalInner(PHG4Reco* g4Reco,
   // hcal->set_double_param("rot_y",0);
   // hcal->set_double_param("rot_z",0);
 
+  // Flat plates with 4 scintillators per tower:
+  hcal->set_int_param("n_scinti_plates",4 * 64);
+  hcal->set_double_param("scinti_outer_gap",1.22*(5.0/4.0));
+
   hcal->SetActive();
   hcal->SuperDetector("HCALIN");
   if (absorberactive)  hcal->SetAbsorberActive();


### PR DESCRIPTION
Modifications to change the inner HCAL reference design from 5 scintillators/tower to 4 scintillators/tower, maintaining 4 crossings and the flat steel plate design, as requested by @blackcathj 