### PR TITLE
Introducing the Embedding Flag to main macro

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -25,7 +25,7 @@ int Fun4All_G4_fsPHENIX(
   // And
   // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
   // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
-  // E.g. /sphenix/sim/sgit sim01/production/2016-07-12/sHijing/spacal2d/
+  // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   const bool do_embedding = false;
 
   //======================

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -1,8 +1,9 @@
 
 int Fun4All_G4_fsPHENIX(
 		       const int nEvents = 2,
-		       const char * inputFile = "/gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal1d/fieldmap/G4Hits_sPHENIX_e-_eta0_16GeV.root",
-		       const char * outputFile = "G4fsPHENIX.root"
+           const char * inputFile = "/sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
+		       const char * outputFile = "G4fsPHENIX.root",
+           const char * embed_input_file = "/sphenix/sim/sim01/production/2016-07-12/sHijing/spacal2d/G4Hits_sPHENIX_sHijing-0-4.4fm.list"
 		       )
 {
   //===============
@@ -21,6 +22,11 @@ int Fun4All_G4_fsPHENIX(
   // Use particle generator
   const bool runpythia8 = false;
   const bool runpythia6 = false;
+  // And
+  // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
+  // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
+  // E.g. /sphenix/sim/sgit sim01/production/2016-07-12/sHijing/spacal2d/
+  const bool do_embedding = false;
 
   //======================
   // What to run
@@ -132,6 +138,11 @@ int Fun4All_G4_fsPHENIX(
     {
       // Get the hits from a file
       // The input manager is declared later
+      if (do_embedding)
+       {
+         cout <<"Do not support read hits and embed background at the same time."<<endl;
+         exit(1);
+       }
     }
   else if (readhepmc)
     {
@@ -170,7 +181,7 @@ int Fun4All_G4_fsPHENIX(
       //gen->add_particles("e-",5); // mu+,e+,proton,pi+,Upsilon
       //gen->add_particles("e+",5); // mu-,e-,anti_proton,pi-
       gen->add_particles("pi-",1); // mu-,e-,anti_proton,pi-
-      if (readhepmc) {
+      if (readhepmc || do_embedding) {
 	gen->set_reuse_existing_vertex(true);
 	gen->set_existing_vertex_offset_vector(0.0,0.0,0.0);
       } else {
@@ -319,6 +330,19 @@ int Fun4All_G4_fsPHENIX(
       Fun4AllInputManager *hitsin = new Fun4AllDstInputManager("DSTin");
       hitsin->fileopen(inputFile);
       se->registerInputManager(hitsin);
+    }
+  if (do_embedding)
+    {
+      if (embed_input_file == NULL)
+        {
+          cout << "Missing embed_input_file! Exit";
+          exit(3);
+        }
+
+      Fun4AllDstInputManager *in1 = new Fun4AllNoSyncDstInputManager("DSTinEmbed");
+      //      in1->AddFile(embed_input_file); // if one use a single input file
+      in1->AddListFile(embed_input_file); // RecommendedL: if one use a text list of many input files
+      se->registerInputManager(in1);
     }
   if (readhepmc)
     {

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -28,7 +28,7 @@ int Fun4All_G4_sPHENIX(
   // And
   // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
   // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
-  // E.g. /sphenix/sim/sgit sim01/production/2016-07-12/sHijing/spacal2d/
+  // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   const bool do_embedding = false;
 
   //======================

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -1,9 +1,9 @@
 
 int Fun4All_G4_sPHENIX(
 		       const int nEvents = 10,
-		       const char * inputFile = "/gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal1d/fieldmap/G4Hits_sPHENIX_e-_eta0_16GeV.root",
+		       const char * inputFile = "/sphenix/sim/sim01/production/2016-07-06/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_gamma_eta0.30_32GeV-0000.root",
 		       const char * outputFile = "G4sPHENIXCells.root",
-           const char * embed_input_file = "sHijing.lst"
+           const char * embed_input_file = "/sphenix/sim/sim01/production/2016-07-12/sHijing/spacal2d/G4Hits_sPHENIX_sHijing-0-4.4fm.list"
 		       )
 {
   //===============
@@ -23,8 +23,8 @@ int Fun4All_G4_sPHENIX(
   const bool runpythia8 = false;
   const bool runpythia6 = false;
   // And
-  // One further choose to embed newly simulated events to a previous simulation:
-  const bool do_embedding = false;
+  // One further choose to embed newly simulated events to a previous simulation. Not compatible with readhits = true
+  const bool do_embedding = true;
 
   //======================
   // What to run

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -23,8 +23,8 @@ int Fun4All_G4_sPHENIX(
   const bool runpythia8 = false;
   const bool runpythia6 = false;
   // And
-  // One further choose to embed newly simulated events to a previous simulation. Not compatible with readhits = true
-  const bool do_embedding = true;
+  // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
+  const bool do_embedding = false;
 
   //======================
   // What to run
@@ -37,7 +37,7 @@ int Fun4All_G4_sPHENIX(
   bool do_svtx = true;
   bool do_svtx_cell = true;
   bool do_svtx_track = true;
-  bool do_svtx_eval = false;
+  bool do_svtx_eval = true;
 
   bool do_preshower = false;
   
@@ -51,7 +51,7 @@ int Fun4All_G4_sPHENIX(
   bool do_hcalin_cell = true;
   bool do_hcalin_twr = true;
   bool do_hcalin_cluster = true;
-  bool do_hcalin_eval = false;
+  bool do_hcalin_eval = true;
 
   bool do_magnet = true;
   
@@ -59,13 +59,13 @@ int Fun4All_G4_sPHENIX(
   bool do_hcalout_cell = true;
   bool do_hcalout_twr = true;
   bool do_hcalout_cluster = true;
-  bool do_hcalout_eval = false;
+  bool do_hcalout_eval = true;
   
   bool do_global = true;
   bool do_global_fastsim = false;
   
-  bool do_jet_reco = false;
-  bool do_jet_eval = false;
+  bool do_jet_reco = true;
+  bool do_jet_eval = true;
 
   bool do_dst_compress = false;
 

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -1,7 +1,7 @@
 
 int Fun4All_G4_sPHENIX(
 		       const int nEvents = 10,
-		       const char * inputFile = "/sphenix/sim/sim01/production/2016-07-06/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_gamma_eta0.30_32GeV-0000.root",
+		       const char * inputFile = "/sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
 		       const char * outputFile = "G4sPHENIXCells.root",
            const char * embed_input_file = "/sphenix/sim/sim01/production/2016-07-12/sHijing/spacal2d/G4Hits_sPHENIX_sHijing-0-4.4fm.list"
 		       )
@@ -14,6 +14,9 @@ int Fun4All_G4_sPHENIX(
   // read previously generated g4-hits files, in this case it opens a DST and skips
   // the simulations step completely. The G4Setup macro is only loaded to get information
   // about the number of layers used for the cell reco code
+  //
+  // In case reading production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
+  // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   const bool readhits = false;
   // Or:
   // read files in HepMC format (typically output from event generators like hijing or pythia)
@@ -24,6 +27,8 @@ int Fun4All_G4_sPHENIX(
   const bool runpythia6 = false;
   // And
   // Further choose to embed newly simulated events to a previous simulation. Not compatible with `readhits = true`
+  // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
+  // E.g. /sphenix/sim/sgit sim01/production/2016-07-12/sHijing/spacal2d/
   const bool do_embedding = false;
 
   //======================


### PR DESCRIPTION
Adding a simple embed switch, 
```c++
const bool do_embedding = false; // or true
```
which allows embedding a new simulation (e.g. single particle or Pythia jetty events) into an existing DST file (e.g. HIJING simulation production). 

Notes:
* Please check consistency between your local macros (```G4*.C```) and the production macros (like ``` /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/ ```) before running ```readhit = true``` or embedding. Production could use different set of detector than the default macro (e.g. version of tracker or EMCal). Inconsistent macro will lead to error and quit processing.
* Embedding DST into DST is NOT supported, because it is likely the two DST streams use inconsistent  vertex points from event-to-event. Therefore, the macro will quit, if both ```readhit``` and ```do_embedding``` were set to true. 
* If run embedding into full calorimetry HIJING simulation, the average memory usage is likely higher than the default condor limit, due to the large amount of calorimetry hits. In this case, running on condor requires use "high memory" setting: https://wiki.bnl.gov/sPHENIX/index.php/Condor#High_memory_jobs

Confirmed with Chris regarding the merge. 