### PR TITLE
Add EMCal to prototype3 simulation

### DIFF
--- a/macros/prototype3/Fun4All_G4_Prototype3.C
+++ b/macros/prototype3/Fun4All_G4_Prototype3.C
@@ -8,7 +8,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   gSystem->Load("libg4eval.so");
   gSystem->Load("libqa_modules");
 
-  bool cemc_on = false;
+  bool cemc_on = true;
   bool cemc_cell = cemc_on && false;
   bool cemc_twr = cemc_cell && false;
   bool cemc_digi = cemc_twr && false;
@@ -25,7 +25,8 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   bool ohcal_twrcal =  ohcal_digi && false;
   bool cryo_on = true;
   bool bh_on = false; // the surrounding boxes need some further thinking
-  bool dstreader = false;
+  bool dstreader = true;
+  bool hit_ntuple = false;
 
   ///////////////////////////////////////////
   // Make the Server
@@ -43,7 +44,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   double add_place_x = 183.-173.93+2.54/2.;
   // Test beam generator
   PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-  gen->add_particles("pi-", 1); // mu-,e-,anti_proton,pi-
+  gen->add_particles("mu-", 1); // mu-,e-,anti_proton,pi-
   gen->set_vertex_distribution_mean(0.0, 0.0, 0);
   gen->set_vertex_distribution_width(0.0, .7, .7); // Rough beam profile size @ 16 GeV measured by Abhisek
   gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,

--- a/macros/prototype3/Fun4All_G4_Prototype3.C
+++ b/macros/prototype3/Fun4All_G4_Prototype3.C
@@ -102,8 +102,8 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
 //      cemc->Verbosity(2);
 //      cemc->set_int_param("construction_verbose",2);
       cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
-//      cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/Prototype3/Geometry/") );
-      cemc->SetCalibrationFileDir("./test_geom/" );
+      cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/Prototype3/Geometry/") );
+//      cemc->SetCalibrationFileDir("./test_geom/" );
       //  cemc->set_double_param("z_rotation_degree", 15); // rotation around CG
 //      cemc->set_double_param("xpos", (116.77 + 137.0)*.5 - 26.5 - 10.2); // location in cm of EMCal CG. Updated with final positioning of EMCal
 //      cemc->set_double_param("ypos", 4); // put it some where in UIUC blocks

--- a/macros/prototype3/Fun4All_G4_Prototype3.C
+++ b/macros/prototype3/Fun4All_G4_Prototype3.C
@@ -27,6 +27,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   bool bh_on = false; // the surrounding boxes need some further thinking
   bool dstreader = true;
   bool hit_ntuple = false;
+  bool dstoutput = false;
 
   ///////////////////////////////////////////
   // Make the Server
@@ -508,26 +509,43 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
       //    {
       //      ana->AddNode("ABSORBER_CEMC");
       //    }
-      ana->AddTower("SIM_CEMC");
-      ana->AddTower("RAW_LG_CEMC");
-      ana->AddTower("CALIB_LG_CEMC");// Low gain CEMC
-      ana->AddTower("RAW_HG_CEMC");
-      ana->AddTower("CALIB_HG_CEMC");// High gain CEMC
 
-      ana->AddTower("SIM_HCALOUT");
-      ana->AddTower("SIM_HCALIN");
+      if (cemc_twr)
+        ana->AddTower("SIM_CEMC");
+      if (cemc_digi)
+        ana->AddTower("RAW_LG_CEMC");
+      if (cemc_twrcal)
+        ana->AddTower("CALIB_LG_CEMC"); // Low gain CEMC
+      if (cemc_digi)
+        ana->AddTower("RAW_HG_CEMC");
+      if (cemc_twrcal)
+        ana->AddTower("CALIB_HG_CEMC"); // High gain CEMC
 
-      ana->AddTower("RAW_LG_HCALIN");
-      ana->AddTower("RAW_HG_HCALIN");
-      ana->AddTower("RAW_LG_HCALOUT");
-      ana->AddTower("RAW_HG_HCALOUT");
+      if (ohcal_twr)
+        ana->AddTower("SIM_HCALOUT");
+      if (ihcal_twr)
+        ana->AddTower("SIM_HCALIN");
 
