### PR TITLE
Macro updates for fast forward tracking

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -75,6 +75,7 @@ int Fun4All_G4_fsPHENIX(
   // fsPHENIX geometry
 
   bool do_FGEM = true;
+  bool do_FGEM_track =true;
 
   bool do_FEMC = true; 
   bool do_FEMC_cell = true; 
@@ -272,6 +273,12 @@ int Fun4All_G4_fsPHENIX(
   //--------------
 
   if (do_svtx_track) Svtx_Reco();
+
+  //--------------
+  // FGEM tracking
+  //--------------
+
+  if(do_FGEM_track) FGEM_FastSim_Reco();
 
   //-----------------
   // Global Vertexing

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -112,6 +112,7 @@ void FEMC_Clusters(int verbosity = 0) {
   RawClusterBuilderFwd* ClusterBuilder = new RawClusterBuilderFwd("FEMCRawClusterBuilderFwd");
   ClusterBuilder->Detector("FEMC");
   ClusterBuilder->Verbosity(verbosity);
+  ClusterBuilder->set_threshold_energy(0.100);  
   se->registerSubsystem( ClusterBuilder );
   
   return;

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -250,3 +250,52 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
 
 }
 
+void FGEM_FastSim_Reco(int verbosity = 0) {
+
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4hough.so");
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4TrackFastSim* kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
+  kalman->Verbosity(0);
+
+  kalman->set_use_vertex_in_fitting(true);
+  kalman->set_vertex_xy_resolution(50E-4);
+  kalman->set_vertex_z_resolution(50E-4);
+
+  kalman->set_detector_type(PHG4TrackFastSim::Vertical_Plane); // Vertical_Plane, Cylinder
+  kalman->set_phi_resolution(50E-4);
+  kalman->set_r_resolution(1.);
+
+  kalman->set_mag_field_file_name("/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root");
+  kalman->set_mag_field_re_scaling_factor(1.);
+
+  kalman->set_pat_rec_hit_finding_eff(1.);
+  kalman->set_pat_rec_noise_prob(0.);
+
+  std::string phg4hits_names[] = {"G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
+  kalman->set_phg4hits_names(phg4hits_names, 5);
+  kalman->set_sub_top_node_name("SVTX");
+  kalman->set_trackmap_out_name("SvtxTrackMap");
+
+  // Saved track states (projections)
+  std::string state_names[] = {"FEMC","FHCAL"};
+  kalman->set_state_names(state_names, 2);
+
+  kalman->set_fit_alg_name("KalmanFitterRefTrack");//
+  kalman->set_primary_assumption_pid(13);
+  kalman->set_do_evt_display(false);
+
+  se->registerSubsystem(kalman);
+
+}
+

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -115,6 +115,7 @@ void FHCAL_Clusters(int verbosity = 0) {
   RawClusterBuilderFwd* ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
   ClusterBuilder->Detector("FHCAL");
   ClusterBuilder->Verbosity(verbosity);
+  ClusterBuilder->set_threshold_energy(0.100);  
   se->registerSubsystem( ClusterBuilder );
   
   return;


### PR DESCRIPTION
Macro updates to serve as an example to users for how to enable the new fast forward tracking by Haiwang, as well  as the projections to forward detectors that I added.  Note that both Haiwang's and my evaluator are currently private code so I have not added the evaluator.  One could certainly be added as an example. 

I also added a minimum tower energy cutoff for the clustering for both the FEMC and the FHCAL.  This gives a reasonable number of towers (~9) for e-/pi- showers between 10-30 GeV, but it's still not a substitute for a proper clustering algorithm. 

All this is just intended to have some more information in place for people starting in simulations and have the simulations behave semi-reasonable out-of-the-box. 