### PR TITLE
Add macros to run EIC Detector geometry

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -68,14 +68,14 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - barrel
 
-  bool do_DIRC = true;
+  bool do_DIRC = false;
 
   // EICDetector geometry - 'hadron' direction
 
   bool do_FGEM = true;
 
   bool do_RICH = true;
-  bool do_Aerogel = true;
+  bool do_Aerogel = false;
 
   bool do_FEMC = true;
   bool do_FEMC_cell = true;
@@ -90,7 +90,7 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - 'hadron' direction
 
-  bool do_EGEM = true;
+  bool do_EGEM = false;
 
   bool do_EEMC = true;
   bool do_EEMC_cell = true;

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -66,9 +66,16 @@ int Fun4All_G4_EICDetector(
   bool do_fwd_jet_reco = true;
   bool do_fwd_jet_eval = true;
 
-  // EICDetector geometry
+  // EICDetector geometry - barrel
+
+  bool do_DIRC = true;
+
+  // EICDetector geometry - 'hadron' direction
 
   bool do_FGEM = true;
+
+  bool do_RICH = true;
+  bool do_Aerogel = true;
 
   bool do_FEMC = true;
   bool do_FEMC_cell = true;
@@ -79,6 +86,18 @@ int Fun4All_G4_EICDetector(
   bool do_FHCAL_cell = true;
   bool do_FHCAL_twr = true;
   bool do_FHCAL_cluster = true;
+
+
+  // EICDetector geometry - 'hadron' direction
+
+  bool do_EGEM = true;
+
+  bool do_EEMC = true;
+  bool do_EEMC_cell = true;
+  bool do_EEMC_twr = true;
+  bool do_EEMC_cluster = true;
+
+  // Other options
 
   bool do_dst_compress = false;
 
@@ -98,7 +117,7 @@ int Fun4All_G4_EICDetector(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_EICDetector.C");
-  G4Init(do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_FEMC,do_FHCAL);
+  G4Init(do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_EGEM,do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel);
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
@@ -198,10 +217,7 @@ int Fun4All_G4_EICDetector(
       // Detector description
       //---------------------
 
-      G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-              do_svtx, do_preshower, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,
-              do_FGEM, do_FEMC, do_FHCAL,
-              magfield_rescale);
+      G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_EGEM,do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel,magfield_rescale);
 
     }
 
@@ -231,6 +247,8 @@ int Fun4All_G4_EICDetector(
   if (do_FEMC_cell) FEMC_Cells();
   if (do_FHCAL_cell) FHCAL_Cells();
 
+  if (do_EEMC_cell) EEMC_Cells();
+
   //-----------------------------
   // CEMC towering and clustering
   //-----------------------------
@@ -248,11 +266,18 @@ int Fun4All_G4_EICDetector(
   if (do_hcalout_twr) HCALOuter_Towers();
   if (do_hcalout_cluster) HCALOuter_Clusters();
 
+  //-----------------------------
+  // e, h direction Calorimeter  towering and clustering
+  //-----------------------------
+
   if (do_FEMC_twr) FEMC_Towers();
   if (do_FEMC_cluster) FEMC_Clusters();
 
   if (do_FHCAL_twr) FHCAL_Towers();
   if (do_FHCAL_cluster) FHCAL_Clusters();
+
+  if (do_EEMC_twr) EEMC_Towers();
+  if (do_EEMC_cluster) EEMC_Clusters();
 
   if (do_dst_compress) ShowerCompress();
 
@@ -352,10 +377,13 @@ int Fun4All_G4_EICDetector(
                                /*bool*/ do_magnet  ,
                                /*bool*/ do_hcalout_twr,
                                /*bool*/ do_FGEM,
+                               /*bool*/ do_EGEM,
                                /*bool*/ do_FHCAL,
                                /*bool*/ do_FHCAL_twr,
                                /*bool*/ do_FEMC,
-                               /*bool*/ do_FEMC_twr
+                               /*bool*/ do_FEMC_twr,
+			       /*bool*/ do_EEMC,
+			       /*bool*/ do_EEMC_twr
                                );
     }
 

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -68,14 +68,14 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - barrel
 
-  bool do_DIRC = false;
+  bool do_DIRC = true;
 
   // EICDetector geometry - 'hadron' direction
 
   bool do_FGEM = true;
 
   bool do_RICH = true;
-  bool do_Aerogel = false;
+  bool do_Aerogel = true;
 
   bool do_FEMC = true;
   bool do_FEMC_cell = true;

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -1,0 +1,368 @@
+
+int Fun4All_G4_EICDetector(
+		       const int nEvents = 10,
+		       const char * inputFile = "/gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal1d/fieldmap/G4Hits_sPHENIX_e-_eta0_16GeV.root",
+		       const char * outputFile = "G4EICDetector.root"
+		       )
+{
+  //===============
+  // Input options
+  //===============
+
+  // Either:
+  // read previously generated g4-hits files, in this case it opens a DST and skips
+  // the simulations step completely. The G4Setup macro is only loaded to get information
+  // about the number of layers used for the cell reco code
+  const bool readhits = false;
+  // Or:
+  // read files in HepMC format (typically output from event generators like hijing or pythia)
+  const bool readhepmc = false; // read HepMC files
+  // Or:
+  // Use particle generator
+  const bool runpythia = false;
+
+  //======================
+  // What to run
+  //======================
+
+  bool do_bbc = true;
+
+  bool do_pipe = true;
+
+  bool do_svtx = true;
+  bool do_svtx_cell = false;
+  bool do_svtx_track = false;
+  bool do_svtx_eval = false;
+
+  bool do_preshower = false;
+
+  bool do_cemc = true;
+  bool do_cemc_cell = true;
+  bool do_cemc_twr = true;
+  bool do_cemc_cluster = true;
+  bool do_cemc_eval = false;
+
+  bool do_hcalin = true;
+  bool do_hcalin_cell = true;
+  bool do_hcalin_twr = true;
+  bool do_hcalin_cluster = true;
+  bool do_hcalin_eval = false;
+
+  bool do_magnet = true;
+
+  bool do_hcalout = true;
+  bool do_hcalout_cell = true;
+  bool do_hcalout_twr = true;
+  bool do_hcalout_cluster = true;
+  bool do_hcalout_eval = false;
+
+  bool do_global = true;
+  bool do_global_fastsim = false;
+
+  bool do_jet_reco = false;
+  bool do_jet_eval = false;
+
+  bool do_fwd_jet_reco = false;
+  bool do_fwd_jet_eval = false;
+
+  // EICDetector geometry
+
+  bool do_FEMC = true;
+  bool do_FEMC_cell = true;
+  bool do_FEMC_twr = true;
+  bool do_FEMC_cluster = true;
+
+  bool do_FHCAL = true;
+  bool do_FHCAL_cell = true;
+  bool do_FHCAL_twr = true;
+  bool do_FHCAL_cluster = true;
+
+  bool do_EEMC = true;
+  bool do_EEMC_cell = true;
+  bool do_EEMC_twr = true;
+  bool do_EEMC_cluster = true;
+
+  bool do_DIRC = true;
+  bool do_RICH = true;
+  bool do_Aerogel = true;
+
+  //Option to convert DST to human command readable TTree for quick poke around the outputs
+  bool do_DSTReader = true;
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libphhepmc.so");
+  gSystem->Load("libg4testbench.so");
+  gSystem->Load("libg4hough.so");
+  gSystem->Load("libcemc.so");
+  gSystem->Load("libg4eval.so");
+
+  // establish the geometry and reconstruction setup
+  gROOT->LoadMacro("G4Setup_EICDetector.C");
+  G4Init(do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_bbc,
+	 do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel);
+
+  int absorberactive = 0; // set to 1 to make all absorbers active volumes
+  //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
+  const string magfield = "/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
+  const float magfield_rescale = 1.4/1.5; // max 1.4T field
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
+  // just if we set some flags somewhere in this macro
+  recoConsts *rc = recoConsts::instance();
+  // By default every random number generator uses
+  // PHRandomSeed() which reads /dev/urandom to get its seed
+  // if the RANDOMSEED flag is set its value is taken as seed
+  // You can either set this to a random value using PHRandomSeed()
+  // which will make all seeds identical (not sure what the point of
+  // this would be:
+  //  rc->set_IntFlag("RANDOMSEED",PHRandomSeed());
+  // or set it to a fixed value so you can debug your code
+  // rc->set_IntFlag("RANDOMSEED", 12345);
+
+  //-----------------
+  // Event generation
+  //-----------------
+
+  if (readhits)
+    {
+      // Get the hits from a file
+      // The input manager is declared later
+    }
+  else if (readhepmc)
+    {
+      // this module is needed to read the HepMC records into our G4 sims
+      // but only if you read HepMC input files
+      HepMCNodeReader *hr = new HepMCNodeReader();
+      se->registerSubsystem(hr);
+    }
+  else if (runpythia)
+    {
+      gSystem->Load("libPHPythia8.so");
+
+      PHPythia8* pythia8 = new PHPythia8();
+      // see coresoftware/generators/PHPythia8 for example config
+      pythia8->set_config_file("phpythia8.cfg");
+      se->registerSubsystem(pythia8);
+
+      HepMCNodeReader *hr = new HepMCNodeReader();
+      se->registerSubsystem(hr);
+    }
+  else
+    {
+      // toss low multiplicity dummy events
+      PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
+      //gen->add_particles("e-",5); // mu+,e+,proton,pi+,Upsilon
+      //gen->add_particles("e+",5); // mu-,e-,anti_proton,pi-
+      gen->add_particles("pi-",1); // mu-,e-,anti_proton,pi-
+      if (readhepmc) {
+	gen->set_reuse_existing_vertex(true);
+	gen->set_existing_vertex_offset_vector(0.0,0.0,0.0);
+      } else {
+	gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+					       PHG4SimpleEventGenerator::Uniform,
+					       PHG4SimpleEventGenerator::Uniform);
+	gen->set_vertex_distribution_mean(0.0,0.0,0.0);
+	gen->set_vertex_distribution_width(0.0,0.0,5.0);
+      }
+      gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
+      gen->set_vertex_size_parameters(0.0,0.0);
+      gen->set_eta_range(-2.0, -2.0);
+      gen->set_phi_range(-1.0*TMath::Pi(), 1.0*TMath::Pi());
+      //gen->set_phi_range(TMath::Pi()/2-0.1, TMath::Pi()/2-0.1);
+      gen->set_p_range(30.0, 30.0);
+      gen->Embed(1);
+      gen->Verbosity(0);
+      se->registerSubsystem(gen);
+    }
+
+  if (!readhits)
+    {
+      //---------------------
+      // Detector description
+      //---------------------
+
+      G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
+	      do_svtx, do_preshower, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_bbc,
+	      do_FEMC, do_FHCAL, do_EEMC, do_DIRC, do_RICH, do_Aerogel,
+	      magfield_rescale);
+
+    }
+
+  //---------
+  // BBC Reco
+  //---------
+
+  if (do_bbc) Bbc_Reco();
+
+  //------------------
+  // Detector Division
+  //------------------
+
+  if (do_svtx_cell) Svtx_Cells();
+
+  if (do_cemc_cell) CEMC_Cells();
+
+  if (do_hcalin_cell) HCALInner_Cells();
+
+  if (do_hcalout_cell) HCALOuter_Cells();
+
+  if (do_FEMC_cell) FEMC_Cells();
+  if (do_FHCAL_cell) FHCAL_Cells();
+
+  if (do_EEMC_cell) EEMC_Cells();
+
+  //-----------------------------
+  // CEMC towering and clustering
+  //-----------------------------
+
+  if (do_cemc_twr) CEMC_Towers();
+  if (do_cemc_cluster) CEMC_Clusters();
+
+  //-----------------------------
+  // HCAL towering and clustering
+  //-----------------------------
+
+  if (do_hcalin_twr) HCALInner_Towers();
+  if (do_hcalin_cluster) HCALInner_Clusters();
+
+  if (do_hcalout_twr) HCALOuter_Towers();
+  if (do_hcalout_cluster) HCALOuter_Clusters();
+
+  if (do_FEMC_twr) FEMC_Towers();
+  if (do_FEMC_cluster) FEMC_Clusters();
+
+  if (do_FHCAL_twr) FHCAL_Towers();
+  if (do_FHCAL_cluster) FHCAL_Clusters();
+
+  if (do_EEMC_twr) EEMC_Towers();
+  if (do_EEMC_cluster) EEMC_Clusters();
+
+  //--------------
+  // SVTX tracking
+  //--------------
+
+  if (do_svtx_track) Svtx_Reco();
+
+  //-----------------
+  // Global Vertexing
+  //-----------------
+
+  if (do_global) Global_Reco();
+  else if (do_global_fastsim) Global_FastSim();
+
+  //---------
+  // Jet reco
+  //---------
+
+  if (do_jet_reco) Jet_Reco();
+
+  if (do_fwd_jet_reco) Jet_FwdReco();
+
+  //----------------------
+  // Simulation evaluation
+  //----------------------
+
+  if (do_svtx_eval) Svtx_Eval("g4svtx_eval.root");
+
+  if (do_cemc_eval) CEMC_Eval("g4cemc_eval.root");
+
+  if (do_hcalin_eval) HCALInner_Eval("g4hcalin_eval.root");
+
+  if (do_hcalout_eval) HCALOuter_Eval("g4hcalout_eval.root");
+
+  if (do_jet_eval) Jet_Eval("g4jet_eval.root");
+
+  if (do_fwd_jet_eval) Jet_FwdEval("g4fwdjet_eval.root");
+
+  //--------------
+  // IO management
+  //--------------
+
+  if (readhits)
+    {
+      // Hits file
+      Fun4AllInputManager *hitsin = new Fun4AllDstInputManager("DSTin");
+      hitsin->fileopen(inputFile);
+      se->registerInputManager(hitsin);
+    }
+  if (readhepmc)
+    {
+      Fun4AllInputManager *in = new Fun4AllHepMCInputManager( "DSTIN");
+      se->registerInputManager( in );
+      se->fileopen( in->Name().c_str(), inputFile );
+    }
+  else
+    {
+      // for single particle generators we just need something which drives
+      // the event loop, the Dummy Input Mgr does just that
+      Fun4AllInputManager *in = new Fun4AllDummyInputManager( "JADE");
+      se->registerInputManager( in );
+    }
+
+  if (do_DSTReader)
+    {
+      //Convert DST to human command readable TTree for quick poke around the outputs
+      gROOT->LoadMacro("G4_DSTReader_EICDetector.C");
+
+      G4DSTreader_EICDetector( outputFile, //
+			       /*int*/ absorberactive ,
+			       /*bool*/ do_svtx ,
+			       /*bool*/ do_preshower ,
+			       /*bool*/ do_cemc ,
+			       /*bool*/ do_hcalin ,
+			       /*bool*/ do_magnet ,
+			       /*bool*/ do_hcalout ,
+			       /*bool*/ do_cemc_twr ,
+			       /*bool*/ do_hcalin_twr ,
+			       /*bool*/ do_magnet  ,
+			       /*bool*/ do_hcalout_twr,
+			       /*bool*/ do_FHCAL,
+			       /*bool*/ do_FHCAL_twr,
+			       /*bool*/ do_FEMC,
+			       /*bool*/ do_FEMC_twr,
+			       /*bool*/ do_EEMC,
+			       /*bool*/ do_EEMC_twr
+			       );
+    }
+
+  //Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outputFile);
+  //se->registerOutputManager(out);
+
+  if (nEvents == 0 && !readhits && !readhepmc)
+    {
+      cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
+      cout << "it will run forever, so I just return without running anything" << endl;
+      return;
+    }
+
+  if (nEvents < 0)
+    {
+      PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+      g4->ApplyCommand("/control/execute eic.mac");
+      //g4->StartGui();
+      se->run(1);
+
+      se->End();
+      std::cout << "All done" << std::endl;
+    }
+  else
+    {
+
+      se->run(nEvents);
+
+      se->End();
+      std::cout << "All done" << std::endl;
+      delete se;
+      gSystem->Exit(0);
+    }
+
+}

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -90,7 +90,7 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - 'hadron' direction
 