-      ana->AddTower("CALIB_LG_HCALIN");
-      ana->AddTower("CALIB_HG_HCALIN");
-      ana->AddTower("CALIB_LG_HCALOUT");
-      ana->AddTower("CALIB_HG_HCALOUT");
+      if (ihcal_digi)
+        ana->AddTower("RAW_LG_HCALIN");
+      if (ihcal_digi)
+        ana->AddTower("RAW_HG_HCALIN");
+      if (ohcal_digi)
+        ana->AddTower("RAW_LG_HCALOUT");
+      if (ohcal_digi)
+        ana->AddTower("RAW_HG_HCALOUT");
 
-      ana->AddNode("BlackHole");// add a G4Hit node
+      if (ihcal_twrcal)
+        ana->AddTower("CALIB_LG_HCALIN");
+      if (ihcal_twrcal)
+        ana->AddTower("CALIB_HG_HCALIN");
+      if (ohcal_twrcal)
+        ana->AddTower("CALIB_LG_HCALOUT");
+      if (ohcal_twrcal)
+        ana->AddTower("CALIB_HG_HCALOUT");
+
+      if (bh_on)
+        ana->AddNode("BlackHole"); // add a G4Hit node
 
       se->registerSubsystem(ana);
     }
@@ -539,6 +557,12 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   // out = new Fun4AllDstOutputManager("DSTHCOUT","/phenix/scratch/pinkenbu/G4Prototype2Hcalout.root");
   // out->AddNode("G4RootScintillatorSlat_HCALOUT");
   // se->registerOutputManager(out);
+
+  if (dstoutput)
+    {
+      Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT","G4Prototype3New.root");
+      se->registerOutputManager(out);
+    }
 
   Fun4AllInputManager *in = new Fun4AllDummyInputManager( "JADE");
   se->registerInputManager( in );

--- a/macros/prototype3/Fun4All_G4_Prototype3.C
+++ b/macros/prototype3/Fun4All_G4_Prototype3.C
@@ -9,10 +9,10 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   gSystem->Load("libqa_modules");
 
   bool cemc_on = true;
-  bool cemc_cell = cemc_on && false;
-  bool cemc_twr = cemc_cell && false;
-  bool cemc_digi = cemc_twr && false;
-  bool cemc_twrcal = cemc_digi && false;
+  bool cemc_cell = cemc_on && true;
+  bool cemc_twr = cemc_cell && true;
+  bool cemc_digi = cemc_twr && true;
+  bool cemc_twrcal = cemc_digi && true;
   bool ihcal_on = true;
   bool ihcal_cell = ihcal_on && false;
   bool ihcal_twr = ihcal_cell && false;
@@ -36,7 +36,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   recoConsts *rc = recoConsts::instance();
   // only set this if you want a fixed random seed to make
   // results reproducible for testing
-  //  rc->set_IntFlag("RANDOMSEED",12345);
+//    rc->set_IntFlag("RANDOMSEED",12345678);
 
   // simulated setup sits at eta=1, theta=40.395 degrees
   double theta = 90-46.4;
@@ -44,7 +44,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   double add_place_x = 183.-173.93+2.54/2.;
   // Test beam generator
   PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-  gen->add_particles("mu-", 1); // mu-,e-,anti_proton,pi-
+  gen->add_particles("e-", 1); // mu-,e-,anti_proton,pi-
   gen->set_vertex_distribution_mean(0.0, 0.0, 0);
   gen->set_vertex_distribution_width(0.0, .7, .7); // Rough beam profile size @ 16 GeV measured by Abhisek
   gen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Gaus,
@@ -56,7 +56,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   gen->set_phi_range(-0.001, 0.001); // 1mrad angular divergence
   const double momentum = 32;
   gen->set_p_range(momentum,momentum, momentum*2e-2); // 2% momentum smearing
