### PR TITLE
Single macro for 40 and 60 TPC layer, option to add primary vertex to…

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -5,6 +5,9 @@ int Fun4All_G4_sPHENIX(
            const char * embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list"
 		       )
 {
+  // Set the number of TPC layer
+  const int n_TPC_layers = 40;  // use 60 for backward compatibility only
+  
   //===============
   // Input options
   //===============
@@ -54,11 +57,13 @@ int Fun4All_G4_sPHENIX(
 
   bool do_preshower = false;
   
+
   bool do_cemc = true;
   bool do_cemc_cell = do_cemc && true;
   bool do_cemc_twr = do_cemc_cell && true;
   bool do_cemc_cluster = do_cemc_twr && true;
   bool do_cemc_eval = do_cemc_cluster && true;
+
 
   bool do_hcalin = true;
   bool do_hcalin_cell = do_hcalin && true;
@@ -105,7 +110,7 @@ int Fun4All_G4_sPHENIX(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe);
+  G4Init(do_svtx,do_preshower,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,n_TPC_layers);
 
   int absorberactive = 1; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
@@ -177,54 +182,13 @@ int Fun4All_G4_sPHENIX(
       se->registerSubsystem(hr);
     }
 
-
-  // If readhepMC is also set, the Upsilons will be embedded in Hijing events
-  if(upsilons)
-    {
-      // run upsilons for momentum, dca performance, alone or embedded in Hijing
-      
-      PHG4ParticleGeneratorVectorMeson *vgen = new PHG4ParticleGeneratorVectorMeson();
-      vgen->set_decay_types("e+","e-");    // dielectron decay
-      vgen->set_vtx_zrange(-10.0, +10.0);
-      //vgen->set_vtx_zrange(0.0, 0.0); // use if Hijing events are at Z = 0
-      // Note: this rapidity range completely fills the acceptance of eta = +/- 1 unit
-      vgen->set_rapidity_range(-1.0, +1.0);
-      vgen->set_pt_range(0.0, 10.0);
-      
-      int istate = 1;
-      
-      if(istate == 1)
-	{
-	  // Upsilon(1S)
-	  vgen->set_mass(9.46);
-	  vgen->set_width(54.02e-6);
-	}
-      else if (istate == 2)
-	{
-	  // Upsilon(2S)
-	  vgen->set_mass(10.0233);
-	  vgen->set_width(31.98e-6);
-	}
-      else
-	{
-	  // Upsilon(3S)
-	  vgen->set_mass(10.3552);
-	  vgen->set_width(20.32e-6);
-	}
-      
-      vgen->Verbosity(0);
-      vgen->Embed(2);
-      se->registerSubsystem(vgen);
-      
-      cout << "Upsilon generator for istate = " << istate << " created and registered "  << endl;	  
-    }      
-  
+  // If "readhepMC" is also set, the particles will be embedded in Hijing events
   if(particles)
     {      
       // toss low multiplicity dummy events
       PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-      gen->add_particles("e-",1); // mu+,e+,proton,pi+,Upsilon
-      // gen->add_particles("pi+",100); // 100 pion option
+      gen->add_particles("pi-",2); // mu+,e+,proton,pi+,Upsilon
+      //gen->add_particles("pi+",100); // 100 pion option
       if (readhepmc || do_embedding)
 	{
 	  gen->set_reuse_existing_vertex(true);
@@ -240,9 +204,10 @@ int Fun4All_G4_sPHENIX(
 	}
       gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
       gen->set_vertex_size_parameters(0.0, 0.0);
-      gen->set_eta_range(-0.5, 0.5);
+      gen->set_eta_range(-1.0, 1.0);
       gen->set_phi_range(-1.0 * TMath::Pi(), 1.0 * TMath::Pi());
-      gen->set_pt_range(0.1, 10.0);
+      //gen->set_pt_range(0.1, 50.0);
+      gen->set_pt_range(0.1, 20.0);
       gen->Embed(1);
       gen->Verbosity(0);
 
@@ -268,6 +233,56 @@ int Fun4All_G4_sPHENIX(
 	  pgen->set_phi_range(5.3/180.*TMath::Pi(),5.7/180.*TMath::Pi());
 	  se->registerSubsystem(pgen);
 	}
+
+      // If "readhepMC" is also set, the Upsilons will be embedded in Hijing events, if 'particles" is set, the Upsilons will be embedded in whatever particles are thrown
+      if(upsilons)
+	{
+	  // run upsilons for momentum, dca performance, alone or embedded in Hijing
+      
+	  PHG4ParticleGeneratorVectorMeson *vgen = new PHG4ParticleGeneratorVectorMeson();
+	  vgen->set_decay_types("e+","e-");    // dielectron decay
+
+	  // event vertex
+	  if (readhepmc || do_embedding || particles)
+	    {
+	      vgen->set_reuse_existing_vertex(true);
+	    }
+	  else
+	    {
+	      vgen->set_vtx_zrange(-10.0, +10.0);
+	    }
+
+	  // Note: this rapidity range completely fills the acceptance of eta = +/- 1 unit
+	  vgen->set_rapidity_range(-1.0, +1.0);
+	  vgen->set_pt_range(0.0, 10.0);
+      
+	  int istate = 1;
+      
+	  if(istate == 1)
+	    {
+	      // Upsilon(1S)
+	      vgen->set_mass(9.46);
+	      vgen->set_width(54.02e-6);
+	    }
+	  else if (istate == 2)
+	    {
+	      // Upsilon(2S)
+	      vgen->set_mass(10.0233);
+	      vgen->set_width(31.98e-6);
+	    }
+	  else
+	    {
+	      // Upsilon(3S)
+	      vgen->set_mass(10.3552);
+	      vgen->set_width(20.32e-6);
+	    }
+      
+	  vgen->Verbosity(0);
+	  vgen->Embed(2);
+	  se->registerSubsystem(vgen);
+      
+	  cout << "Upsilon generator for istate = " << istate << " created and registered "  << endl;	  
+	}      
 
   if (!readhits)
     {

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -8,7 +8,8 @@ void G4Init(bool do_svtx = true,
 	    bool do_hcalin = true,
 	    bool do_magnet = true,
 	    bool do_hcalout = true,
-	    bool do_pipe = true)
+	    bool do_pipe = true,
+	    int n_TPC_layers = 40)
   {
 
   // load detector/material macros and execute Init() function
@@ -20,9 +21,8 @@ void G4Init(bool do_svtx = true,
     }  
   if (do_svtx)
     {
-      gROOT->LoadMacro("G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C");  // default tracker setup with laddered silicon trackers and 60-layer TPC (approximation of final design)
-      // gROOT->LoadMacro("G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C"); // 40-layer TPC under test by tracking team
-      SvtxInit();
+      gROOT->LoadMacro("G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C"); 
+      SvtxInit(n_TPC_layers);
     }
 
   if (do_preshower) 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C
@@ -1,17 +1,19 @@
 #include <vector>
 
+bool use_primary_vertex = false;   // include primary vertex in track fit if true 
+
 const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
 const int n_intt_layer = 4;   // must be 0-4, setting this to zero will remove the INTT completely, n < 4 gives you the first n layers
-const int n_gas_layer = 40;
+int n_gas_layer  = 40;
 
 double inner_cage_radius = 20.;
 
-int Max_si_layer = n_maps_layer + n_intt_layer + n_gas_layer;
+int Max_si_layer;
 
-void SvtxInit(int verbosity = 0)
+void SvtxInit(int n_TPC_layers = 40, int verbosity = 0)
 {
+  n_gas_layer = n_TPC_layers;
   Max_si_layer = n_maps_layer + n_intt_layer + n_gas_layer;
-  double inner_cage_radius = 20.; // options of 20.0 or 30.0 cm
 }
 
 double Svtx(PHG4Reco* g4Reco, double radius, 
@@ -22,15 +24,29 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     {
       bool maps_overlapcheck = false; // set to true if you want to check for overlaps
       
+      /*
+	The numbers used in the macro below are from the xml file dump of ITS.gdml
+	As a sanity check, I got numbers  from Walt Sondheim's drawings, sent by email June 20, 2017:
+	OD of Be beam pipe is 41.53 mm, ID is 40 mm
+	Layer 0: radius 23.44 mm to sensor center, tilt from normal to radial vector:  17.37 degrees (0.303 rad), spacing btw sensor centers: 30 deg, arc spacing 12.27 mm
+	Layer 1: radius 31.54 mm to sensor center, ttilt from normal to radial vector:  17.53 degrees (0.306 rad), spacing btw sensor centers: 22.5 deg, arc spacing 12.38 mm
+	Layer 2: radius 39.29 to sensor center, tilt from normal to radial vector: 17.02 degrees (0.297 rad), spacing btw sensor centers: 18.0 deg, arc spacing 12.34 mm
+	These are in reasonable agreement with the numbers I extracted from the gdml file, which are what we use below.
+	These use a spacing in arc length of 12.37 mm and a tilt of 0.304 for all of the first three layers
+      */
+
       // MAPS inner barrel layers 
       //======================================================
       
-      //double maps_layer_radius[3] = {23.4, 31.5, 39.3};   // mm  - precise numbers from ITS.gdml
-      double maps_layer_radius[3] = {23.635, 31.5, 39.385};   // mm  - adjusted for closest fit
+      double maps_layer_radius[3] = {23.4, 31.5, 39.3};   // mm  - precise numbers from ITS.gdml
+      //double maps_layer_radius[3] = {24.9, 33.0, 40.8};   // mm  - precise numbers from ITS.gdml + 1.5 mm for greater clearance from beam pipe
+
       // type 1 = inner barrel stave, 2 = middle barrel stave, 3 = outer barrel stave
       // we use only type 0 here
       int stave_type[3] = {0, 0, 0};
-      
+      int staves_in_layer[3] = {12, 16, 20};   // Number of staves per layer in sPHENIX MVTX
+      double phi_tilt[3] = {0.304, 0.304, 0.304};  // radians, from the gdml file, 0.304 radians is 17.4 degrees
+
       for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
 	{
 	  if (verbosity)
@@ -41,12 +57,13 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 	  lyr->Verbosity(verbosity);
 	  
 	  lyr->set_double_param("layer_nominal_radius",maps_layer_radius[ilayer]);// thickness in cm
-	  
+	  lyr->set_int_param("N_staves", staves_in_layer[ilayer]);	  // uses fixed number of staves regardless of radius, if set. Otherwise, calculates optimum number of staves
+
 	  // The cell size is used only during pixilization of sensor hits, but it is convemient to set it now because the geometry object needs it
 	  lyr->set_double_param("pixel_x",0.0030);// pitch in cm
 	  lyr->set_double_param("pixel_z",0.0030);// length in cm
 	  lyr->set_double_param("pixel_thickness",0.0018);// thickness in cm
-	  lyr->set_double_param("phitilt",0.304);   // radians, equivalent to 17.4 degrees
+	  lyr->set_double_param("phitilt", phi_tilt[ilayer]);  
 	  
 	  lyr->set_int_param("active",1);
 	  lyr->OverlapCheck(maps_overlapcheck);
@@ -221,6 +238,11 @@ void Svtx_Cells(int verbosity = 0)
   // TPC cells
   double tpc_cell_x = 0.12*0.5;
   double tpc_cell_y = 0.17*0.5;
+  if(n_gas_layer == 60)
+    {
+      tpc_cell_x = 0.12;
+      tpc_cell_y = 0.17;
+    }
 
   // Main switch for TPC distortion
   const bool do_tpc_distortion = true;
@@ -246,10 +268,21 @@ void Svtx_Cells(int verbosity = 0)
   PHG4CylinderCellTPCReco *svtx_cells = new PHG4CylinderCellTPCReco(n_maps_layer+n_intt_layer);
   svtx_cells->Detector("SVTX");
   svtx_cells->setDistortion(tpc_distortion);
-  svtx_cells->setDiffusionT(0.0130);
-  svtx_cells->setDiffusionL(0.0130);
-  svtx_cells->setSmearRPhi(0.10);  // additional smearing of cloud positions wrt hits
-  svtx_cells->setSmearZ(0.09);     // additional smearing of cloud positions wrt hits
+  if(n_gas_layer == 40)
+    {
+      svtx_cells->setDiffusionT(0.0130);
+      svtx_cells->setDiffusionL(0.0130);
+      svtx_cells->setSmearRPhi(0.10);  // additional smearing of cloud positions wrt hits
+      svtx_cells->setSmearZ(0.09);     // additional smearing of cloud positions wrt hits
+    }
+  else
+    {
+      // 60 layer tune
+      svtx_cells->setDiffusionT(0.0120);
+      svtx_cells->setDiffusionL(0.0120);
+      svtx_cells->setSmearRPhi(0.09);  // additional smearing of cluster positions 
+      svtx_cells->setSmearZ(0.06);       // additional smearing of cluster positions 
+    }
   svtx_cells->set_drift_velocity(6.0/1000.0l);
   svtx_cells->setHalfLength( 105.5 );
   svtx_cells->setElectronsPerKeV(28);
@@ -358,7 +391,7 @@ void Svtx_Reco(int verbosity = 0)
   // INTT
   for(int i=n_maps_layer;i<n_maps_layer + n_intt_layer;i++)
     {
-      thresholds->set_threshold(i,0.25);
+      thresholds->set_threshold(i,0.1);
       thresholds->set_use_thickness_mip(i, true);
 
     }
@@ -384,13 +417,24 @@ void Svtx_Reco(int verbosity = 0)
 
   PHG4TPCClusterizer* tpcclusterizer = new PHG4TPCClusterizer();
   tpcclusterizer->Verbosity(0);
-  tpcclusterizer->setEnergyCut(0/*15 adc*/);
   tpcclusterizer->setRangeLayers(n_maps_layer+n_intt_layer,Max_si_layer);
-  tpcclusterizer->setFitWindowSigmas(0.0160,0.0160);  // should be changed when TPC cluster resolution changes
-  tpcclusterizer->setFitWindowMax(8/*rphibins*/,6/*zbins*/);
- tpcclusterizer->setFitEnergyThreshold( 0.01 /*fraction*/ );
+  if(n_gas_layer == 40)
+    {
+      tpcclusterizer->setEnergyCut(0/*15 adc*/);
+      tpcclusterizer->setFitWindowSigmas(0.0160,0.0160);  // should be changed when TPC cluster resolution changes
+      tpcclusterizer->setFitWindowMax(8/*rphibins*/,6/*zbins*/);
+      tpcclusterizer->setFitEnergyThreshold( 0.01 /*fraction*/ );
+    }
+  else
+    {
+      // 60 layer tune  
+      tpcclusterizer->setEnergyCut(15/*adc*/);
+      tpcclusterizer->setFitWindowSigmas(0.0150,0.0160);  // should be changed when TPC cluster resolution changes
+      tpcclusterizer->setFitWindowMax(4/*rphibins*/,3/*zbins*/);
+      tpcclusterizer->setFitEnergyThreshold( 0.05 /*fraction*/ );
+    }
   se->registerSubsystem( tpcclusterizer );
-
+  
   // This should be true for everything except testing!
   const bool use_kalman_pat_rec = true;
   if (use_kalman_pat_rec) {
@@ -417,6 +461,8 @@ void Svtx_Reco(int verbosity = 0)
   
   PHG4TrackKalmanFitter* kalman = new PHG4TrackKalmanFitter();
   kalman->Verbosity(0);  
+  if(use_primary_vertex)
+    kalman->set_fit_primary_tracks(true); // include primary vertex in track fit if true
   se->registerSubsystem(kalman);
   
     
@@ -470,10 +516,14 @@ void Svtx_Eval(std::string outputfile, int verbosity = 0)
   // SVTX evaluation
   //----------------
 
-  SvtxEvaluator* eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str());
+  SvtxEvaluator* eval;
+  if(use_primary_vertex)
+    eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str(), "PrimaryTrackMap");
+  else
+    eval = new SvtxEvaluator("SVTXEVALUATOR",  outputfile.c_str());
   eval->do_cluster_eval(true);
-  eval->do_g4hit_eval(false);
-  eval->do_hit_eval(false);
+  eval->do_g4hit_eval(true);
+  eval->do_hit_eval(true);
   eval->do_gpoint_eval(false);
   eval->scan_for_embedded(true); // take all tracks if false - take only embedded tracks if true
   eval->Verbosity(verbosity);


### PR DESCRIPTION
… fit, option to fix number of MVTX staves per layer, re-ordered particles and upsilon generation to allow upsilons to use particles vertex.

The number of TPC layers is now specified in Fun4All_G4_sPHENIX.C and passed to G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C, which is now the only tracking macro needed.

A flag is provided in G4_Svtx_maps_ladders+intt_ladders+tpc_40layer_KalmanPatRec.C to allow the primary vertex to be included the fit for each track. 

The number of MVTX staves per layer can now be fixed in the macro, regardless of the layer radius. Needs coresoftware pull request #324. This is backward compatible, so old macros will still work.

The generator sections for "particles" and "upsilons" have been re-ordered to allow the Upsilons to inherit their vertex from the particles. This allows simultaneous evaluation of tracking performance with pions, and measurement of the Upsilon mass resolution.