-  bool do_EGEM = false;
+  bool do_EGEM = true;
 
   bool do_EEMC = true;
   bool do_EEMC_cell = true;

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -75,7 +75,7 @@ void G4Init(bool do_svtx = true,
 
   if (do_FEMC)
     {
-      gROOT->LoadMacro("G4_FEMC_EIC.C");
+      gROOT->LoadMacro("G4_FEMC.C");
       FEMCInit();
     }
 
@@ -273,7 +273,7 @@ int G4Setup(const int absorberactive = 0,
 
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
-  blackhole->set_double_param("radius",radius + 10); // add 10 cm
+  blackhole->set_double_param("radius",radius + 60); // add 60 cm
 
   blackhole->set_int_param("lengthviarapidity",0);
   blackhole->set_double_param("length",g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -273,7 +273,7 @@ int G4Setup(const int absorberactive = 0,
 
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
-  blackhole->set_double_param("radius",radius + 10); // add 10 cm
+  blackhole->set_double_param("radius",radius + 100); // add 100 cm
 
   blackhole->set_int_param("lengthviarapidity",0);
   blackhole->set_double_param("length",g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -67,9 +67,15 @@ void G4Init(bool do_svtx = true,
       FGEM_Init();
     }
 
+  if (do_EGEM)
+    {
+      gROOT->LoadMacro("G4_EGEM_EIC.C");
+      EGEM_Init();
+    }
+
   if (do_FEMC)
     {
-      gROOT->LoadMacro("G4_FEMC.C");
+      gROOT->LoadMacro("G4_FEMC_EIC.C");
       FEMCInit();
     }
 
@@ -84,6 +90,26 @@ void G4Init(bool do_svtx = true,
       gROOT->LoadMacro("G4_EEMC.C");
       EEMCInit();
     }
+
+  if (do_DIRC)
+    {
+      gROOT->LoadMacro("G4_DIRC.C");
+      DIRCInit();
+    }
+
+  if (do_RICH)
+    {
+      gROOT->LoadMacro("G4_RICH.C");
+      RICHInit();
+    }
+
+  if (do_Aerogel)
+    {
+      gROOT->LoadMacro("G4_Aerogel.C");
+      AerogelInit();
+    }
+
+
 }
 
 
@@ -184,6 +210,9 @@ int G4Setup(const int absorberactive = 0,
   if ( do_FGEM )
     FGEMSetup(g4Reco);
 
+  if ( do_EGEM )
+    EGEMSetup(g4Reco);
+
   //----------------------------------------
   // FEMC
 
@@ -201,6 +230,18 @@ int G4Setup(const int absorberactive = 0,
 
   if ( do_EEMC )
     EEMCSetup(g4Reco, absorberactive);
+
+  //----------------------------------------
+  // PID
+
+  if ( do_DIRC )
+    DIRCSetup(g4Reco);
+
+  if ( do_RICH )
+    RICHSetup(g4Reco);
+
+  if ( do_Aerogel )
+    AerogelSetup(g4Reco);
 
   // sPHENIX forward flux return(s)
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -273,7 +273,7 @@ int G4Setup(const int absorberactive = 0,
 
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
-  blackhole->set_double_param("radius",radius + 100); // add 100 cm
+  blackhole->set_double_param("radius",radius + 10); // add 10 cm
 
   blackhole->set_int_param("lengthviarapidity",0);
   blackhole->set_double_param("length",g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -1,0 +1,273 @@
+
+double no_overlapp = 0.0001; // added to radii to avoid overlapping volumes
+bool overlapcheck = false; // set to true if you want to check for overlaps
+
+void G4Init(bool do_svtx = true,
+	    bool do_preshower = false,
+	    bool do_cemc = true,
+	    bool do_hcalin = true,
+	    bool do_magnet = true,
+	    bool do_hcalout = true,
+	    bool do_pipe = true,
+	    bool do_bbc = true,
+	    bool do_global = true,
+	    bool do_FEMC = true,
+	    bool do_FHCAL = true,
+	    bool do_EEMC = true,
+	    bool do_DIRC = true,
+	    bool do_RICH = true,
+	    bool do_Aerogel = true) {
+
+  gROOT->LoadMacro("G4_Bbc.C");
+  if (do_bbc) BbcInit();
+
+  gROOT->LoadMacro("G4_Pipe.C");
+  if (do_pipe) PipeInit();
+
+  // load detector macros and execute Init() function
+  gROOT->LoadMacro("G4_Svtx.C");           // default
+  //gROOT->LoadMacro("G4_Svtx_ladders.C"); // testing
+  //gROOT->LoadMacro("G4_Svtx_ITS.C");     // testing
+  if (do_svtx) SvtxInit();
+
+  if (do_preshower) {
+    gROOT->LoadMacro("G4_PreShower.C");   // testing
+    PreShowerInit();
+  }
+
+  gROOT->LoadMacro("G4_CEmc_Spacal.C");    //
+  if (do_cemc) CEmcInit(72); // make it 2*2*2*3*3 so we can try other combinations
+
+  gROOT->LoadMacro("G4_HcalIn_ref.C");       // default
+  if (do_hcalin) HCalInnerInit();
+
+  gROOT->LoadMacro("G4_Magnet.C");
+  if (do_magnet) MagnetInit();
+
+  gROOT->LoadMacro("G4_HcalOut_ref.C");       // default
+  if (do_hcalout) HCalOuterInit();
+
+  gROOT->LoadMacro("G4_Global.C");
+
+  gROOT->LoadMacro("G4_Jets.C");
+
+  gROOT->LoadMacro("G4_FwdJets.C");
+
+  gROOT->LoadMacro("G4_FEMC.C");
+  if ( do_FEMC ) FEMCInit();
+
+  gROOT->LoadMacro("G4_FHCAL.C");
+  if ( do_FHCAL ) FHCALInit();
+
+  gROOT->LoadMacro("G4_EEMC.C");
+  if ( do_EEMC ) EEMCInit();
+
+  gROOT->LoadMacro("G4_DIRC.C");
+  if ( do_DIRC ) DIRCInit();
+
+  gROOT->LoadMacro("G4_RICH.C");
+  if ( do_RICH ) RICHInit();
+
+  gROOT->LoadMacro("G4_Aerogel.C");
+  if ( do_Aerogel ) AerogelInit();
+
+}
+
+
+int G4Setup(const int absorberactive = 0,
+	    const string &field ="1.5",
+	    const EDecayType decayType = TPythia6Decayer::kAll,
+	    const bool do_svtx = true,
+	    const bool do_preshower = false,
+	    const bool do_cemc = true,
+	    const bool do_hcalin = true,
+	    const bool do_magnet = true,
+	    const bool do_hcalout = true,
+	    const bool do_pipe = true,
+	    const bool do_bbc = true,
+	    const bool do_FEMC = false,
+	    const bool do_FHCAL = false,
+	    const bool do_EEMC = false,
+	    const bool do_DIRC = false,
+	    const bool do_RICH = false,
+	    const bool do_Aerogel = false,
+     	    const float magfield_rescale = 1.0) {
+
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4testbench.so");
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco* g4Reco = new PHG4Reco();
+  g4Reco->set_rapidity_coverage(1.1); // according to drawings
+
+  if (decayType != TPythia6Decayer::kAll) {
+    g4Reco->set_force_decay(decayType);
+  }
+
+  double fieldstrength;
+  istringstream stringline(field);
+  stringline >> fieldstrength;
+  if (stringline.fail()) { // conversion to double fails -> we have a string
+
+    if (field.find("sPHENIX.root") != string::npos) {
+      g4Reco->set_field_map(field, 1);
+    } else {
+      g4Reco->set_field_map(field, 2);
+    }
+  } else {
+    g4Reco->set_field(fieldstrength); // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(magfield_rescale);
+
+  double radius = 0.;
+
+  //----------------------------------------
+  // PIPE
+  if (do_pipe) radius = Pipe(g4Reco, radius, absorberactive);
+
+  //----------------------------------------
+  // SVTX
+  if (do_svtx) radius = Svtx(g4Reco, radius, absorberactive);
+
+  //----------------------------------------
+  // PRESHOWER
+
+  if (do_preshower) radius = PreShower(g4Reco, radius, absorberactive);
+
+  //----------------------------------------
+  // CEMC
+//
+  if (do_cemc) radius = CEmc(g4Reco, radius, 8, absorberactive);
+//  if (do_cemc) radius = CEmc_Vis(g4Reco, radius, 8, absorberactive);// for visualization substructure of SPACAL, slow to render
+
+  //----------------------------------------
+  // HCALIN
+
+  if (do_hcalin) radius = HCalInner(g4Reco, radius, 4, absorberactive);
+
+  //----------------------------------------
+  // MAGNET
+
+  if (do_magnet) radius = Magnet(g4Reco, radius, 0, absorberactive);
+
+  //----------------------------------------
+  // HCALOUT
+
+  if (do_hcalout) radius = HCalOuter(g4Reco, radius, 4, absorberactive);
+
+  //----------------------------------------
+  // FEMC
+
+  if ( do_FEMC )
+    FEMCSetup(g4Reco, absorberactive);
+
+  //----------------------------------------
+  // FHCAL
+
+  if ( do_FHCAL )
+    FHCALSetup(g4Reco, absorberactive);
+
+  //----------------------------------------
+  // EEMC
+
+  if ( do_EEMC )
+    EEMCSetup(g4Reco, absorberactive);
+
+  //----------------------------------------
+  // Barrel DIRC
+
+  if ( do_DIRC )
+    DIRCSetup(g4Reco);
+
+  //----------------------------------------
+  // Forward gas RICH
+
+  if ( do_RICH )
+    RICHSetup(g4Reco);
+
+  //----------------------------------------
+  // Forward Aerogel
+
+  if ( do_Aerogel )
+    AerogelSetup(g4Reco);
+
+  // sPHENIX forward flux return(s)
+  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_plus->SetLength(10.2);
+  flux_return_plus->SetPosition(0,0,335.9);
+  flux_return_plus->SetRadius(5.0);
+  flux_return_plus->SetLengthViaRapidityCoverage(false);
+  flux_return_plus->SetThickness(263.5-5.0);
+  flux_return_plus->SetMaterial("G4_Fe");
+  flux_return_plus->SetActive(false);
+  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+  flux_return_plus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_plus);
+
+  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_minus->SetLength(10.2);
+  flux_return_minus->SetPosition(0,0,-335.9);
+  flux_return_minus->SetRadius(5.0);
+  flux_return_minus->SetLengthViaRapidityCoverage(false);
+  flux_return_minus->SetThickness(263.5-5.0);
+  flux_return_minus->SetMaterial("G4_Fe");
+  flux_return_minus->SetActive(false);
+  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+  flux_return_minus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_minus);
+
+
+  //----------------------------------------
+  // BLACKHOLE
+
+  // swallow all particles coming out of the backend of sPHENIX
+  PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
+  blackhole->SetRadius(radius + 10); // add 10 cm
+  blackhole->SetLengthViaRapidityCoverage(false);
+  blackhole->SetLength(g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length
+  blackhole->BlackHole();
+  blackhole->SetThickness(0.1); // it needs some thickness
+  blackhole->SetActive(); // always see what leaks out
+  blackhole->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(blackhole);
+
+  //----------------------------------------
+  // FORWARD BLACKHOLEs
+  // +Z
+  blackhole = new PHG4CylinderSubsystem("BH_FORWARD_PLUS", 1);
+  blackhole->SuperDetector("BH_FORWARD_PLUS");
+  blackhole->SetRadius(0); // add 10 cm
+  blackhole->SetLengthViaRapidityCoverage(false);
+  blackhole->SetLength(0.1); // make it cover the world in length
+  blackhole->SetPosition(0,0, g4Reco->GetWorldSizeZ()/2. - 0.1  - no_overlapp);
+  blackhole->BlackHole();
+  blackhole->SetThickness(radius - no_overlapp); // it needs some thickness
+  blackhole->SetActive(); // always see what leaks out
+  blackhole->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(blackhole);
+
+  blackhole = new PHG4CylinderSubsystem("BH_FORWARD_NEG", 1);
+  blackhole->SuperDetector("BH_FORWARD_NEG");
+  blackhole->SetRadius(0); // add 10 cm
+  blackhole->SetLengthViaRapidityCoverage(false);
+  blackhole->SetLength(0.1); // make it cover the world in length
+  blackhole->SetPosition(0,0, - g4Reco->GetWorldSizeZ()/2. +0.1  + no_overlapp);
+  blackhole->BlackHole();
+  blackhole->SetThickness(radius - no_overlapp); // it needs some thickness
+  blackhole->SetActive(); // always see what leaks out
+  blackhole->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(blackhole);
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+  se->registerSubsystem( g4Reco );
+}

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -10,8 +10,14 @@ void G4Init(bool do_svtx = true,
             bool do_hcalout = true,
             bool do_pipe = true,
             bool do_FGEM = true,
+            bool do_EGEM = true,
             bool do_FEMC = true,
-            bool do_FHCAL = true) {
+            bool do_FHCAL = true,
+            bool do_EEMC = true,
+            bool do_DIRC = true,
+            bool do_RICH = true,
+            bool do_Aerogel = true
+	    ) {
 
   // load detector/material macros and execute Init() function
 
@@ -72,6 +78,12 @@ void G4Init(bool do_svtx = true,
       gROOT->LoadMacro("G4_FHCAL.C");
       FHCALInit();
     }
+
+  if (do_EEMC)
+    {
+      gROOT->LoadMacro("G4_EEMC.C");
+      EEMCInit();
+    }
 }
 
 
@@ -86,8 +98,13 @@ int G4Setup(const int absorberactive = 0,
             const bool do_hcalout = true,
             const bool do_pipe = true,
             const bool do_FGEM = true,
+            const bool do_EGEM = true,
             const bool do_FEMC = false,
             const bool do_FHCAL = false,
+            const bool do_EEMC = true,
+            const bool do_DIRC = true,
+            const bool do_RICH = true,
+            const bool do_Aerogel = true,
             const float magfield_rescale = 1.0) {
 
   //---------------
@@ -178,6 +195,12 @@ int G4Setup(const int absorberactive = 0,
 
   if ( do_FHCAL )
     FHCALSetup(g4Reco, absorberactive);
+
+  //----------------------------------------
+  // EEMC
+
+  if ( do_EEMC )
+    EEMCSetup(g4Reco, absorberactive);
 
   // sPHENIX forward flux return(s)
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
@@ -301,6 +324,13 @@ void ShowerCompress(int verbosity = 0) {
   compress->AddTowerContainer("TOWER_RAW_FHCAL");
   compress->AddTowerContainer("TOWER_CALIB_FHCAL");
 
+  compress->AddHitContainer("G4HIT_EEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_EEMC");
+  compress->AddCellContainer("G4CELL_EEMC");
+  compress->AddTowerContainer("TOWER_SIM_EEMC");
+  compress->AddTowerContainer("TOWER_RAW_EEMC");
+  compress->AddTowerContainer("TOWER_CALIB_EEMC");
+
   se->registerSubsystem(compress);
 
   return;
@@ -333,5 +363,9 @@ void DstCompress(Fun4AllDstOutputManager* out) {
     out->StripNode("G4HIT_ABSORBER_FHCAL");
     out->StripNode("G4CELL_FEMC");
     out->StripNode("G4CELL_FHCAL");
+
+    out->StripNode("G4HIT_EEMC");
+    out->StripNode("G4HIT_ABSORBER_EEMC");
+    out->StripNode("G4CELL_EEMC");
   }
 }

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -3,95 +3,92 @@ double no_overlapp = 0.0001; // added to radii to avoid overlapping volumes
 bool overlapcheck = false; // set to true if you want to check for overlaps
 
 void G4Init(bool do_svtx = true,
-	    bool do_preshower = false,
-	    bool do_cemc = true,
-	    bool do_hcalin = true,
-	    bool do_magnet = true,
-	    bool do_hcalout = true,
-	    bool do_pipe = true,
-	    bool do_bbc = true,
-	    bool do_global = true,
-	    bool do_FEMC = true,
-	    bool do_FHCAL = true,
-	    bool do_EEMC = true,
-	    bool do_DIRC = true,
-	    bool do_RICH = true,
-	    bool do_Aerogel = true) {
+            bool do_preshower = false,
+            bool do_cemc = true,
+            bool do_hcalin = true,
+            bool do_magnet = true,
+            bool do_hcalout = true,
+            bool do_pipe = true,
+            bool do_FGEM = true,
+            bool do_FEMC = true,
+            bool do_FHCAL = true) {
 
-  gROOT->LoadMacro("G4_Bbc.C");
-  if (do_bbc) BbcInit();
+  // load detector/material macros and execute Init() function
 
-  gROOT->LoadMacro("G4_Pipe.C");
-  if (do_pipe) PipeInit();
+  if (do_pipe)
+    {
+      gROOT->LoadMacro("G4_Pipe.C");
+      PipeInit();
+    }
+  if (do_svtx)
+    {
+      gROOT->LoadMacro("G4_Svtx_maps+tpc.C");
+      SvtxInit();
+    }
 
-  // load detector macros and execute Init() function
-  gROOT->LoadMacro("G4_Svtx.C");           // default
-  //gROOT->LoadMacro("G4_Svtx_ladders.C"); // testing
-  //gROOT->LoadMacro("G4_Svtx_ITS.C");     // testing
-  if (do_svtx) SvtxInit();
+  if (do_preshower)
+    {
+      gROOT->LoadMacro("G4_PreShower.C");
+      PreShowerInit();
+    }
 
-  if (do_preshower) {
-    gROOT->LoadMacro("G4_PreShower.C");   // testing
-    PreShowerInit();
-  }
+  if (do_cemc)
+    {
+      gROOT->LoadMacro("G4_CEmc_Spacal.C");
+      CEmcInit(72); // make it 2*2*2*3*3 so we can try other combinations
+    }
 
-  gROOT->LoadMacro("G4_CEmc_Spacal.C");    //
-  if (do_cemc) CEmcInit(72); // make it 2*2*2*3*3 so we can try other combinations
+  if (do_hcalin)
+    {
+      gROOT->LoadMacro("G4_HcalIn_ref.C");
+      HCalInnerInit();
+    }
 
-  gROOT->LoadMacro("G4_HcalIn_ref.C");       // default
-  if (do_hcalin) HCalInnerInit();
+  if (do_magnet)
+    {
+      gROOT->LoadMacro("G4_Magnet.C");
+      MagnetInit();
+    }
+  if (do_hcalout)
+    {
+      gROOT->LoadMacro("G4_HcalOut_ref.C");
+      HCalOuterInit();
+    }
 
-  gROOT->LoadMacro("G4_Magnet.C");
-  if (do_magnet) MagnetInit();
+  if (do_FGEM)
+    {
+      gROOT->LoadMacro("G4_FGEM_fsPHENIX.C");
+      FGEM_Init();
+    }
 
-  gROOT->LoadMacro("G4_HcalOut_ref.C");       // default
-  if (do_hcalout) HCalOuterInit();
+  if (do_FEMC)
+    {
+      gROOT->LoadMacro("G4_FEMC.C");
+      FEMCInit();
+    }
 
-  gROOT->LoadMacro("G4_Global.C");
-
-  gROOT->LoadMacro("G4_Jets.C");
-
-  gROOT->LoadMacro("G4_FwdJets.C");
-
-  gROOT->LoadMacro("G4_FEMC.C");
-  if ( do_FEMC ) FEMCInit();
-
-  gROOT->LoadMacro("G4_FHCAL.C");
-  if ( do_FHCAL ) FHCALInit();
-
-  gROOT->LoadMacro("G4_EEMC.C");
-  if ( do_EEMC ) EEMCInit();
-
-  gROOT->LoadMacro("G4_DIRC.C");
-  if ( do_DIRC ) DIRCInit();
-
-  gROOT->LoadMacro("G4_RICH.C");
-  if ( do_RICH ) RICHInit();
-
-  gROOT->LoadMacro("G4_Aerogel.C");
-  if ( do_Aerogel ) AerogelInit();
-
+  if (do_FHCAL)
+    {
+      gROOT->LoadMacro("G4_FHCAL.C");
+      FHCALInit();
+    }
 }
 
 
 int G4Setup(const int absorberactive = 0,
-	    const string &field ="1.5",
-	    const EDecayType decayType = TPythia6Decayer::kAll,
-	    const bool do_svtx = true,
-	    const bool do_preshower = false,
-	    const bool do_cemc = true,
-	    const bool do_hcalin = true,
-	    const bool do_magnet = true,
-	    const bool do_hcalout = true,
-	    const bool do_pipe = true,
-	    const bool do_bbc = true,
-	    const bool do_FEMC = false,
-	    const bool do_FHCAL = false,
-	    const bool do_EEMC = false,
-	    const bool do_DIRC = false,
-	    const bool do_RICH = false,
-	    const bool do_Aerogel = false,
-     	    const float magfield_rescale = 1.0) {
+            const string &field ="1.5",
+            const EDecayType decayType = TPythia6Decayer::kAll,
+            const bool do_svtx = true,
+            const bool do_preshower = false,
+            const bool do_cemc = true,
+            const bool do_hcalin = true,
+            const bool do_magnet = true,
+            const bool do_hcalout = true,
+            const bool do_pipe = true,
+            const bool do_FGEM = true,
+            const bool do_FEMC = false,
+            const bool do_FHCAL = false,
+            const float magfield_rescale = 1.0) {
 
   //---------------
   // Load libraries
@@ -145,9 +142,9 @@ int G4Setup(const int absorberactive = 0,
 
   //----------------------------------------
   // CEMC
-//
+  //
   if (do_cemc) radius = CEmc(g4Reco, radius, 8, absorberactive);
-//  if (do_cemc) radius = CEmc_Vis(g4Reco, radius, 8, absorberactive);// for visualization substructure of SPACAL, slow to render
+  //  if (do_cemc) radius = CEmc_Vis(g4Reco, radius, 8, absorberactive);// for visualization substructure of SPACAL, slow to render
 
   //----------------------------------------
   // HCALIN
@@ -165,6 +162,12 @@ int G4Setup(const int absorberactive = 0,
   if (do_hcalout) radius = HCalOuter(g4Reco, radius, 4, absorberactive);
 
   //----------------------------------------
+  // Forward tracking
+
+  if ( do_FGEM )
+    FGEMSetup(g4Reco);
+
+  //----------------------------------------
   // FEMC
 
   if ( do_FEMC )
@@ -176,66 +179,42 @@ int G4Setup(const int absorberactive = 0,
   if ( do_FHCAL )
     FHCALSetup(g4Reco, absorberactive);
 
-  //----------------------------------------
-  // EEMC
-
-  if ( do_EEMC )
-    EEMCSetup(g4Reco, absorberactive);
-
-  //----------------------------------------
-  // Barrel DIRC
-
-  if ( do_DIRC )
-    DIRCSetup(g4Reco);
-
-  //----------------------------------------
-  // Forward gas RICH
-
-  if ( do_RICH )
-    RICHSetup(g4Reco);
-
-  //----------------------------------------
-  // Forward Aerogel
-
-  if ( do_Aerogel )
-    AerogelSetup(g4Reco);
-
   // sPHENIX forward flux return(s)
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
-  flux_return_plus->SetLength(10.2);
-  flux_return_plus->SetPosition(0,0,335.9);
-  flux_return_plus->SetRadius(5.0);
-  flux_return_plus->SetLengthViaRapidityCoverage(false);
-  flux_return_plus->SetThickness(263.5-5.0);
-  flux_return_plus->SetMaterial("G4_Fe");
+  flux_return_plus->set_int_param("lengthviarapidity",0);
+  flux_return_plus->set_double_param("length",10.2);
+  flux_return_plus->set_double_param("radius",2.1);
+  flux_return_plus->set_double_param("thickness",263.5-5.0);
+  flux_return_plus->set_double_param("place_z",335.9);
+  flux_return_plus->set_string_param("material","G4_Fe");
   flux_return_plus->SetActive(false);
   flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
   flux_return_plus->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(flux_return_plus);
 
   PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
-  flux_return_minus->SetLength(10.2);
-  flux_return_minus->SetPosition(0,0,-335.9);
-  flux_return_minus->SetRadius(5.0);
-  flux_return_minus->SetLengthViaRapidityCoverage(false);
-  flux_return_minus->SetThickness(263.5-5.0);
-  flux_return_minus->SetMaterial("G4_Fe");
+  flux_return_minus->set_int_param("lengthviarapidity",0);
+  flux_return_minus->set_double_param("length",10.2);
+  flux_return_minus->set_double_param("radius",2.1);
+  flux_return_minus->set_double_param("place_z",-335.9);
+  flux_return_minus->set_double_param("thickness",263.5-5.0);
+  flux_return_minus->set_string_param("material","G4_Fe");
   flux_return_minus->SetActive(false);
   flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
   flux_return_minus->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(flux_return_minus);
-
 
   //----------------------------------------
   // BLACKHOLE
 
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
-  blackhole->SetRadius(radius + 10); // add 10 cm
-  blackhole->SetLengthViaRapidityCoverage(false);
-  blackhole->SetLength(g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length
+  blackhole->set_double_param("radius",radius + 10); // add 10 cm
+
+  blackhole->set_int_param("lengthviarapidity",0);
+  blackhole->set_double_param("length",g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length
   blackhole->BlackHole();
-  blackhole->SetThickness(0.1); // it needs some thickness
+  blackhole->set_double_param("thickness",0.1); // it needs some thickness
   blackhole->SetActive(); // always see what leaks out
   blackhole->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(blackhole);
@@ -245,24 +224,24 @@ int G4Setup(const int absorberactive = 0,
   // +Z
   blackhole = new PHG4CylinderSubsystem("BH_FORWARD_PLUS", 1);
   blackhole->SuperDetector("BH_FORWARD_PLUS");
-  blackhole->SetRadius(0); // add 10 cm
-  blackhole->SetLengthViaRapidityCoverage(false);
-  blackhole->SetLength(0.1); // make it cover the world in length
-  blackhole->SetPosition(0,0, g4Reco->GetWorldSizeZ()/2. - 0.1  - no_overlapp);
+  blackhole->set_double_param("radius",0); // add 10 cm
+  blackhole->set_int_param("lengthviarapidity",0);
+  blackhole->set_double_param("length",0.1); // make it cover the world in length
+  blackhole->set_double_param("place_z",g4Reco->GetWorldSizeZ()/2. - 0.1  - no_overlapp);
   blackhole->BlackHole();
-  blackhole->SetThickness(radius - no_overlapp); // it needs some thickness
+  blackhole->set_double_param("thickness",radius - no_overlapp); // it needs some thickness
   blackhole->SetActive(); // always see what leaks out
   blackhole->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(blackhole);
 
   blackhole = new PHG4CylinderSubsystem("BH_FORWARD_NEG", 1);
   blackhole->SuperDetector("BH_FORWARD_NEG");
-  blackhole->SetRadius(0); // add 10 cm
-  blackhole->SetLengthViaRapidityCoverage(false);
-  blackhole->SetLength(0.1); // make it cover the world in length
-  blackhole->SetPosition(0,0, - g4Reco->GetWorldSizeZ()/2. +0.1  + no_overlapp);
+  blackhole->set_double_param("radius",0); // add 10 cm
+  blackhole->set_int_param("lengthviarapidity",0);
+  blackhole->set_double_param("length",0.1); // make it cover the world in length
+  blackhole->set_double_param("place_z", - g4Reco->GetWorldSizeZ()/2. +0.1  + no_overlapp);
   blackhole->BlackHole();
-  blackhole->SetThickness(radius - no_overlapp); // it needs some thickness
+  blackhole->set_double_param("thickness",radius - no_overlapp); // it needs some thickness
   blackhole->SetActive(); // always see what leaks out
   blackhole->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(blackhole);
@@ -270,4 +249,89 @@ int G4Setup(const int absorberactive = 0,
   PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
   g4Reco->registerSubsystem(truth);
   se->registerSubsystem( g4Reco );
+}
+
+
+void ShowerCompress(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4eval.so");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco* compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_SVTXSUPPORT");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddHitContainer("G4HIT_FHCAL");
+  compress->AddHitContainer("G4HIT_ABSORBER_FHCAL");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddCellContainer("G4CELL_FHCAL");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FHCAL");
+  compress->AddTowerContainer("TOWER_RAW_FHCAL");
+  compress->AddTowerContainer("TOWER_CALIB_FHCAL");
+
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager* out) {
+  if (out) {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4HIT_FHCAL");
+    out->StripNode("G4HIT_ABSORBER_FHCAL");
+    out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4CELL_FHCAL");
+  }
 }

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -259,9 +259,9 @@ int G4Setup(const int absorberactive = 0,
   PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
   flux_return_minus->set_int_param("lengthviarapidity",0);
   flux_return_minus->set_double_param("length",10.2);
-  flux_return_minus->set_double_param("radius",2.1);
+  flux_return_minus->set_double_param("radius",90.0);
   flux_return_minus->set_double_param("place_z",-335.9);
-  flux_return_minus->set_double_param("thickness",263.5-5.0);
+  flux_return_minus->set_double_param("thickness",263.5-5.0 - (90-2.1));
   flux_return_minus->set_string_param("material","G4_Fe");
   flux_return_minus->SetActive(false);
   flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
@@ -273,7 +273,7 @@ int G4Setup(const int absorberactive = 0,
 
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
-  blackhole->set_double_param("radius",radius + 60); // add 60 cm
+  blackhole->set_double_param("radius",radius + 100); // add 100 cm
 
   blackhole->set_int_param("lengthviarapidity",0);
   blackhole->set_double_param("length",g4Reco->GetWorldSizeZ() - no_overlapp); // make it cover the world in length

--- a/macros/g4simulations/G4_Aerogel.C
+++ b/macros/g4simulations/G4_Aerogel.C
@@ -16,7 +16,7 @@ AerogelInit()
 
 void
 AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-    const double min_eta = 1.45 //
+    const double min_eta = 1.1 // 1.45
     )
 {
 
@@ -39,7 +39,12 @@ AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   ag->get_geometry().set_N_Sector(N_Sector);
   ag->OverlapCheck(overlapcheck);
 
-  ag->get_geometry().AddLayers_AeroGel_ePHENIX();
+  // Aerogel dimensions ins cm
+  double radiator_length = 2.;
+  double expansion_length = 10.;
+
+  ag->get_geometry().AddLayers_AeroGel_ePHENIX( radiator_length * PHG4Sector::Sector_Geometry::Unit_cm(),
+						expansion_length * PHG4Sector::Sector_Geometry::Unit_cm() );
   g4Reco->registerSubsystem(ag);
 
 }

--- a/macros/g4simulations/G4_Aerogel.C
+++ b/macros/g4simulations/G4_Aerogel.C
@@ -39,7 +39,7 @@ AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   ag->get_geometry().set_N_Sector(N_Sector);
   ag->OverlapCheck(overlapcheck);
 
-  ag->get_geometry().AddLayers_Aerogel_ePHENIX();
+  ag->get_geometry().AddLayers_AeroGel_ePHENIX();
   g4Reco->registerSubsystem(ag);
 
 }

--- a/macros/g4simulations/G4_Aerogel.C
+++ b/macros/g4simulations/G4_Aerogel.C
@@ -28,7 +28,7 @@ AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
           + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
 //  ag->get_geometry().set_normal_polar_angle(0);
   ag->get_geometry().set_normal_start(
-      283 * PHG4Sector::Sector_Geometry::Unit_cm()); // 307
+      280 * PHG4Sector::Sector_Geometry::Unit_cm()); // 307
   ag->get_geometry().set_min_polar_angle(
       PHG4Sector::Sector_Geometry::eta_to_polar_angle(1.9));
   ag->get_geometry().set_max_polar_angle(

--- a/macros/g4simulations/G4_Aerogel.C
+++ b/macros/g4simulations/G4_Aerogel.C
@@ -16,7 +16,7 @@ AerogelInit()
 
 void
 AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-    const double min_eta = 1.1 //
+    const double min_eta = 1.45 //
     )
 {
 
@@ -28,7 +28,7 @@ AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
           + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
 //  ag->get_geometry().set_normal_polar_angle(0);
   ag->get_geometry().set_normal_start(
-      307 * PHG4Sector::Sector_Geometry::Unit_cm());
+      283 * PHG4Sector::Sector_Geometry::Unit_cm()); // 307
   ag->get_geometry().set_min_polar_angle(
       PHG4Sector::Sector_Geometry::eta_to_polar_angle(1.9));
   ag->get_geometry().set_max_polar_angle(

--- a/macros/g4simulations/G4_Aerogel.C
+++ b/macros/g4simulations/G4_Aerogel.C
@@ -1,0 +1,46 @@
+// $Id: G4_Aerogel.C,v 1.2 2013/10/09 01:08:17 jinhuang Exp $
+
+/*!
+ * \file G4_Aerogel.C
+ * \brief Aerogel RICH for EIC detector
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.2 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+
+void
+AerogelInit()
+{
+
+}
+
+void
+AerogelSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
+    const double min_eta = 1.1 //
+    )
+{
+
+  PHG4SectorSubsystem *ag;
+  ag = new PHG4SectorSubsystem("Aerogel");
+
+  ag->get_geometry().set_normal_polar_angle(
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
+          + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+//  ag->get_geometry().set_normal_polar_angle(0);
+  ag->get_geometry().set_normal_start(
+      307 * PHG4Sector::Sector_Geometry::Unit_cm());
+  ag->get_geometry().set_min_polar_angle(
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(1.9));
+  ag->get_geometry().set_max_polar_angle(
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+  ag->get_geometry().set_min_polar_edge(
+      PHG4Sector::Sector_Geometry::FlatEdge());
+  ag->get_geometry().set_material("G4_AIR");
+  ag->get_geometry().set_N_Sector(N_Sector);
+  ag->OverlapCheck(overlapcheck);
+
+  ag->get_geometry().AddLayers_Aerogel_ePHENIX();
+  g4Reco->registerSubsystem(ag);
+
+}
+

--- a/macros/g4simulations/G4_DIRC.C
+++ b/macros/g4simulations/G4_DIRC.C
@@ -24,8 +24,7 @@ DIRCSetup(PHG4Reco* g4Reco)
 {
   const double radiator_R = 83.65;
   const double length = 470;
-  //const double z_shift = -135; // ePHENIX LOI
-  const double z_shift = -75; // shift to fit within flux return doors; NF 1/13/2016
+  const double z_shift = -115;
   const double z_start = z_shift + length / 2.;
   const double z_end = z_shift - length / 2.;
 

--- a/macros/g4simulations/G4_DIRC.C
+++ b/macros/g4simulations/G4_DIRC.C
@@ -1,0 +1,79 @@
+// $Id: G4_DIRC.C,v 1.3 2013/10/09 01:08:17 jinhuang Exp $
+
+/*!
+ * \file G4_DIRC.C
+ * \brief Macro setting up the barrel DIRC
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.3 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+
+#include <cmath>
+
+void
+DIRCInit()
+{
+
+}
+
+//! Babar DIRC (Without most of support structure)
+//! Ref: I. Adam et al. The DIRC particle identification system for the BaBar experiment.
+//! Nucl. Instrum. Meth., A538:281-357, 2005. doi:10.1016/j.nima.2004.08.129.
+double
+DIRCSetup(PHG4Reco* g4Reco)
+{
+  const double radiator_R = 83.65;
+  const double length = 470;
+  //const double z_shift = -135; // ePHENIX LOI
+  const double z_shift = -65; // shift to fit within flux return doors; NF 1/13/2016
+  const double z_start = z_shift + length / 2.;
+  const double z_end = z_shift - length / 2.;
+
+  PHG4SectorSubsystem *dirc;
+  dirc = new PHG4SectorSubsystem("DIRC");
+  dirc->get_geometry().set_normal_polar_angle(3.14159265358979323846/2);
+  dirc->get_geometry().set_normal_start(
+      83.65 * PHG4Sector::Sector_Geometry::Unit_cm());
+  dirc->get_geometry().set_min_polar_angle(atan2(radiator_R, z_start));
+  dirc->get_geometry().set_max_polar_angle(atan2(radiator_R, z_end));
+  dirc->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  dirc->get_geometry().set_max_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
+  dirc->get_geometry().set_material("Quartz");
+  dirc->get_geometry().set_N_Sector(12);
+  dirc->OverlapCheck(overlapcheck);
+  dirc->get_geometry().AddLayer("Radiator", "Quartz",
+      1.7 * PHG4Sector::Sector_Geometry::Unit_cm(), true);
+  g4Reco->registerSubsystem(dirc);
+
+  PHG4CylinderSubsystem *cyl;
+
+  //  The cylinder skins provide most of the strength
+  //  and stiffness of the CST. The thickness of the inner
+  //  and outer skins is 1.27 and 0.76 mm, respectively
+  cyl = new PHG4CylinderSubsystem("DIRC_CST_Inner_Skin", 10);
+  cyl->SetRadius(81.71);
+  cyl->SetLengthViaRapidityCoverage(false);
+  cyl->SetMaterial("G4_Al");
+  cyl->SetLength(length);
+  cyl->SetThickness(0.127);
+  cyl->SetPosition(0., 0., z_shift);
+  cyl->SetActive(0);
+  cyl->SuperDetector("DIRC");
+  cyl->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(cyl);
+
+  cyl = new PHG4CylinderSubsystem("DIRC_CST_Outer_Skin", 11);
+  cyl->SetRadius(89.25 - 0.076);
+  cyl->SetLengthViaRapidityCoverage(false);
+  cyl->SetMaterial("G4_Al");
+  cyl->SetLength(length);
+  cyl->SetThickness(0.076);
+  cyl->SetPosition(0., 0., z_shift);
+  cyl->SetActive(0);
+  cyl->SuperDetector("DIRC");
+  cyl->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(cyl);
+
+  return 89.25;
+
+}

--- a/macros/g4simulations/G4_DIRC.C
+++ b/macros/g4simulations/G4_DIRC.C
@@ -33,7 +33,7 @@ DIRCSetup(PHG4Reco* g4Reco)
   dirc = new PHG4SectorSubsystem("DIRC");
   dirc->get_geometry().set_normal_polar_angle(3.14159265358979323846/2);
   dirc->get_geometry().set_normal_start(
-      83.65 * PHG4Sector::Sector_Geometry::Unit_cm());
+                                        83.65 * PHG4Sector::Sector_Geometry::Unit_cm());
   dirc->get_geometry().set_min_polar_angle(atan2(radiator_R, z_start));
   dirc->get_geometry().set_max_polar_angle(atan2(radiator_R, z_end));
   dirc->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::FlatEdge());
@@ -42,7 +42,7 @@ DIRCSetup(PHG4Reco* g4Reco)
   dirc->get_geometry().set_N_Sector(12);
   dirc->OverlapCheck(overlapcheck);
   dirc->get_geometry().AddLayer("Radiator", "Quartz",
-      1.7 * PHG4Sector::Sector_Geometry::Unit_cm(), true);
+                                1.7 * PHG4Sector::Sector_Geometry::Unit_cm(), true);
   g4Reco->registerSubsystem(dirc);
 
   PHG4CylinderSubsystem *cyl;
@@ -50,30 +50,40 @@ DIRCSetup(PHG4Reco* g4Reco)
   //  The cylinder skins provide most of the strength
   //  and stiffness of the CST. The thickness of the inner
   //  and outer skins is 1.27 and 0.76 mm, respectively
+
+  // Inner skin:
   cyl = new PHG4CylinderSubsystem("DIRC_CST_Inner_Skin", 10);
-  cyl->SetRadius(81.71);
-  cyl->SetLengthViaRapidityCoverage(false);
-  cyl->SetMaterial("G4_Al");
-  cyl->SetLength(length);
-  cyl->SetThickness(0.127);
-  cyl->SetPosition(0., 0., z_shift);
+  cyl->set_double_param("radius",81.71);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",length);
+  cyl->set_string_param("material","G4_Al");
+  cyl->set_double_param("thickness",0.127);
+  cyl->set_double_param("place_x",0.);
+  cyl->set_double_param("place_y",0.);
+  cyl->set_double_param("place_z",z_shift);
   cyl->SetActive(0);
   cyl->SuperDetector("DIRC");
   cyl->OverlapCheck(overlapcheck);
+
   g4Reco->registerSubsystem(cyl);
 
+  // Outer skin:
   cyl = new PHG4CylinderSubsystem("DIRC_CST_Outer_Skin", 11);
-  cyl->SetRadius(89.25 - 0.076);
-  cyl->SetLengthViaRapidityCoverage(false);
-  cyl->SetMaterial("G4_Al");
-  cyl->SetLength(length);
-  cyl->SetThickness(0.076);
-  cyl->SetPosition(0., 0., z_shift);
+  cyl->set_double_param("radius",89.25 - 0.076);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",length);
+  cyl->set_string_param("material","G4_Al");
+  cyl->set_double_param("thickness",0.076);
+  cyl->set_double_param("place_x",0.);
+  cyl->set_double_param("place_y",0.);
+  cyl->set_double_param("place_z",z_shift);
   cyl->SetActive(0);
   cyl->SuperDetector("DIRC");
   cyl->OverlapCheck(overlapcheck);
+
   g4Reco->registerSubsystem(cyl);
 
+  // Done
   return 89.25;
 
 }

--- a/macros/g4simulations/G4_DIRC.C
+++ b/macros/g4simulations/G4_DIRC.C
@@ -25,7 +25,7 @@ DIRCSetup(PHG4Reco* g4Reco)
   const double radiator_R = 83.65;
   const double length = 470;
   //const double z_shift = -135; // ePHENIX LOI
-  const double z_shift = -65; // shift to fit within flux return doors; NF 1/13/2016
+  const double z_shift = -75; // shift to fit within flux return doors; NF 1/13/2016
   const double z_start = z_shift + length / 2.;
   const double z_end = z_shift - length / 2.;
 

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -165,6 +165,12 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
       ana->AddTower("RAW_FEMC");
       ana->AddTower("CALIB_FEMC");
     }
+  if (do_EEMC_twr)
+    {
+      ana->AddTower("SIM_EEMC");
+      ana->AddTower("RAW_EEMC");
+      ana->AddTower("CALIB_EEMC");
+    }
 
   // Jets disabled for now
   //  if (do_jet_reco)

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -1,0 +1,171 @@
+//////////////////////////////////////////////////////////////////
+/*!
+ \file G4_DSTReader_EICDetector.C
+ \brief Adapt G4_DSTReader.C for use with EIC detector
+ \author  Nils Feege
+ \version $Revision:  $
+ \date    $Date: $
+ */
+//////////////////////////////////////////////////////////////////
+
+#include <string>
+
+void
+G4DSTreader_EICDetector( const char * outputFile = "G4EICDetectorCells.root",//
+			 int absorberactive = 1, //
+			 bool do_svtx = true, //
+			 bool do_preshower = false, //
+			 bool do_cemc = true, //
+			 bool do_hcalin = true, //
+			 bool do_magnet = true, //
+			 bool do_hcalout = true, //
+			 bool do_cemc_twr = true, //
+			 bool do_hcalin_twr = true, //
+			 bool do_magnet = true, //
+			 bool do_hcalout_twr = true, //
+			 bool do_FHCAL = true, //
+			 bool do_FHCAL_twr = true, //
+			 bool do_FEMC = true, //
+			 bool do_FEMC_twr = true, //
+			 bool do_EEMC = true, //
+			 bool do_EEMC_twr = true //
+			 )
+{
+
+  //! debug output on screen?
+  const bool debug = false;
+
+  //! save raw g4 hits
+  const bool save_g4_raw = true;
+
+  // save a comprehensive  evaluation file
+  PHG4DSTReader* ana = new PHG4DSTReader(
+      string(outputFile) + string("_DSTReader.root"));
+  ana->set_save_particle(true);
+  ana->set_load_all_particle(false);
+  ana->set_load_active_particle(true);
+  ana->set_save_vertex(true);
+
+  if (debug)
+    {
+      ana->Verbosity(2);
+    }
+
+  if (save_g4_raw)
+    {
+      if (do_svtx)
+        {
+          ana->AddNode("SVTX");
+        }
+
+      if (do_cemc)
+        {
+          ana->AddNode("CEMC");
+          if (absorberactive)
+            {
+              ana->AddNode("ABSORBER_CEMC");
+              ana->AddNode("CEMC_ELECTRONICS");
+              ana->AddNode("CEMC_SPT");
+            }
+        }
+
+      if (do_hcalin)
+        {
+          ana->AddNode("HCALIN");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_HCALIN");
+        }
+
+      if (do_magnet)
+        {
+          if (absorberactive)
+            ana->AddNode("MAGNET");
+        }
+
+      if (do_hcalout)
+        {
+          ana->AddNode("HCALOUT");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_HCALOUT");
+        }
+
+      if (do_FHCAL)
+        {
+          ana->AddNode("FHCAL");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_FHCAL");
+        }
+
+      if (do_FEMC)
+        {
+          ana->AddNode("FEMC");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_FEMC");
+        }
+
+      if (do_EEMC)
+        {
+          ana->AddNode("EEMC");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_EEMC");
+        }
+
+      ana->AddNode("BH_1");
+      ana->AddNode("BH_FORWARD_PLUS");
+      ana->AddNode("BH_FORWARD_NEG");
+
+    }
+
+  ana->set_tower_zero_sup(1e-6);
+  if (do_cemc_twr)
+    {
+      ana->AddTower("SIM_CEMC");
+      ana->AddTower("RAW_CEMC");
+      ana->AddTower("CALIB_CEMC");
+    }
+  if (do_hcalin_twr)
+    {
+      ana->AddTower("SIM_HCALIN");
+      ana->AddTower("RAW_HCALIN");
+      ana->AddTower("CALIB_HCALIN");
+    }
+  if (do_hcalout_twr)
+    {
+      ana->AddTower("SIM_HCALOUT");
+      ana->AddTower("RAW_HCALOUT");
+      ana->AddTower("CALIB_HCALOUT");
+    }
+  if (do_FHCAL_twr)
+    {
+      ana->AddTower("SIM_FHCAL");
+      ana->AddTower("RAW_FHCAL");
+      ana->AddTower("CALIB_FHCAL");
+    }
+  if (do_FEMC_twr)
+    {
+      ana->AddTower("SIM_FEMC");
+      ana->AddTower("RAW_FEMC");
+      ana->AddTower("CALIB_FEMC");
+    }
+  if (do_EEMC_twr)
+    {
+      ana->AddTower("SIM_EEMC");
+      ana->AddTower("RAW_EEMC");
+      ana->AddTower("CALIB_EEMC");
+    }
+
+  // Jets disabled for now
+//  if (do_jet_reco)
+//    {
+//
+//      ana->AddJet("AntiKt06JetsInPerfect");
+//      ana->AddJet("G4TowerJets_6");
+//    }
+//  if (embed_input_file && do_jet_reco)
+//    {
+//      ana->AddJet("G4TowerJets_combined_6");
+//    }
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->registerSubsystem(ana);
+}

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -1,8 +1,8 @@
 //////////////////////////////////////////////////////////////////
 /*!
- \file G4_DSTReader_EICDetector.C
- \brief Adapt G4_DSTReader.C for use with EIC detector
- \author  Nils Feege
+ \file G4_DSTReader.C
+ \brief Convert DST to human command readable TTree for quick poke around the outputs
+ \author  Jin Huang
  \version $Revision:  $
  \date    $Date: $
  */
@@ -11,25 +11,24 @@
 #include <string>
 
 void
-G4DSTreader_EICDetector( const char * outputFile = "G4EICDetectorCells.root",//
-			 int absorberactive = 1, //
-			 bool do_svtx = true, //
-			 bool do_preshower = false, //
-			 bool do_cemc = true, //
-			 bool do_hcalin = true, //
-			 bool do_magnet = true, //
-			 bool do_hcalout = true, //
-			 bool do_cemc_twr = true, //
-			 bool do_hcalin_twr = true, //
-			 bool do_magnet = true, //
-			 bool do_hcalout_twr = true, //
-			 bool do_FHCAL = true, //
-			 bool do_FHCAL_twr = true, //
-			 bool do_FEMC = true, //
-			 bool do_FEMC_twr = true, //
-			 bool do_EEMC = true, //
-			 bool do_EEMC_twr = true //
-			 )
+G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
+    int absorberactive = 1, //
+    bool do_svtx = true, //
+    bool do_preshower = false, //
+    bool do_cemc = true, //
+    bool do_hcalin = true, //
+    bool do_magnet = true, //
+    bool do_hcalout = true, //
+    bool do_cemc_twr = true, //
+    bool do_hcalin_twr = true, //
+    bool do_magnet = true, //
+    bool do_hcalout_twr = true, //
+    bool do_FGEM = true, //
+    bool do_FHCAL = true, //
+    bool do_FHCAL_twr = true, //
+    bool do_FEMC = true, //
+    bool do_FEMC_twr = true //
+    )
 {
 
   //! debug output on screen?
@@ -103,11 +102,13 @@ G4DSTreader_EICDetector( const char * outputFile = "G4EICDetectorCells.root",//
             ana->AddNode("ABSORBER_FEMC");
         }
 
-      if (do_EEMC)
+      if (do_FGEM)
         {
-          ana->AddNode("EEMC");
-          if (absorberactive)
-            ana->AddNode("ABSORBER_EEMC");
+          ana->AddNode("FGEM_0");
+          ana->AddNode("FGEM_1");
+          ana->AddNode("FGEM_2");
+          ana->AddNode("FGEM_3");
+          ana->AddNode("FGEM_4");
         }
 
       ana->AddNode("BH_1");
@@ -146,12 +147,6 @@ G4DSTreader_EICDetector( const char * outputFile = "G4EICDetectorCells.root",//
       ana->AddTower("SIM_FEMC");
       ana->AddTower("RAW_FEMC");
       ana->AddTower("CALIB_FEMC");
-    }
-  if (do_EEMC_twr)
-    {
-      ana->AddTower("SIM_EEMC");
-      ana->AddTower("RAW_EEMC");
-      ana->AddTower("CALIB_EEMC");
     }
 
   // Jets disabled for now

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -1,34 +1,37 @@
 //////////////////////////////////////////////////////////////////
 /*!
- \file G4_DSTReader.C
- \brief Convert DST to human command readable TTree for quick poke around the outputs
- \author  Jin Huang
- \version $Revision:  $
- \date    $Date: $
- */
+  \file G4_DSTReader.C
+  \brief Convert DST to human command readable TTree for quick poke around the outputs
+  \author  Jin Huang
+  \version $Revision:  $
+  \date    $Date: $
+*/
 //////////////////////////////////////////////////////////////////
 
 #include <string>
 
 void
 G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
-    int absorberactive = 1, //
-    bool do_svtx = true, //
-    bool do_preshower = false, //
-    bool do_cemc = true, //
-    bool do_hcalin = true, //
-    bool do_magnet = true, //
-    bool do_hcalout = true, //
-    bool do_cemc_twr = true, //
-    bool do_hcalin_twr = true, //
-    bool do_magnet = true, //
-    bool do_hcalout_twr = true, //
-    bool do_FGEM = true, //
-    bool do_FHCAL = true, //
-    bool do_FHCAL_twr = true, //
-    bool do_FEMC = true, //
-    bool do_FEMC_twr = true //
-    )
+                         int absorberactive = 1, //
+                         bool do_svtx = true, //
+                         bool do_preshower = false, //
+                         bool do_cemc = true, //
+                         bool do_hcalin = true, //
+                         bool do_magnet = true, //
+                         bool do_hcalout = true, //
+                         bool do_cemc_twr = true, //
+                         bool do_hcalin_twr = true, //
+                         bool do_magnet = true, //
+                         bool do_hcalout_twr = true, //
+                         bool do_FGEM = true, //
+                         bool do_EGEM = true, //
+                         bool do_FHCAL = true, //
+                         bool do_FHCAL_twr = true, //
+                         bool do_FEMC = true, //
+                         bool do_FEMC_twr = true, //
+                         bool do_EEMC = true, //
+                         bool do_EEMC_twr = true //
+                         )
 {
 
   //! debug output on screen?
@@ -39,7 +42,7 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
 
   // save a comprehensive  evaluation file
   PHG4DSTReader* ana = new PHG4DSTReader(
-      string(outputFile) + string("_DSTReader.root"));
+                                         string(outputFile) + string("_DSTReader.root"));
   ana->set_save_particle(true);
   ana->set_load_all_particle(false);
   ana->set_load_active_particle(true);
@@ -102,6 +105,13 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
             ana->AddNode("ABSORBER_FEMC");
         }
 
+      if (do_EEMC)
+        {
+          ana->AddNode("EEMC");
+          if (absorberactive)
+            ana->AddNode("ABSORBER_EEMC");
+        }
+
       if (do_FGEM)
         {
           ana->AddNode("FGEM_0");
@@ -109,6 +119,13 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
           ana->AddNode("FGEM_2");
           ana->AddNode("FGEM_3");
           ana->AddNode("FGEM_4");
+        }
+
+      if (do_EGEM)
+        {
+          ana->AddNode("EGEM_0");
+          ana->AddNode("EGEM_1");
+          ana->AddNode("EGEM_2");
         }
 
       ana->AddNode("BH_1");
@@ -150,16 +167,16 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
     }
 
   // Jets disabled for now
-//  if (do_jet_reco)
-//    {
-//
-//      ana->AddJet("AntiKt06JetsInPerfect");
-//      ana->AddJet("G4TowerJets_6");
-//    }
-//  if (embed_input_file && do_jet_reco)
-//    {
-//      ana->AddJet("G4TowerJets_combined_6");
-//    }
+  //  if (do_jet_reco)
+  //    {
+  //
+  //      ana->AddJet("AntiKt06JetsInPerfect");
+  //      ana->AddJet("G4TowerJets_6");
+  //    }
+  //  if (embed_input_file && do_jet_reco)
+  //    {
+  //      ana->AddJet("G4TowerJets_combined_6");
+  //    }
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->registerSubsystem(ana);

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -31,7 +31,7 @@ EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   ostringstream mapping_eemc;
 
   /* Use non-projective geometry */
-  mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
+  mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v004.txt";
 
   cout << mapping_eemc.str() << endl;
 

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -1,7 +1,5 @@
 using namespace std;
 
-// global macro parameters
-
 void
 EEMCInit()
 {
@@ -23,6 +21,9 @@ void EEMC_Cells(int verbosity = 0) {
 void
 EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 {
+
+  gSystem->Load("libg4detectors.so");
+
   /** Use dedicated EEMC module */
   PHG4CrystalCalorimeterSubsystem *eemc = new PHG4CrystalCalorimeterSubsystem("EEMC");
 
@@ -30,16 +31,16 @@ EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   ostringstream mapping_eemc;
 
   /* Use non-projective geometry */
-  mapping_eemc << getenv("OFFLINE_MAIN") << "/share/calibrations";
-  mapping_eemc << "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
+  mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
 
   cout << mapping_eemc.str() << endl;
-  eemc->SetTowerMappingFile( mapping_eemc.str() );
 
-  /* register Ecal module */
+  eemc->SetTowerMappingFile( mapping_eemc.str() );
   eemc->OverlapCheck(overlapcheck);
+
   if (absorberactive)  eemc->SetAbsorberActive();
 
+  /* register Ecal module */
   g4Reco->registerSubsystem( eemc );
 
 }
@@ -51,9 +52,8 @@ void EEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_eemc;
-  mapping_eemc << getenv("OFFLINE_MAIN") <<
-    "/share/calibrations/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
-  //mapping_eemc << "towerMap_EEMC_latest.txt";
+  mapping_eemc << getenv("CALIBRATIONROOT") <<
+    "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");
@@ -61,6 +61,7 @@ void EEMC_Towers(int verbosity = 0) {
   tower_EEMC->GeometryTableFile( mapping_eemc.str() );
 
   se->registerSubsystem(tower_EEMC);
+
 
   /* Calorimeter digitization */
 
@@ -79,6 +80,7 @@ void EEMC_Towers(int verbosity = 0) {
   TowerDigitizer_EEMC->set_zero_suppression_ADC(16); // eRD1 test beam setting
 
   se->registerSubsystem( TowerDigitizer_EEMC );
+
 
   /* Calorimeter calibration */
 

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -32,7 +32,6 @@ EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   /* Use non-projective geometry */
   mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v004.txt";
-
   cout << mapping_eemc.str() << endl;
 
   eemc->SetTowerMappingFile( mapping_eemc.str() );
@@ -53,7 +52,7 @@ void EEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_eemc;
   mapping_eemc << getenv("CALIBRATIONROOT") <<
-    "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
+    "/CrystalCalorimeter/mapping/towerMap_EEMC_v004.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -1,44 +1,46 @@
 using namespace std;
 
-bool overlapcheck = false; // set to true if you want to check for overlaps
+// global macro parameters
 
 void
 EEMCInit()
 {
-  // load detector macros
+}
+
+void EEMC_Cells(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("EEMCCellReco");
+  hc->Detector("EEMC");
+  se->registerSubsystem(hc);
+
+  return;
 }
 
 void
 EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 {
-  //---------------
-  // Load libraries
-  //---------------
+  /** Use dedicated EEMC module */
+  PHG4CrystalCalorimeterSubsystem *eemc = new PHG4CrystalCalorimeterSubsystem("EEMC");
 
-  gSystem->Load("libg4detectors.so");
-
-  //---------------
-  // Fun4All server
-  //---------------
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  /////////////////////////////////////////////////
-  //  electron going detectors
-  /////////////////////////////////////////////////
-
-  PHG4CrystalCalorimeterSubsystem *eecal = new PHG4CrystalCalorimeterSubsystem("EEMC");
+  /* path to central copy of calibrations repositry */
+  ostringstream mapping_eemc;
 
   /* Use non-projective geometry */
-  ostringstream mapping_eecal;
-  mapping_eecal << getenv("OFFLINE_MAIN") <<
-    "/share/calibrations/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
+  mapping_eemc << getenv("OFFLINE_MAIN") << "/share/calibrations";
+  mapping_eemc << "/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
 
-  cout << mapping_eecal.str() << endl;
-  eecal->SetTowerMappingFile( mapping_eecal.str() );
+  cout << mapping_eemc.str() << endl;
+  eemc->SetTowerMappingFile( mapping_eemc.str() );
 
   /* register Ecal module */
-  eecal->OverlapCheck(overlapcheck);
-  g4Reco->registerSubsystem( eecal );
+  eemc->OverlapCheck(overlapcheck);
+  if (absorberactive)  eemc->SetAbsorberActive();
+
+  g4Reco->registerSubsystem( eemc );
 
 }
 
@@ -49,9 +51,9 @@ void EEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_eemc;
-  //mapping_eemc << getenv("OFFLINE_MAIN") <<
-  //	"/share/calibrations/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
-  mapping_eemc << "towerMap_EEMC_latest.txt";
+  mapping_eemc << getenv("OFFLINE_MAIN") <<
+    "/share/calibrations/CrystalCalorimeter/mapping/towerMap_EEMC_v003.txt";
+  //mapping_eemc << "towerMap_EEMC_latest.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");
@@ -59,6 +61,8 @@ void EEMC_Towers(int verbosity = 0) {
   tower_EEMC->GeometryTableFile( mapping_eemc.str() );
 
   se->registerSubsystem(tower_EEMC);
+
+  /* Calorimeter digitization */
 
   // CMS lead tungstate barrel ECAL at 18 degree centrigrade: 4.5 photoelectrons per MeV
   const double EEMC_photoelectron_per_GeV = 4500;
@@ -76,6 +80,8 @@ void EEMC_Towers(int verbosity = 0) {
 
   se->registerSubsystem( TowerDigitizer_EEMC );
 
+  /* Calorimeter calibration */
+
   RawTowerCalibration *TowerCalibration_EEMC = new RawTowerCalibration("EEMCRawTowerCalibration");
   TowerCalibration_EEMC->Detector("EEMC");
   TowerCalibration_EEMC->Verbosity(verbosity);
@@ -84,5 +90,19 @@ void EEMC_Towers(int verbosity = 0) {
   TowerCalibration_EEMC->set_pedstal_ADC( 0 );
 
   se->registerSubsystem( TowerCalibration_EEMC );
-      
+
+}
+
+void EEMC_Clusters(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  RawClusterBuilderFwd* ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
+  ClusterBuilder->Detector("EEMC");
+  ClusterBuilder->Verbosity(verbosity);
+  se->registerSubsystem( ClusterBuilder );
+
+  return;
 }

--- a/macros/g4simulations/G4_EGEM_EIC.C
+++ b/macros/g4simulations/G4_EGEM_EIC.C
@@ -1,0 +1,116 @@
+/*!
+ * \file G4_EGEM_EIC.C
+ * \brief
+ * \author Nils Feege <nils.feege@stonybrook.edu>
+ * \version $Revision: 1.2 $
+ * \date $Date: 2014/01/22 01:44:13 $
+ */
+
+using namespace std;
+
+void
+EGEM_Init()
+{
+
+}
+
+void
+EGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
+          const double min_eta = 1.45 //
+          )
+{
+
+  const double tilt = .1;
+
+  string name;
+  double etamax;
+  double etamin;
+  double zpos;
+  PHG4SectorSubsystem *gem;
+
+  make_GEM_station("EGEM_0", g4Reco, 17, -1.01, 2.7, N_Sector);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+}
+
+//! Add drift layers to mini TPC
+void
+AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+{
+  assert(gem);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+
+  //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
+  const int N_Layers = 1; // simplified setup
+  const double thickness = 2 * cm;
+
+  gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false,
+                               100);
+  gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
+
+  for (int d = 1; d <= N_Layers; d++)
+    {
+      stringstream s;
+      s << "DriftLayer_";
+      s << d;
+
+      gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
+                                   true);
+
+    }
+}
+
+int
+make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
+                 double etamax,  const int N_Sector = 8)
+{
+
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  double polar_angle = 0;
+
+  if (zpos < 0)
+    {
+      zpos = -zpos;
+      polar_angle = TMath::Pi();
+
+    }
+  if (etamax < etamin)
+    {
+      double t = etamax;
+      etamax = etamin;
+      etamin = t;
+    }
+
+  PHG4SectorSubsystem *gem;
+  gem = new PHG4SectorSubsystem(name.c_str());
+
+  gem->SuperDetector(name);
+
+  gem->get_geometry().set_normal_polar_angle(polar_angle);
+  gem->get_geometry().set_normal_start(
+                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  gem->get_geometry().set_min_polar_angle(
+                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(
+                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(
+                                         PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_min_polar_edge(
+                                         PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->OverlapCheck(overlapcheck);
+
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
+
+}
+

--- a/macros/g4simulations/G4_EGEM_EIC.C
+++ b/macros/g4simulations/G4_EGEM_EIC.C
@@ -19,7 +19,7 @@ EGEMSetup(PHG4Reco* g4Reco)
 {
   make_GEM_station("EGEM_0", g4Reco, -32., -1.6, -3.4);
   make_GEM_station("EGEM_1", g4Reco, -58., -2.1, -3.98); // reduce max eta from -4.0 to -3.98 to avoid overlap with volume S_AL_PIPE_5 (aluminum beam pipe)
-  make_GEM_station("EGEM_2", g4Reco, -98., -1.2, -4.5);
+  make_GEM_station("EGEM_2", g4Reco, -101., -1.2, -4.5);
 }
 
 int

--- a/macros/g4simulations/G4_EGEM_EIC.C
+++ b/macros/g4simulations/G4_EGEM_EIC.C
@@ -1,12 +1,12 @@
-/*!
- * \file G4_EGEM_EIC.C
- * \brief
- * \author Nils Feege <nils.feege@stonybrook.edu>
- * \version $Revision: 1.2 $
- * \date $Date: 2014/01/22 01:44:13 $
- */
+// $Id: G4_FGEM_ePHENIX.C,v 1.4 2013/10/13 21:45:27 jinhuang Exp $
 
-using namespace std;
+/*!
+ * \file G4_FGEM_ePHENIX.C
+ * \brief
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.4 $
+ * \date $Date: 2013/10/13 21:45:27 $
+ */
 
 void
 EGEM_Init()
@@ -15,91 +15,21 @@ EGEM_Init()
 }
 
 void
-EGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-          const double min_eta = 1.45 //
-          )
+EGEMSetup(PHG4Reco* g4Reco)
 {
-
-  const double tilt = .1;
-
-  string name;
-  double etamax;
-  double etamin;
-  double zpos;
-  PHG4SectorSubsystem *gem;
-
-  make_GEM_station("EGEM_0", g4Reco, -30, 1.01, 2.7, N_Sector);
-  make_GEM_station("EGEM_1", g4Reco, -55, 2.15, 4.0, N_Sector);
-
-  ///////////////////////////////////////////////////////////////////////////
-
-  ///////////////////////////////////////////////////////////////////////////
-
-  name = "EGEM_2";
-  etamax = 4;
-  etamin = min_eta;
-  zpos = -1.0e2;
-
-  gem = new PHG4SectorSubsystem(name.c_str());
-
-  gem->get_geometry().set_normal_polar_angle(tilt);
-  gem->get_geometry().set_normal_start(
-      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
-  gem->get_geometry().set_min_polar_angle(
-      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
-  gem->get_geometry().set_max_polar_angle(
-      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
-  gem->get_geometry().set_max_polar_edge(
-      PHG4Sector::Sector_Geometry::FlatEdge());
-  gem->get_geometry().set_material("G4_METHANE");
-  gem->get_geometry().set_N_Sector(N_Sector);
-  gem->OverlapCheck(overlapcheck);
-  AddLayers_MiniTPCDrift(gem);
-  gem->get_geometry().AddLayers_HBD_GEM();
-  g4Reco->registerSubsystem(gem);
-
-  ///////////////////////////////////////////////////////////////////////////
-
-}
-
-//! Add drift layers to mini TPC
-void
-AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
-{
-  assert(gem);
-
-  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
-  const double mm = .1 * cm;
-  const double um = 1e-3 * mm;
-
-  //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
-  const int N_Layers = 1; // simplified setup
-  const double thickness = 2 * cm;
-
-  gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false,
-                               100);
-  gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
-
-  for (int d = 1; d <= N_Layers; d++)
-    {
-      stringstream s;
-      s << "DriftLayer_";
-      s << d;
-
-      gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
-                                   true);
-
-    }
+  make_GEM_station("EGEM_0", g4Reco, -32., -1.6, -3.4);
+  make_GEM_station("EGEM_1", g4Reco, -58., -2.1, -4.0);
+  make_GEM_station("EGEM_2", g4Reco, -98., -1.2, -4.5);
 }
 
 int
 make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-                 double etamax,  const int N_Sector = 8)
+                 double etamax)
 {
 
   //  cout
-  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
-  //      << name << endl;
+  //    << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //    << name << endl;
 
   double polar_angle = 0;
 
@@ -119,8 +49,6 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
   PHG4SectorSubsystem *gem;
   gem = new PHG4SectorSubsystem(name.c_str());
 
-  gem->SuperDetector(name);
-
   gem->get_geometry().set_normal_polar_angle(polar_angle);
   gem->get_geometry().set_normal_start(
                                        zpos * PHG4Sector::Sector_Geometry::Unit_cm());
@@ -128,15 +56,11 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
                                           PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
                                           PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
-  gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
-  gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
-  gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(1);
   gem->OverlapCheck(overlapcheck);
 
-  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_DriftVol_COMPASS();
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
 

--- a/macros/g4simulations/G4_EGEM_EIC.C
+++ b/macros/g4simulations/G4_EGEM_EIC.C
@@ -28,7 +28,35 @@ EGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   double zpos;
   PHG4SectorSubsystem *gem;
 
-  make_GEM_station("EGEM_0", g4Reco, 17, -1.01, 2.7, N_Sector);
+  make_GEM_station("EGEM_0", g4Reco, -30, 1.01, 2.7, N_Sector);
+  make_GEM_station("EGEM_1", g4Reco, -55, 2.15, 4.0, N_Sector);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  name = "EGEM_2";
+  etamax = 4;
+  etamin = min_eta;
+  zpos = -1.0e2;
+
+  gem = new PHG4SectorSubsystem(name.c_str());
+
+  gem->get_geometry().set_normal_polar_angle(tilt);
+  gem->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+  gem->get_geometry().set_min_polar_angle(
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+  gem->get_geometry().set_max_polar_angle(
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+  gem->get_geometry().set_max_polar_edge(
+      PHG4Sector::Sector_Geometry::FlatEdge());
+  gem->get_geometry().set_material("G4_METHANE");
+  gem->get_geometry().set_N_Sector(N_Sector);
+  gem->OverlapCheck(overlapcheck);
+  AddLayers_MiniTPCDrift(gem);
+  gem->get_geometry().AddLayers_HBD_GEM();
+  g4Reco->registerSubsystem(gem);
 
   ///////////////////////////////////////////////////////////////////////////
 

--- a/macros/g4simulations/G4_EGEM_EIC.C
+++ b/macros/g4simulations/G4_EGEM_EIC.C
@@ -18,7 +18,7 @@ void
 EGEMSetup(PHG4Reco* g4Reco)
 {
   make_GEM_station("EGEM_0", g4Reco, -32., -1.6, -3.4);
-  make_GEM_station("EGEM_1", g4Reco, -58., -2.1, -4.0);
+  make_GEM_station("EGEM_1", g4Reco, -58., -2.1, -3.98); // reduce max eta from -4.0 to -3.98 to avoid overlap with volume S_AL_PIPE_5 (aluminum beam pipe)
   make_GEM_station("EGEM_2", g4Reco, -98., -1.2, -4.5);
 }
 

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -31,10 +31,6 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   ostringstream mapping_femc;
 
-  // EIC ECAL
-  //femc->SetEICDetector(); 
-  //mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
-
   // fsPHENIX ECAL
   femc->SetfsPHENIXDetector(); 
   mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v002.txt";
@@ -57,9 +53,6 @@ void FEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_femc;
-  // EIC ECAL
-  //mapping_femc << getenv("OFFLINE_MAIN") <<
-  // 	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
 
   // fsPHENIX ECAL
   mapping_femc << getenv("CALIBRATIONROOT") <<

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -1,0 +1,122 @@
+using namespace std;
+
+// global macro parameters
+bool overlapcheck = false; // set to true if you want to check for overlaps
+
+void
+FEMCInit()
+{
+}
+
+void FEMC_Cells(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
+  hc->Detector("FEMC");
+  se->registerSubsystem(hc);
+  
+  return;  
+}
+
+void
+FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
+{
+
+  gSystem->Load("libg4detectors.so");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  /** Use dedicated FEMC module */
+  PHG4ForwardEcalSubsystem *femc = new PHG4ForwardEcalSubsystem("FEMC");
+
+  ostringstream mapping_femc;
+
+  /* path to central copy of calibrations repositry */
+  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations";
+  mapping_femc << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+  cout << mapping_femc.str() << endl;
+  //mapping_femc << "towerMap_FEMC_latest.txt";
+
+  femc->SetTowerMappingFile( mapping_femc.str() );
+  femc->OverlapCheck(overlapcheck);
+
+  if (absorberactive)  femc->SetAbsorberActive();
+
+  g4Reco->registerSubsystem( femc );
+
+}
+
+void FEMC_Towers(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ostringstream mapping_femc;
+  mapping_femc << getenv("OFFLINE_MAIN") <<
+   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+  //mapping_femc << "towerMap_FEMC_latest.txt";
+
+  RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
+  tower_FEMC->Detector("FEMC");
+  tower_FEMC->set_sim_tower_node_prefix("SIM");
+  tower_FEMC->GeometryTableFile( mapping_femc.str() );
+
+  se->registerSubsystem(tower_FEMC);
+
+  // const double FEMC_photoelectron_per_GeV = 500; //500 photon per total GeV deposition
+
+  // RawTowerDigitizer *TowerDigitizer_FEMC = new RawTowerDigitizer("FEMCRawTowerDigitizer");
+  // TowerDigitizer_FEMC->Detector("FEMC");
+  // TowerDigitizer_FEMC->Verbosity(verbosity);
+  // TowerDigitizer_FEMC->set_raw_tower_node_prefix("RAW");
+  // TowerDigitizer_FEMC->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
+  // TowerDigitizer_FEMC->set_pedstal_central_ADC(0);
+  // TowerDigitizer_FEMC->set_pedstal_width_ADC(8);// eRD1 test beam setting
+  // TowerDigitizer_FEMC->set_photonelec_ADC(1);//not simulating ADC discretization error
+  // TowerDigitizer_FEMC->set_photonelec_yield_visible_GeV( FEMC_photoelectron_per_GeV );
+  // TowerDigitizer_FEMC->set_zero_suppression_ADC(16); // eRD1 test beam setting
+
+  // se->registerSubsystem( TowerDigitizer_FEMC );
+
+  // RawTowerCalibration *TowerCalibration_FEMC = new RawTowerCalibration("FEMCRawTowerCalibration");
+  // TowerCalibration_FEMC->Detector("FEMC");
+  // TowerCalibration_FEMC->Verbosity(verbosity);
+  // TowerCalibration_FEMC->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  // TowerCalibration_FEMC->set_calib_const_GeV_ADC( 1. / FEMC_photoelectron_per_GeV );
+  // TowerCalibration_FEMC->set_pedstal_ADC( 0 );
+
+  // se->registerSubsystem( TowerCalibration_FEMC );
+
+  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FEMCRawTowerDigitizer");
+  TowerDigitizer->Detector("FEMC");
+  TowerDigitizer->Verbosity(verbosity);
+  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
+  se->registerSubsystem( TowerDigitizer );
+
+  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FEMCRawTowerCalibration");
+  TowerCalibration->Detector("FEMC");
+  TowerCalibration->Verbosity(verbosity);
+  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration->set_calib_const_GeV_ADC(1.0/0.2949);  // calibrated with muons
+  TowerCalibration->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration );
+
+}
+
+void FEMC_Clusters(int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+  
+  RawClusterBuilderFwd* ClusterBuilder = new RawClusterBuilderFwd("FEMCRawClusterBuilderFwd");
+  ClusterBuilder->Detector("FEMC");
+  ClusterBuilder->Verbosity(verbosity);
+  se->registerSubsystem( ClusterBuilder );
+  
+  return;
+}

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -1,8 +1,5 @@
 using namespace std;
 
-// global macro parameters
-bool overlapcheck = false; // set to true if you want to check for overlaps
-
 void
 FEMCInit()
 {
@@ -17,8 +14,8 @@ void FEMC_Cells(int verbosity = 0) {
   PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
   hc->Detector("FEMC");
   se->registerSubsystem(hc);
-  
-  return;  
+
+  return;
 }
 
 void
@@ -34,11 +31,11 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   ostringstream mapping_femc;
 
-  /* path to central copy of calibrations repositry */
-  mapping_femc << getenv("OFFLINE_MAIN") << "/share/calibrations";
-  mapping_femc << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+  // EIC ECAL
+  femc->SetEICDetector();
+  mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
+
   cout << mapping_femc.str() << endl;
-  //mapping_femc << "towerMap_FEMC_latest.txt";
 
   femc->SetTowerMappingFile( mapping_femc.str() );
   femc->OverlapCheck(overlapcheck);
@@ -56,9 +53,8 @@ void FEMC_Towers(int verbosity = 0) {
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_femc;
-  mapping_femc << getenv("OFFLINE_MAIN") <<
-   	"/share/calibrations/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
-  //mapping_femc << "towerMap_FEMC_latest.txt";
+  // EIC ECAL
+  mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v005.txt";
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -67,43 +63,23 @@ void FEMC_Towers(int verbosity = 0) {
 
   se->registerSubsystem(tower_FEMC);
 
-  // const double FEMC_photoelectron_per_GeV = 500; //500 photon per total GeV deposition
+  // PbSc towers
+  RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  TowerDigitizer2->Detector("FEMC");
+  TowerDigitizer2->TowerType(2);
+  TowerDigitizer2->Verbosity(verbosity);
+  TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
+  se->registerSubsystem( TowerDigitizer2 );
 
-  // RawTowerDigitizer *TowerDigitizer_FEMC = new RawTowerDigitizer("FEMCRawTowerDigitizer");
-  // TowerDigitizer_FEMC->Detector("FEMC");
-  // TowerDigitizer_FEMC->Verbosity(verbosity);
-  // TowerDigitizer_FEMC->set_raw_tower_node_prefix("RAW");
-  // TowerDigitizer_FEMC->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
-  // TowerDigitizer_FEMC->set_pedstal_central_ADC(0);
-  // TowerDigitizer_FEMC->set_pedstal_width_ADC(8);// eRD1 test beam setting
-  // TowerDigitizer_FEMC->set_photonelec_ADC(1);//not simulating ADC discretization error
-  // TowerDigitizer_FEMC->set_photonelec_yield_visible_GeV( FEMC_photoelectron_per_GeV );
-  // TowerDigitizer_FEMC->set_zero_suppression_ADC(16); // eRD1 test beam setting
-
-  // se->registerSubsystem( TowerDigitizer_FEMC );
-
-  // RawTowerCalibration *TowerCalibration_FEMC = new RawTowerCalibration("FEMCRawTowerCalibration");
-  // TowerCalibration_FEMC->Detector("FEMC");
-  // TowerCalibration_FEMC->Verbosity(verbosity);
-  // TowerCalibration_FEMC->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  // TowerCalibration_FEMC->set_calib_const_GeV_ADC( 1. / FEMC_photoelectron_per_GeV );
-  // TowerCalibration_FEMC->set_pedstal_ADC( 0 );
-
-  // se->registerSubsystem( TowerCalibration_FEMC );
-
-  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FEMCRawTowerDigitizer");
-  TowerDigitizer->Detector("FEMC");
-  TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitalization);
-  se->registerSubsystem( TowerDigitizer );
-
-  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FEMCRawTowerCalibration");
-  TowerCalibration->Detector("FEMC");
-  TowerCalibration->Verbosity(verbosity);
-  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1.0/0.2949);  // calibrated with muons
-  TowerCalibration->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration );
+  // PbSc towers
+  RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  TowerCalibration2->Detector("FEMC");
+  TowerCalibration2->TowerType(2);
+  TowerCalibration2->Verbosity(verbosity);
+  TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
+  TowerCalibration2->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration2 );
 
 }
 
@@ -112,11 +88,11 @@ void FEMC_Clusters(int verbosity = 0) {
   gSystem->Load("libfun4all.so");
   gSystem->Load("libg4detectors.so");
   Fun4AllServer *se = Fun4AllServer::instance();
-  
+
   RawClusterBuilderFwd* ClusterBuilder = new RawClusterBuilderFwd("FEMCRawClusterBuilderFwd");
   ClusterBuilder->Detector("FEMC");
   ClusterBuilder->Verbosity(verbosity);
   se->registerSubsystem( ClusterBuilder );
-  
+
   return;
 }

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -26,7 +26,8 @@ RICHSetup(PHG4Reco* g4Reco, //
 	  const int N_RICH_Sector = 8, //
 	  const double min_eta = 1.45, //
 	  const double R_mirror_ref = 195, //cm
-	  const double z_shift = 65 // cm
+	  const double z_shift = 75, // cm
+	  const double R_shift = 18.5 // cm
 	  )
 {
 
@@ -40,7 +41,7 @@ RICHSetup(PHG4Reco* g4Reco, //
   rich->get_RICH_geometry().set_R_mirror_ref(R_mirror_ref * ePHENIXRICH::RICH_Geometry::Unit_cm());
 
   rich->get_RICH_geometry().set_z_shift(z_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
-
+  rich->get_RICH_geometry().set_R_shift(R_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
 
   /* Register RICH module */
   rich->OverlapCheck( overlapcheck );

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -25,7 +25,7 @@ void
 RICHSetup(PHG4Reco* g4Reco, //
 	  const int N_RICH_Sector = 8, //
 	  const double min_eta = 1.2, //
-	  const double R_mirror_ref = 195, //cm
+	  const double R_mirror_ref = 155, //cm
 	  )
 {
 

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -1,0 +1,46 @@
+// $Id: G4_RICH.C,v 1.2 2013/10/09 01:08:17 jinhuang Exp $
+
+/*!
+ * \file G4_RICH.C
+ * \brief Setup the gas RICH detector as designed in ePHENIX LOI
+ * \author Jin Huang <jhuang@bnl.gov>
+ * \version $Revision: 1.2 $
+ * \date $Date: 2013/10/09 01:08:17 $
+ */
+
+using namespace std;
+
+// global macro parameters
+
+void
+RICHInit()
+{
+}
+
+//! ePHENIX Gas RICH. Ref to Geometry parameter defined in ePHENIXRICH::RICH_Geometry
+//! \param[in] N_RICH_Sector number of RICH sectors
+//! \param[in] min_eta minimal eta coverage
+//! \param[in] R_mirror_ref Radius for the reflection layer of the mirror
+void
+RICHSetup(PHG4Reco* g4Reco, //
+	  const int N_RICH_Sector = 8, //
+	  const double min_eta = 1.2, //
+	  const double R_mirror_ref = 195, //cm
+	  )
+{
+
+  /* Use dedicated RICH subsystem */
+  PHG4RICHSubsystem *rich = new PHG4RICHSubsystem("RICH");
+  rich->get_RICH_geometry().set_N_RICH_Sector(N_RICH_Sector);
+  rich->get_RICH_geometry().set_min_eta(min_eta);
+
+  //  rich->get_RICH_geometry().set_R_shift(10 * ePHENIXRICH::RICH_Geometry::Unit_cm()); // For compact RICH of 2<Eta<4
+
+  rich->get_RICH_geometry().set_R_mirror_ref(R_mirror_ref * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  /* Register RICH module */
+  rich->OverlapCheck( overlapcheck );
+
+  g4Reco->registerSubsystem( rich );
+
+}

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -24,8 +24,9 @@ RICHInit()
 void
 RICHSetup(PHG4Reco* g4Reco, //
 	  const int N_RICH_Sector = 8, //
-	  const double min_eta = 1.2, //
-	  const double R_mirror_ref = 155, //cm
+	  const double min_eta = 1.45, //
+	  const double R_mirror_ref = 195, //cm
+	  const double z_shift = 65 // cm
 	  )
 {
 
@@ -37,6 +38,9 @@ RICHSetup(PHG4Reco* g4Reco, //
   //  rich->get_RICH_geometry().set_R_shift(10 * ePHENIXRICH::RICH_Geometry::Unit_cm()); // For compact RICH of 2<Eta<4
 
   rich->get_RICH_geometry().set_R_mirror_ref(R_mirror_ref * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->get_RICH_geometry().set_z_shift(z_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
 
   /* Register RICH module */
   rich->OverlapCheck( overlapcheck );


### PR DESCRIPTION
Adding macros to build full EIC detector geometry.

![eicdet](https://cloud.githubusercontent.com/assets/9557412/17252749/a5451862-5562-11e6-916b-f5317b6ed783.jpg)

Overlapcheck of all detectors yields overlaps of:

CEMC_1_sec1 with CEMC_1_sec0 volume's (message repeated for all subsequent CEMC_1_sec###) --> Is this a known overlap? Should be the same for default sPHENIX.

hEcalTower_envelope with OuterHcal volume's --> Corner of forward-ECAL clears the physical outer-HCAL, but touches the rectangular boundary box.

BH_1 with hHcalTower_envelope --> hHcalTower_envelope is cone shaped and extends beyond the physical towers, hence this overlap.

