### PR TITLE
sPHENIX style file, introduced by Peter Steinberg

### DIFF
--- a/macros/sPHENIXStyle/README.md
+++ b/macros/sPHENIXStyle/README.md
@@ -1,6 +1,16 @@
 Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template . Here is a snapshot:
 
-# The rules of the sPHENIX style are
+# How to use
+
+To ensure some consistency among plots produced by different sPHENIX members, a candidate style file is being proposed (May 2017), based on the ATLAS style file. Please click here for the gzipped tar file.
+For general use, copy or link the ```sPHENIXStyle.h``` and ```sPHENIXStyle.C``` files somewhere, either locally or in your macro path (```gROOT->GetMacroPath()``` will tell you, and add it in ```.rootrc``` if you need one).
+Then do
+```
+[0] gROOT->LoadMacro("sPhenixStyle.C") [1] SetsPhenixStyle()
+```
+and you're good to go (even better, add this all into your ```.rootlogon.C``` file)
+
+# Rules of the sPHENIX style
 
 * Don't talk about the style file.
 * Always use the style file.
@@ -11,13 +21,3 @@ Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template 
 * "MC" predictions should be filled, with distinguishable colors
 * Data or pseudodata should always be histograms or graphs with error bars
 * Elements should never overlap, with each other or with the axis
-
-# Hints
-
-To ensure some consistency among plots produced by different sPHENIX members, a candidate style file is being proposed (May 2017), based on the ATLAS style file. Please click here for the gzipped tar file.
-For general use, install the ```.h``` and ```.C``` files somewhere, either locally or in your macro path (```gROOT->GetMacroPath()``` will tell you, and add it in ```.rootrc``` if you need one).
-Then do
-```
-[0] gROOT->LoadMacro("sPhenixStyle.C") [1] SetsPhenixStyle()
-```
-and you're good to go (even better, add this all into your ```.rootlogon.C``` file)

--- a/macros/sPHENIXStyle/README.md
+++ b/macros/sPHENIXStyle/README.md
@@ -1,0 +1,23 @@
+Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template . Here is a snapshot:
+
+# The rules of the sPHENIX style are
+
+* Don't talk about the style file.
+* Always use the style file.
+* Units should always be indicated in brackets "[ ]", while counts will typically specify the bin width "Events / 2 GeV" or "Events / 0.13 rad".
+* Every plot should have a legend indicating "sPHENIX", "sPHENIX Preliminary", "sPHENIX Simulation", etc.
+* sPHENIX should be bold, italic
+* Where possible, indicate the system being considered and it's energy
+* "MC" predictions should be filled, with distinguishable colors
+* Data or pseudodata should always be histograms or graphs with error bars
+* Elements should never overlap, with each other or with the axis
+
+# Hints
+
+To ensure some consistency among plots produced by different sPHENIX members, a candidate style file is being proposed (May 2017), based on the ATLAS style file. Please click here for the gzipped tar file.
+For general use, install the ```.h``` and ```.C``` files somewhere, either locally or in your macro path (```gROOT->GetMacroPath()``` will tell you, and add it in ```.rootrc``` if you need one).
+Then do
+```
+[0] gROOT->LoadMacro("sPhenixStyle.C") [1] SetsPhenixStyle()
+```
+and you're good to go (even better, add this all into your ```.rootlogon.C``` file)

--- a/macros/sPHENIXStyle/README.md
+++ b/macros/sPHENIXStyle/README.md
@@ -6,7 +6,9 @@ To ensure some consistency among plots produced by different sPHENIX members, a 
 For general use, copy or link the ```sPHENIXStyle.h``` and ```sPHENIXStyle.C``` files somewhere, either locally or in your macro path (```gROOT->GetMacroPath()``` will tell you, and add it in ```.rootrc``` if you need one).
 Then do
 ```
-[0] gROOT->LoadMacro("sPhenixStyle.C") [1] SetsPhenixStyle()
+[0] gROOT->LoadMacro("sPhenixStyle.C") 
+[1] SetsPhenixStyle()
+[2] .x test_style.C  // give it a try
 ```
 and you're good to go (even better, add this all into your ```.rootlogon.C``` file)
 

