### PR TITLE
use TPC gas mixture from PHG4Reco::DefineMaterials (90%Ne, 10%CF4)

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -119,7 +119,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
   double inner_readout_radius = 30.;
   if (inner_readout_radius<radius)  inner_readout_radius = radius;
 
-  string tpcgas = "G4_Ar";
+  string tpcgas = "sPHENIX_TPC_Gas";
 
   // Layer of inert TPC gas from 20-30 cm
   if (inner_readout_radius - radius > 0) {


### PR DESCRIPTION
In the meantime the proposed gas mixture for the sphenix tpc was added to PHG4Reco::DefineMaterials, 90%Ne, 10%CF4. Not sure how much of a difference this makes for the ionization