-  //se->registerSubsystem(gen);
+  se->registerSubsystem(gen);
 
   PHG4ParticleGenerator *pgen = new PHG4ParticleGenerator();
   pgen->set_name("geantino");
@@ -81,7 +81,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
   gun->set_vtx(0, 0, 0);
   double angle = theta*TMath::Pi()/180.;
   gun->set_mom(sin(angle),0.,cos(angle));
-  se->registerSubsystem(gun);
+//  se->registerSubsystem(gun);
 
 
   PHG4Reco* g4Reco = new PHG4Reco();
@@ -99,12 +99,15 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
       cemc->SuperDetector("CEMC");
       cemc->SetAbsorberActive();
       cemc->OverlapCheck(true);
+//      cemc->Verbosity(2);
+//      cemc->set_int_param("construction_verbose",2);
       cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
-      cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/Prototype2/Geometry/") ); 
+//      cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/Prototype3/Geometry/") );
+      cemc->SetCalibrationFileDir("./test_geom/" );
       //  cemc->set_double_param("z_rotation_degree", 15); // rotation around CG
-      cemc->set_double_param("xpos", (116.77 + 137.0)*.5 - 26.5 - 10.2); // location in cm of EMCal CG. Updated with final positioning of EMCal
-      cemc->set_double_param("ypos", 4); // put it some where in UIUC blocks
-      cemc->set_double_param("zpos", 4); // put it some where in UIUC blocks
+//      cemc->set_double_param("xpos", (116.77 + 137.0)*.5 - 26.5 - 10.2); // location in cm of EMCal CG. Updated with final positioning of EMCal
+//      cemc->set_double_param("ypos", 4); // put it some where in UIUC blocks
+//      cemc->set_double_param("zpos", 4); // put it some where in UIUC blocks
       g4Reco->registerSubsystem(cemc);
     }
   //----------------------------------------

--- a/macros/prototype3/Fun4All_G4_Prototype3.C
+++ b/macros/prototype3/Fun4All_G4_Prototype3.C
@@ -248,7 +248,7 @@ int Fun4All_G4_Prototype3(int nEvents = 1)
       TowerBuilder->set_sim_tower_node_prefix("SIM");
       se->registerSubsystem(TowerBuilder);
     }
-  const double sampling_fraction = 0.0233369; //  +/-   8.22211e-05  from 15 Degree indenting 8 GeV electron showers
+  const double sampling_fraction = 0.0190134; //  +/-   0.000224984  from 0 Degree indenting 32 GeV electron showers
   const double photoelectron_per_GeV = 500; //500 photon per total GeV deposition
   const double ADC_per_photoelectron_HG = 3.8; // From Sean Stoll, Mar 29
   const double ADC_per_photoelectron_LG = 0.24; // From Sean Stoll, Mar 29

--- a/macros/prototype3/vis_prototype3.mac
+++ b/macros/prototype3/vis_prototype3.mac
@@ -27,12 +27,13 @@
 # list of available graphics systems at some point.
 #/vis/open OGLIX
 /vis/open OGLSX 1200x900-0+0
-/vis/viewer/set/viewpointThetaPhi 270 271
+/vis/viewer/set/viewpointThetaPhi 90 90
+/vis/viewer/set/upThetaPhi 90 0
 # /vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
 /vis/viewer/zoom 1.5
-/vis/viewer/panTo 0 30 cm
+#/vis/viewer/panTo 0 30 cm
 #
 # Use this open statement instead to get a HepRep version 1 file
 # suitable for viewing in WIRED.


### PR DESCRIPTION
Pending merge of the pull request in the coresoftware (https://github.com/sPHENIX-Collaboration/coresoftware/pull/231) and calibration (https://github.com/sPHENIX-Collaboration/calibrations/pull/17). The current default output in event display mode is 32 GeV electron in three calorimeters: 
![prototypethree16](https://cloud.githubusercontent.com/assets/7947083/21614009/cf7a815c-d1a5-11e6-962c-af247cd367af.png)