--- a/macros/sPHENIXStyle/sPhenixStyle.C
+++ b/macros/sPHENIXStyle/sPhenixStyle.C
@@ -1,0 +1,117 @@
+//
+// sPHENIX Style, based on a style file from BaBar, v0.1
+//
+
+#include <iostream>
+
+#include "sPhenixStyle.h"
+
+#include "TROOT.h"
+
+void SetsPhenixStyle ()
+{
+  static TStyle* sphenixStyle = 0;
+  std::cout << "sPhenixStyle: Applying nominal settings." << std::endl ;
+  if ( sphenixStyle==0 ) sphenixStyle = sPhenixStyle();
+  gROOT->SetStyle("sPHENIX");
+  gROOT->ForceStyle();
+}
+
+TStyle* sPhenixStyle() 
+{
+  TStyle *sphenixStyle = new TStyle("sPHENIX","sPHENIX style");
+
+  // use plain black on white colors
+  Int_t icol=0; // WHITE
+  sphenixStyle->SetFrameBorderMode(icol);
+  sphenixStyle->SetFrameFillColor(icol);
+  sphenixStyle->SetCanvasBorderMode(icol);
+  sphenixStyle->SetCanvasColor(icol);
+  sphenixStyle->SetPadBorderMode(icol);
+  sphenixStyle->SetPadColor(icol);
+  sphenixStyle->SetStatColor(icol);
+  //sphenixStyle->SetFillColor(icol); // don't use: white fill color for *all* objects
+
+  // set the paper & margin sizes
+  sphenixStyle->SetPaperSize(20,26);
+
+  // set margin sizes
+  sphenixStyle->SetPadTopMargin(0.05);
+  sphenixStyle->SetPadRightMargin(0.05);
+  sphenixStyle->SetPadBottomMargin(0.16);
+  sphenixStyle->SetPadLeftMargin(0.16);
+
+  // set title offsets (for axis label)
+  sphenixStyle->SetTitleXOffset(1.4);
+  sphenixStyle->SetTitleYOffset(1.4);
+
+  // use large fonts
+  //Int_t font=72; // Helvetica italics
+  Int_t font=42; // Helvetica
+  Double_t tsize=0.05;
+  sphenixStyle->SetTextFont(font);
+
+  sphenixStyle->SetTextSize(tsize);
+  sphenixStyle->SetLabelFont(font,"x");
+  sphenixStyle->SetTitleFont(font,"x");
+  sphenixStyle->SetLabelFont(font,"y");
+  sphenixStyle->SetTitleFont(font,"y");
+  sphenixStyle->SetLabelFont(font,"z");
+  sphenixStyle->SetTitleFont(font,"z");
+  
+  sphenixStyle->SetLabelSize(tsize,"x");
+  sphenixStyle->SetTitleSize(tsize,"x");
+  sphenixStyle->SetLabelSize(tsize,"y");
+  sphenixStyle->SetTitleSize(tsize,"y");
+  sphenixStyle->SetLabelSize(tsize,"z");
+  sphenixStyle->SetTitleSize(tsize,"z");
+
+  // use bold lines and markers
+  sphenixStyle->SetMarkerStyle(20);
+  sphenixStyle->SetMarkerSize(1.2);
+  sphenixStyle->SetHistLineWidth(2.);
+  sphenixStyle->SetLineStyleString(2,"[12 12]"); // postscript dashes
+
+  // get rid of X error bars 
+  //sphenixStyle->SetErrorX(0.001);
+  // get rid of error bar caps
+  sphenixStyle->SetEndErrorSize(0.);
+
+  // do not display any of the standard histogram decorations
+  sphenixStyle->SetOptTitle(0);
+  //sphenixStyle->SetOptStat(1111);
+  sphenixStyle->SetOptStat(0);
+  //sphenixStyle->SetOptFit(1111);
+  sphenixStyle->SetOptFit(0);
+
+  // put tick marks on top and RHS of plots
+  sphenixStyle->SetPadTickX(1);
+  sphenixStyle->SetPadTickY(1);
+
+  // legend modificatin
+  sphenixStyle->SetLegendBorderSize(0);
+  sphenixStyle->SetLegendFillColor(0);
+  sphenixStyle->SetLegendFont(font);
+
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+  std::cout << "sPhenixStyle: ROOT6 mode" << std::endl;
+  sphenixStyle->SetLegendTextSize(tsize);
+  sphenixStyle->SetPalette(kBird);
+#else
+  std::cout << "sPhenixStyle: ROOT5 mode" << std::endl;
+  // color palette - manually define 'kBird' palette only available in ROOT 6
+  Int_t alpha = 0;
+  Double_t stops[9] = { 0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000};
+  Double_t red[9]   = { 0.2082, 0.0592, 0.0780, 0.0232, 0.1802, 0.5301, 0.8186, 0.9956, 0.9764};
+  Double_t green[9] = { 0.1664, 0.3599, 0.5041, 0.6419, 0.7178, 0.7492, 0.7328, 0.7862, 0.9832};
+  Double_t blue[9]  = { 0.5293, 0.8684, 0.8385, 0.7914, 0.6425, 0.4662, 0.3499, 0.1968, 0.0539};
+  TColor::CreateGradientColorTable(9, stops, red, green, blue, 255, alpha);
+#endif
+
+  sphenixStyle->SetNumberContours(80);
+
+  return sphenixStyle;
+
+}
+

