### PR TITLE
adding macros for new TPC readout geometry

### DIFF
--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -22,6 +22,7 @@ void G4Init(bool do_svtx = true,
     {
       gROOT->LoadMacro("G4_Svtx.C");                 // default MIE projections
       //gROOT->LoadMacro("G4_Svtx_maps+IT+tpc.C"); // Reference design for 2016 tracking review
+      //gROOT->LoadMacro("G4_Svtx_MAPScyl_ITTcyl_TPC.C"); // TPC new readout && MAPS/IT
       //gROOT->LoadMacro("G4_Svtx_pixels+strips.C"); // testing
       //gROOT->LoadMacro("G4_Svtx_pixels+tpc.C");    // testing
       //gROOT->LoadMacro("G4_Svtx_maps+strips.C");   // testing

--- a/macros/g4simulations/G4_Svtx_MAPScyl_ITTcyl_TPC.C
+++ b/macros/g4simulations/G4_Svtx_MAPScyl_ITTcyl_TPC.C
@@ -1,0 +1,339 @@
+#include "G4_TPC.C"
+
+const int n_ib_layer = 3;   // number of maps inner barrel layers
+const int n_intt_layer = 4; // number of int. tracker layers. Make this number 0 to use MAPS + TPC only.
+const int n_gas_layer = 40; // number of TPC layers
+
+int Min_si_layer = 0;
+int Max_si_layer = n_ib_layer + n_intt_layer + n_gas_layer;
+
+void SvtxInit(int verbosity = 0)
+{
+  Min_si_layer = 0;
+  Max_si_layer = n_ib_layer + n_intt_layer + n_gas_layer;
+}
+
+double Svtx(PHG4Reco* g4Reco, double radius, 
+      const int absorberactive = 0,
+      int verbosity = 0) {
+
+  float svtx_inner_radius = 2.3;
+  
+  if (radius > svtx_inner_radius) {
+    cout << "inconsistency: radius: " << radius 
+   << " larger than SVTX inner radius: " << svtx_inner_radius << endl;
+    gSystem->Exit(-1);
+  }
+ 
+  PHG4CylinderSubsystem *cyl;
+
+  // silicon layers ------------------------------------------------------------
+
+  // inner barrel
+  
+  double ib_si_thickness[3] = {0.0050, 0.0050, 0.0050};
+  double ib_rad[3] = {svtx_inner_radius, 3.2, 3.9};
+  double ib_support_thickness[3] = {0.0036, 0.0036, 0.0036};
+  double ib_length[3] = {27.0, 27.0, 27.0};
+
+  for (int ilayer=0;ilayer<n_ib_layer;++ilayer) {
+    cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
+    cyl->Verbosity(verbosity);
+    radius = ib_rad[ilayer];
+    cyl->set_double_param("radius",radius);
+    //cyl->set_int_param("lengthviarapidity",0);
+    cyl->set_double_param("length",ib_length[ilayer]);
+    cyl->set_string_param("material","G4_Si");
+    cyl->set_double_param("thickness",ib_si_thickness[ilayer]);
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem( cyl );
+    
+    radius += ib_si_thickness[ilayer] + no_overlapp;
+    
+    cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", ilayer);
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("radius",radius);
+    //cyl->set_int_param("lengthviarapidity",1);
+    cyl->set_double_param("length",ib_length[ilayer]);
+    cyl->set_string_param("material","G4_Cu");
+    cyl->set_double_param("thickness",ib_support_thickness[ilayer]);
+    cyl->SuperDetector("SVTXSUPPORT");
+    g4Reco->registerSubsystem( cyl );
+
+    cout << "Added inner barrel layer with radius " << ib_rad[ilayer]
+	 << " si thickness " << ib_si_thickness[ilayer]
+	 << " support thickness " << ib_support_thickness[ilayer]
+	 << " length " << ib_length[ilayer]
+	 << endl;
+  }
+
+  // intermediate tracker
+  // parameters from RIKEN
+  double intt_si_thickness[4] = {0.0120, 0.0120, 0.0120,0.0120};
+  double intt_rad[4] = { 6.0, 8.0, 10.0, 12.0};
+  // 120 microns of silicon is 0.13% of X_0, so to get 1% total we need 0.87% more in the Cu
+  double multiplier = 0.87;  // how many times 1% do you want?
+  double apercent = 0.0144;  // Cu thickness in cm corresponding to 1% X_0 
+  double intt_support_thickness[4] = {apercent*multiplier, apercent*multiplier, apercent*multiplier, apercent*multiplier};
+  double intt_length[4] = {50.0, 50.0, 50.0, 50.0};
+
+  for (int ilayer=n_ib_layer;ilayer<n_intt_layer+n_ib_layer;++ilayer) {
+    cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
+    cyl->Verbosity(verbosity);
+    radius = intt_rad[ilayer-n_ib_layer];
+    cyl->set_double_param("radius",radius);
+    cyl->set_int_param("lengthviarapidity",1);
+    //cyl->set_double_param("length",intt_length[ilayer-n_ib_layer]);
+    cyl->set_string_param("material","G4_Si");
+    cyl->set_double_param("thickness",intt_si_thickness[ilayer-n_ib_layer]);
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem( cyl );
+    
+    radius += intt_si_thickness[ilayer-n_ib_layer] + no_overlapp;
+    
+    cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", ilayer);
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("radius",radius);
+    cyl->set_int_param("lengthviarapidity",1);
+    //cyl->set_double_param("length", intt_length[ilayer-n_ib_layer]);
+    cyl->set_string_param("material","G4_Cu");
+    cyl->set_double_param("thickness",intt_support_thickness[ilayer-n_ib_layer]);
+    cyl->SuperDetector("SVTXSUPPORT");
+    g4Reco->registerSubsystem( cyl );
+ 
+    cout << "Added intermediate tracker layer with radius " << intt_rad[ilayer-n_ib_layer]
+	 << " si thickness " << intt_si_thickness[ilayer-n_ib_layer]
+	 << " support thickness " << intt_support_thickness[ilayer-n_ib_layer]
+	 << " length " << intt_length[ilayer-n_ib_layer]
+	 << endl;
+  }
+  
+  //TPC
+  radius = AddTPC2G4Geo(g4Reco,radius,0);
+
+  return radius;
+}
+
+void Svtx_Cells(int verbosity = 0)
+{
+  // runs the cellularization of the energy deposits (g4hits) 
+  // into detector hits (g4cells)
+
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  //-----------
+  // cells
+  //-----------
+
+  // inner barrel
+  double svxcellsizex[3] = {0.0020, 0.0020, 0.0020};
+  double svxcellsizey[3] = {0.0020, 0.0020, 0.0020};
+
+  // intermediate tracker
+  double intt_cellsizex[4] = { 0.0080, 0.0080, 0.0080, 0.0080}; // cm
+  double intt_cellsizey[4] = { 1.2, 1.2, 1.2, 1.2}; // cm
+
+  PHG4CylinderCellTPCReco *svtx_cells = new PHG4CylinderCellTPCReco(n_ib_layer+n_intt_layer);
+  svtx_cells->Verbosity(1);
+  svtx_cells->Detector("SVTX");
+
+  for (int i=0;i<n_ib_layer;++i) {
+    svtx_cells->cellsize(i, svxcellsizex[i], svxcellsizey[i]);
+    svtx_cells->set_timing_window(i, -2000.0, +2000.0);
+  }
+  for (int i=n_ib_layer;i<n_ib_layer+n_intt_layer;++i) {
+    svtx_cells->cellsize(i, intt_cellsizex[i-n_ib_layer], intt_cellsizey[i-n_ib_layer]);
+    svtx_cells->set_timing_window(i, -50.0, +50.0);
+  }
+
+  // TPC
+  AddTPC2CellReco(svtx_cells);
+  
+  se->registerSubsystem(svtx_cells);
+  return;
+}
+
+void Svtx_Reco(int verbosity = 0)
+{
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4hough.so");
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  //----------------------------------
+  // Digitize the cell energy into ADC
+  //----------------------------------
+  PHG4SvtxDigitizer* digi = new PHG4SvtxDigitizer();
+  digi->Verbosity(0);
+  for (int i=0;i<n_ib_layer+n_intt_layer;++i) {
+    digi->set_adc_scale(i, 255, 1.0e-6);
+  }
+  se->registerSubsystem( digi );
+  
+  //-------------------------------------
+  // Apply Live Area Inefficiency to Hits
+  //-------------------------------------
+  // defaults to 1.0 (fully active)
+  
+  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
+  deadarea->Verbosity(verbosity);
+  for(int i=0;i<n_ib_layer;i++)
+    deadarea->set_hit_efficiency(i,0.99);
+
+  for(int i=n_ib_layer;i<n_ib_layer+n_intt_layer;i++)
+    deadarea->set_hit_efficiency(i-n_ib_layer,0.99);
+
+  se->registerSubsystem( deadarea );
+
+  //-----------------------------
+  // Apply MIP thresholds to Hits
+  //-----------------------------
+
+  PHG4SvtxThresholds* thresholds = new PHG4SvtxThresholds();
+  thresholds->Verbosity(verbosity);
+  for(int i=0;i<n_ib_layer;i++)
+    thresholds->set_threshold(i,0.25);  // reduce to 0.1 for increased efficiency
+
+  for(int i=n_ib_layer;i<n_ib_layer+n_intt_layer;i++)
+    thresholds->set_threshold(i,0.25);  
+
+  se->registerSubsystem( thresholds );
+
+  //-------------
+  // Cluster Hits
+  //-------------
+
+  PHG4SvtxClusterizer* clusterizer = new PHG4SvtxClusterizer("PHG4SvtxClusterizer",Min_si_layer,n_ib_layer+n_intt_layer-1);
+  clusterizer->set_threshold(0.25);  // reduced from 0.5, should be same as cell threshold, since many hits are single cell
+  se->registerSubsystem( clusterizer );
+  
+  //---------------------
+  // Track reconstruction
+  //---------------------
+  PHG4HoughTransformTPC* hough = new PHG4HoughTransformTPC(Max_si_layer,Max_si_layer-30);
+  hough->set_mag_field(1.4);
+  hough->setPtRescaleFactor(1.00/0.993892);
+  hough->set_use_vertex(true);
+  hough->setRemoveHits(true);
+  hough->setRejectGhosts(true);
+  hough->set_min_pT(0.2);
+  hough->set_chi2_cut_full( 2.0 );
+  hough->set_chi2_cut_init( 2.0 );
+
+  hough->setBinScale(1.0);
+  hough->setZBinScale(1.0);
+
+  hough->Verbosity(verbosity);
+
+  double mat_scale = 1.0;
+  // maps inner barrel, total of 0.3% of X_0 per layer
+  for(int i=0;i<n_ib_layer;i++)
+    hough->set_material(i, mat_scale*0.003);
+  // intermediate tracker, total 1% of X_0 pair layer
+  for(int i=n_ib_layer;i<n_ib_layer+n_intt_layer;i++)
+    hough->set_material(i-n_ib_layer, mat_scale*0.010);
+
+  // silicon
+  for (int i=0;i<n_ib_layer+n_intt_layer;++i) {
+    hough->setVoteErrorScale(i, 1.0);
+  }
+  for (int i=0;i<n_ib_layer+n_intt_layer;++i) {
+    hough->setFitErrorScale(i, 1./sqrt(12.));
+  }
+
+  //TPC
+  AddTPC2Reco(digi,hough);
+  
+  se->registerSubsystem( hough );
+
+  //-----------------------
+  // Momentum Recalibration
+  //----------------------- 
+  TF1 *corr = new TF1("corr","1.0/(1+0.00908642+5.91337e-05*x+-1.87201e-05*x*x+-3.31928e-06*x*x*x+1.03004e-07*x*x*x*x+-1.05111e-09*x*x*x*x*x)",0.0,40.0);
+  PHG4SvtxMomentumRecal* recal = new PHG4SvtxMomentumRecal("PHG4SvtxMomentumRecal",corr);
+  se->registerSubsystem(recal);
+    
+  //------------------
+  // Track Projections
+  //------------------
+  PHG4SvtxTrackProjection* projection = new PHG4SvtxTrackProjection();
+  projection->Verbosity(verbosity);
+  se->registerSubsystem( projection );
+
+  //----------------------
+  // Beam Spot Calculation
+  //----------------------
+  PHG4SvtxBeamSpotReco* beamspot = new PHG4SvtxBeamSpotReco();
+  beamspot->Verbosity(verbosity);
+  se->registerSubsystem( beamspot );
+
+  return;
+}
+
+void G4_Svtx_Reco()
+{
+  cout << "\033[31;1m"
+       << "Warning: G4_Svtx_Reco() was moved to G4_Svtx.C and renamed to Svtx_Reco(), please update macros"
+       << "\033[0m" << endl;
+  Svtx_Reco();
+
+  return;
+}
+
+void Svtx_Eval(std::string outputfile, int verbosity = 0)
+{
+  //---------------
+  // Load libraries
+  //---------------
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4hough.so");
+  gSystem->Load("libg4eval.so");
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  //----------------
+  // SVTX evaluation
+  //----------------
+
+  SvtxEvaluator* eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str());
+  eval->do_cluster_eval(true);   // make cluster ntuple
+  eval->do_g4hit_eval(false);     // make g4hit ntuple
+  eval->do_hit_eval(false);         // make hit ntuple
+  eval->do_gpoint_eval(false);  
+  //eval->scan_for_embedded(true);  // evaluator will only collect embedded tracks - it will also ignore decay tracks from embedded particles!
+  eval->scan_for_embedded(false); // evaluator takes all tracks
+  eval->Verbosity(verbosity);
+  se->registerSubsystem( eval );
+
+  // MomentumEvaluator* eval = new MomentumEvaluator(outputfile.c_str(),0.2,0.4,Max_si_layer,2,Max_si_layer-4,10.,80.);
+  // se->registerSubsystem( eval );
+  
+  return;
+}

--- a/macros/g4simulations/G4_TPC.C
+++ b/macros/g4simulations/G4_TPC.C
@@ -1,0 +1,247 @@
+//Three radial modules |-||-||-|
+//Sixteen layers per module
+//Choosing Readable Radius => 23.1 cm to 75cm => module size is 17.3
+//OPTION 1:
+//R1:  6 cards/R1  * 12 R1/end * 2 end/TPC = 144 cards/TPC
+//R2:  8 cards/R2  * 12 R2/end * 2 end/TPC = 192 cards/TPC
+//R3: 12 cards/R3  * 12 R3/end * 2 end/TPC = 288 cards/TPC
+//TOTAL = 624 cards/TPC * 8 SAMPA/card = 4992 SAMPA/TPC * 32 channels/SAMPA = 159,744 channels/TPC
+
+const double TPC_CAGE_LENGTH = 211.;
+const double TPC_CAGE_IR = 20.;
+const double TPC_CAGE_OR = 78.;
+const int TPC_MOD_NLAY = 16;
+const int TPC_MOD_CH[3] = {1152,1536,2304};
+const int TPC_GAS_LAYERS = TPC_MOD_NLAY*5/2;
+const int previous_active_layers = 3/*maps*/ + 4/*itt*/;
+double TPC_RI[TPC_GAS_LAYERS];
+
+double AddTPC2G4Geo(PHG4Reco* g4Reco, double radius, int verbosity) {
+  cout << "TPC::AddTPC2G4Geo called" << endl;
+  if(radius > TPC_CAGE_IR) {
+    cout << "ConstructDetector_TPC: No space for TPC" << endl;
+    exit(0);
+  }
+
+  int previous_support_layers = 3/*maps*/ + 4/*itt*/;
+
+  PHG4CylinderSubsystem *cyl;
+
+  radius = TPC_CAGE_IR;
+
+  double n_rad_length_cage = 1.0e-02;
+  double cage_thickness = 1.436 * n_rad_length_cage;
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++ );
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material","G4_Cu");
+  cyl->set_double_param("thickness",cage_thickness );
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius += cage_thickness;
+
+  TString tpcgas = "G4_Ar";
+  double st_mod = 23.1;
+  const double TPC_MOD_DR = 17.3;
+  const double TPC_MOD_WL = 0.3;
+  const double lay_dr = (TPC_MOD_DR - TPC_MOD_WL*2)/double(TPC_MOD_NLAY);
+
+  //=== GAS UNTIL FIRST READOUT
+  double delta = TPC_MOD_DR/2 + st_mod - radius;
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++);
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material",tpcgas.Data());
+  cyl->set_double_param("thickness", delta);
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius += delta;
+
+  //=== ACTIVE FIRST HALF MODULE
+  delta = lay_dr;
+  for(int ilayer=0; ilayer<TPC_MOD_NLAY/2; ++ilayer) {
+    TPC_RI[ilayer] = radius;
+    cyl = new PHG4CylinderSubsystem("SVTX", previous_active_layers+ilayer );
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("radius",radius);
+    cyl->set_int_param("lengthviarapidity",0);
+    cyl->set_double_param("length",TPC_CAGE_LENGTH);
+    cyl->set_string_param("material",tpcgas.Data());
+    cyl->set_double_param("thickness", delta-0.0038 );
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem( cyl );
+    radius += delta;
+  }
+
+  //=== GAS UNTIL SECOND READOUT
+  double delta = 0.6;
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++);
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material",tpcgas.Data());
+  cyl->set_double_param("thickness", delta);
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius += delta;
+
+  //=== ACTIVE SECOND MODULE
+  delta = lay_dr;
+  for(int ilayer=TPC_MOD_NLAY/2; ilayer<TPC_MOD_NLAY*3/2; ++ilayer) {
+    TPC_RI[ilayer] = radius;
+    cyl = new PHG4CylinderSubsystem("SVTX", previous_active_layers+ilayer );
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("radius",radius);
+    cyl->set_int_param("lengthviarapidity",0);
+    cyl->set_double_param("length",TPC_CAGE_LENGTH);
+    cyl->set_string_param("material",tpcgas.Data());
+    cyl->set_double_param("thickness", delta-0.0038 );
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem( cyl );
+    radius += delta;
+  }
+
+  //=== GAS UNTIL THIRD READOUT
+  double delta = 0.6;
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++);
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material",tpcgas.Data());
+  cyl->set_double_param("thickness", delta);
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius += delta;
+
+  //=== ACTIVE THIRD MODULE
+  delta = lay_dr;
+  for(int ilayer=TPC_MOD_NLAY*3/2; ilayer<TPC_MOD_NLAY*5/2; ++ilayer) {
+    TPC_RI[ilayer] = radius;
+    cyl = new PHG4CylinderSubsystem("SVTX", previous_active_layers+ilayer );
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("radius",radius);
+    cyl->set_int_param("lengthviarapidity",0);
+    cyl->set_double_param("length",TPC_CAGE_LENGTH);
+    cyl->set_string_param("material",tpcgas.Data());
+    cyl->set_double_param("thickness", delta-0.0038 );
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem( cyl );
+    radius += delta;
+  }
+
+  //=== GAS UNTIL OUTER CAGE
+  delta = TPC_CAGE_OR-cage_thickness - radius;
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++);
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material",tpcgas.Data());
+  cyl->set_double_param("thickness",delta);
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius = TPC_CAGE_OR-cage_thickness;
+
+  //=== OUTER CAGE
+  cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", previous_support_layers++);
+  cyl->Verbosity(verbosity);
+  cyl->set_double_param("radius",radius);
+  cyl->set_int_param("lengthviarapidity",0);
+  cyl->set_double_param("length",TPC_CAGE_LENGTH);
+  cyl->set_string_param("material","G4_Cu");
+  cyl->set_double_param("thickness",cage_thickness );
+  cyl->SuperDetector("SVTXSUPPORT");
+  g4Reco->registerSubsystem( cyl );
+
+  radius = TPC_CAGE_OR;
+
+  return radius;
+}
+
+void AddTPC2CellReco(PHG4CylinderCellTPCReco *svtx_cells, int verbosity=0) {
+  cout << "TPC::AddTPC2CellReco called" << endl;
+  const bool do_tpc_distoration = false;//true;
+  const double diffusion = 0.0057;
+  const double electrons_per_kev = 38.;
+
+  PHG4TPCSpaceChargeDistortion* tpc_distortion = NULL;
+  if(do_tpc_distoration) {
+    if(TPC_CAGE_IR != 20. && TPC_CAGE_IR != 30.) {
+      cout << "Svtx_Cells - Fatal Error - TPC distoration required that "
+	"TPC_CAGE_IR is either 20 or 30 cm."
+           << endl;
+      exit(3);
+    }
+    string TPC_distroation_file = string(getenv("CALIBRATIONROOT")) + Form("/Tracking/TPC/SpaceChargeDistortion/sPHENIX%.0f.root",TPC_CAGE_IR);
+    PHG4TPCSpaceChargeDistortion* tpc_distortion = new PHG4TPCSpaceChargeDistortion(TPC_distroation_file);
+    //  tpc_distortion -> setAccuracy(0); // option to overwrite default
+    //  tpc_distortion -> setPrecision(1); // option to overwrite default
+  }
+  svtx_cells->setDistortion(tpc_distortion); // apply TPC distrotion if tpc_distortion is not NULL
+  svtx_cells->setDiffusion(diffusion);
+  svtx_cells->setElectronsPerKeV(electrons_per_kev);
+
+  if(verbosity>0) {
+    for(int i=0; i!=TPC_GAS_LAYERS; ++i)
+      cout << "Added TPC layer " << i << " starting at " << TPC_RI[i] << " cm." << endl;
+  }
+
+  const double tpc_dt = 0.17;
+  //=== FIRST MODULE
+  for(int i=0; i<TPC_MOD_NLAY/2; ++i) {
+    double tpc_rdphi = TMath::TwoPi()*TPC_RI[i]/double(TPC_MOD_CH[0]);
+    svtx_cells->cellsize(previous_active_layers+i, tpc_rdphi, tpc_dt);
+    svtx_cells->set_timing_window(previous_active_layers+i, -14000.0, +14000.0);
+  }
+  //=== SECOND MODULE
+  for(int i=TPC_MOD_NLAY/2; i<TPC_MOD_NLAY*3/2; ++i) {
+    double tpc_rdphi = TMath::TwoPi()*TPC_RI[i]/double(TPC_MOD_CH[1]);
+    svtx_cells->cellsize(previous_active_layers+i, tpc_rdphi, tpc_dt);
+    svtx_cells->set_timing_window(previous_active_layers+i, -14000.0, +14000.0);
+  }
+  //=== THIRD MODULE
+  for(int i=TPC_MOD_NLAY*3/2; i<TPC_MOD_NLAY*5/2; ++i) {
+    double tpc_rdphi = TMath::TwoPi()*TPC_RI[i]/double(TPC_MOD_CH[2]);
+    svtx_cells->cellsize(previous_active_layers+i, tpc_rdphi, tpc_dt);
+    svtx_cells->set_timing_window(previous_active_layers+i, -14000.0, +14000.0);
+  }
+  return;
+}
+
+void AddTPC2Reco(PHG4SvtxDigitizer* digi, PHG4HoughTransformTPC* hough) {
+  cout << "TPC::AddTPC2Reco called" << endl;
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  //clusterizer
+  PHG4TPCClusterizer* tpcclusterizer = new PHG4TPCClusterizer("PHG4TPCClusterizer",3,4,previous_active_layers,previous_active_layers+TPC_GAS_LAYERS);
+  tpcclusterizer->setEnergyCut(20.0*45.0/TPC_GAS_LAYERS);
+  se->registerSubsystem( tpcclusterizer );
+  //digitizer
+  for(int i=previous_active_layers;i<previous_active_layers+TPC_GAS_LAYERS;++i) {
+    digi->set_adc_scale(i, 10000, 1.0);
+  }
+  //hough
+  hough->setUseCellSize(true);
+  double mat_scale = 1.0;
+  for(int i=previous_active_layers;i<previous_active_layers+TPC_GAS_LAYERS;++i) {
+    hough->set_material(i, mat_scale*0.06/TPC_GAS_LAYERS);
+    hough->setFitErrorScale(i, 1./sqrt(12.));
+    hough->setVoteErrorScale(i, 1.0);
+  }
+  hough->set_material(previous_active_layers, mat_scale*0.010);   // TPC inner field cage wall, 1% of X_0
+  return;
+}


### PR DESCRIPTION
Include new macro G4_TPC.C with new TPC readout specifics: 40 layers and new rphi segmentation.
The longitudinal extension of the cage was updated too.

Including G4_Svtx_MAPScyl_ITTcyl_TPC.C to integrate new TPC to Svtx tracking in a more modular way.

New configuration is switchable from G4Setup_sPHENIX.C. Needs to be switch on by user if he wants to use it.