### PR TITLE
Prototype-3 production macro update

### DIFF
--- a/macros/prototype3/Fun4All_TestBeam.C
+++ b/macros/prototype3/Fun4All_TestBeam.C
@@ -3,10 +3,10 @@
 using namespace std;
 
 void
-Fun4All_TestBeam(int nEvents = 100,
+Fun4All_TestBeam(int nEvents = 1000,
     const char *input_file =
-        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00003373-0000.prdf",
-    const char *output_file = "data/beam_00003373.root")
+        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00003514-0000.prdf",
+    const char *output_file = "data/beam_00003514.root")
 {
   gSystem->Load("libfun4all");
   gSystem->Load("libPrototype3.so");

--- a/macros/prototype3/Fun4All_TestBeam.C
+++ b/macros/prototype3/Fun4All_TestBeam.C
@@ -5,8 +5,8 @@ using namespace std;
 void
 Fun4All_TestBeam(int nEvents = 100,
     const char *input_file =
-        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00002609-0000.prdf",
-    const char *output_file = "data/beam_00002609.root")
+        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00003373-0000.prdf",
+    const char *output_file = "data/beam_00003373.root")
 {
   gSystem->Load("libfun4all");
   gSystem->Load("libPrototype3.so");

--- a/macros/prototype3/Fun4All_TestBeam.C
+++ b/macros/prototype3/Fun4All_TestBeam.C
@@ -3,10 +3,10 @@
 using namespace std;
 
 void
-Fun4All_TestBeam(int nEvents = 1000,
+Fun4All_TestBeam(int nEvents = 100,
     const char *input_file =
-        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00003514-0000.prdf",
-    const char *output_file = "data/beam_00003514.root")
+        "/gpfs/mnt/gpfs02/sphenix/data/data01/t1044-2016a/fnal/beam/beam_00003513-0000.prdf",
+    const char *output_file = "data/beam_00003513.root")
 {
   gSystem->Load("libfun4all");
   gSystem->Load("libPrototype3.so");
@@ -186,10 +186,11 @@ Fun4All_TestBeam(int nEvents = 1000,
 
   gunpack = new GenericUnpackPRDF("PbGL");
 // unpack->Verbosity(1);
-  gunpack->add_channel(second_packet_id, 0, 0); // 0 PbGL  Only inserted in beam for testing
+  gunpack->add_channel(second_packet_id, 27, 0); // 27  PbGl  From channel 2 of adjacent 612AM amplifier
   se->registerSubsystem(gunpack);
 
   calib = new CaloCalibration("PbGL");
+  calib->GetCalibrationParameters().set_double_param("calib_const_scale", 1);
   se->registerSubsystem(calib);
 
   gunpack = new GenericUnpackPRDF("TRIGGER_VETO");
@@ -218,6 +219,25 @@ Fun4All_TestBeam(int nEvents = 1000,
   se->registerSubsystem(gunpack);
 
   calib = new CaloCalibration("TILE_MAPPER");
+  se->registerSubsystem(calib);
+
+  //  https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#Facility_Detector_ADC_Map
+  gunpack = new GenericUnpackPRDF("SC3");
+// unpack->Verbosity(1);
+  gunpack->add_channel(second_packet_id, 17, 0); // 17  SC3 From channel 3 of adjacent 612AM amplifier
+  se->registerSubsystem(gunpack);
+
+  calib = new CaloCalibration("SC3");
+  calib->GetCalibrationParameters().set_double_param("calib_const_scale", 1);
+  se->registerSubsystem(calib);
+
+  gunpack = new GenericUnpackPRDF("SC_MWPC4");
+// unpack->Verbosity(1);
+  gunpack->add_channel(second_packet_id, 18, 0); // 18  SC behind MWPC4 From channel 4 of adjacent 612AM amplifier
+  se->registerSubsystem(gunpack);
+
+  calib = new CaloCalibration("SC_MWPC4");
+  calib->GetCalibrationParameters().set_double_param("calib_const_scale", -1);
   se->registerSubsystem(calib);
 
   // -------------------  Output -------------------
@@ -273,6 +293,12 @@ Fun4All_TestBeam(int nEvents = 1000,
 
   reader->AddTower("RAW_TILE_MAPPER");
   reader->AddTower("CALIB_TILE_MAPPER");
+
+  reader->AddTower("RAW_SC3");
+  reader->AddTower("CALIB_SC3");
+
+  reader->AddTower("RAW_SC_MWPC4");
+  reader->AddTower("CALIB_SC_MWPC4");
 
   reader->AddTowerTemperature("HCALIN");
   reader->AddTowerTemperature("HCALIN");


### PR DESCRIPTION
Update facility channel map for Prototype-3 production macro. Source of information is from https://wiki.bnl.gov/sPHENIX/index.php/2017_calorimeter_beam_test#Facility_Detector_ADC_Map :

* Channel map change for lead glass
* Add channel for beam trigger counter 3 to DST/TOWER_CALIB_SC3
* Add channel for beam scintillating counter behind MWPC4 to DST/TOWER_CALIB_SC_MWPC4

tower.energy variable for these signals are set to be the peak height of wavelet in ADC . The signs of these signals are always adjusted to be positive. 