--- a/macros/sPHENIXStyle/sPhenixStyle.h
+++ b/macros/sPHENIXStyle/sPhenixStyle.h
@@ -1,0 +1,22 @@
+//
+//   @file    sPhenixStyle.h         
+//   
+//            sPHENIX Style, based on a style file from ATLAS
+//
+//
+//   @author Peter Steinberg
+// 
+//   Copyright (C) 2017 sPhenix Collaboration
+//
+//   Version 0.1
+
+#ifndef  __SPHENIXSTYLE_H
+#define __SPHENIXSTYLE_H
+
+#include "TStyle.h"
+
+void SetsPhenixStyle();
+
+TStyle* sPhenixStyle(); 
+
+#endif // __SPHENIXSTYLE_H

--- a/macros/sPHENIXStyle/sPhenixStyle.h
+++ b/macros/sPHENIXStyle/sPhenixStyle.h
@@ -15,6 +15,34 @@
 
 #include "TStyle.h"
 
+//! \brief
+/*
+Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template . Here is a snapshot:
+
+# How to use
+
+To ensure some consistency among plots produced by different sPHENIX members, a candidate style file is being proposed (May 2017), based on the ATLAS style file. Please click here for the gzipped tar file.
+For general use, copy or link the ``sPHENIXStyle.h`` and ``sPHENIXStyle.C`` files somewhere, either locally or in your macro path (``gROOT->GetMacroPath()`` will tell you, and add it in ``.rootrc`` if you need one).
+Then do
+``
+[0] gROOT->LoadMacro("sPhenixStyle.C") [1] SetsPhenixStyle()
+``
+and you're good to go (even better, add this all into your ``.rootlogon.C`` file)
+
+# Rules of the sPHENIX style
+
+* Don't talk about the style file.
+* Always use the style file.
+* Units should always be indicated in brackets "[ ]", while counts will typically specify the bin width "Events / 2 GeV" or "Events / 0.13 rad".
+* Every plot should have a legend indicating "sPHENIX", "sPHENIX Preliminary", "sPHENIX Simulation", etc.
+* sPHENIX should be bold, italic
+* Where possible, indicate the system being considered and it's energy
+* "MC" predictions should be filled, with distinguishable colors
+* Data or pseudodata should always be histograms or graphs with error bars
+* Elements should never overlap, with each other or with the axis
+
+ *
+ */
 void SetsPhenixStyle();
 
 TStyle* sPhenixStyle(); 

