### PR TITLE
Switch on save geometry from Geant4 to DST

### DIFF
--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -106,6 +106,7 @@ int G4Setup(const int absorberactive = 0,
   Fun4AllServer *se = Fun4AllServer::instance();
 
   PHG4Reco* g4Reco = new PHG4Reco();
+  g4Reco->save_DST_geometry(true); //Save geometry from Geant4 to DST
   g4Reco->set_rapidity_coverage(1.1); // according to drawings
 
   if (decayType != TPythia6Decayer::kAll) {


### PR DESCRIPTION
Turn on PHG4Reco:: save_DST_geometry() by default.

This will use Jin's PHGeometry utilities to save a TGeometry version of detector geometry in the DST node, which makes the using of GenFit2 based modules possible. Turn this on to make the macros able to run out of box.