--- a/macros/sPHENIXStyle/sPhenixStyle.h
+++ b/macros/sPHENIXStyle/sPhenixStyle.h
@@ -15,7 +15,7 @@
 
 #include "TStyle.h"
 
-//! \brief
+//! \brief sPHENIX Style, based on a style file from ATLAS by Peter Steinberg
 /*
 Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template . Here is a snapshot:
 

--- a/macros/sPHENIXStyle/test_style.C
+++ b/macros/sPHENIXStyle/test_style.C
@@ -1,0 +1,36 @@
+//
+{
+  TCanvas c;
+  TH1F h1("h1","H1;Mass [GeV];Counts [/ GeV];",20,0,20);
+  TH1F h2("h2","H2;Mass [GeV];Counts [/ GeV];",20,0,20);
+  for (int i = 0;i<1000;i++){h1.Fill(gRandom->Gaus(7,2));}
+  for (int i = 0;i<1000;i++){h1.Fill(gRandom->Exp(.5)*20);}
+  for (int i = 0;i<1000;i++){h2.Fill(gRandom->Exp(.5)*20);}
+  h1.Draw("e1");
+  h2.Draw("same");
+  h2.SetFillColor(5);
+  h1.Draw("e1same");
+
+  TLegend leg(.55,.70,.85,.93);
+  leg.AddEntry("","#it{#bf{sPHENIX}} Preliminary","");
+  leg.AddEntry("","Au+Au #sqrt{s_{NN}}=200 GeV","");
+  leg.AddEntry(&h1,"Data","LP");
+  leg.AddEntry(&h2,"MC","F");
+  leg.Draw();
+  c.RedrawAxis();
+  c.Print("test_style.pdf");
+  c.Print("test_style.png");
+
+  TCanvas c2;
+  c2.SetRightMargin(.2);
+  TF2 f2("f2","exp(-x/5)*sin(y)",-5,5,-5,5);
+  //f2.SetContour(100);
+  f2.SetNpx(100);
+  f2.SetNpy(100);
+  f2.Draw("surf2z");
+  f2.GetXaxis()->SetTitle("X");
+  f2.GetYaxis()->SetTitle("Y");
+  f2.GetZaxis()->SetTitle("Z");
+  c2.Print("test_style_f2.pdf");
+  c2.Print("test_style_f2.png");
+}


### PR DESCRIPTION
As mentioned in the software meeting, uploading the sPHENIX style file to the macro repository. 

Please find instruction at https://wiki.bnl.gov/sPHENIX/index.php/Plot_template . Here is a snapshot:

# How to use

To ensure some consistency among plots produced by different sPHENIX members, a candidate style file is being proposed (May 2017), based on the ATLAS style file. Please click here for the gzipped tar file.
For general use, copy or link the ```sPHENIXStyle.h``` and ```sPHENIXStyle.C``` files somewhere, either locally or in your macro path (```gROOT->GetMacroPath()``` will tell you, and add it in ```.rootrc``` if you need one).
Then do
```
[0] gROOT->LoadMacro("sPhenixStyle.C") 
[1] SetsPhenixStyle()
[2] .x test_style.C  // give it a try
```
and you're good to go (even better, add this all into your ```.rootlogon.C``` file)

# Rules of the sPHENIX style

* Don't talk about the style file.
* Always use the style file.
* Units should always be indicated in brackets "[ ]", while counts will typically specify the bin width "Events / 2 GeV" or "Events / 0.13 rad".
* Every plot should have a legend indicating "sPHENIX", "sPHENIX Preliminary", "sPHENIX Simulation", etc.
* sPHENIX should be bold, italic
* Where possible, indicate the system being considered and it's energy
* "MC" predictions should be filled, with distinguishable colors
* Data or pseudodata should always be histograms or graphs with error bars
* Elements should never overlap, with each other or with the axis

