### PR TITLE
Introduce digitization step for HCal simulation

### DIFF
--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -156,7 +156,7 @@ void HCALInner_Towers(int verbosity = 0) {
   TowerDigitizer->set_zero_suppression_ADC(-0); // no-zero suppression
   se->registerSubsystem(TowerDigitizer);
 
-  const double visible_sample_fraction_HCALIN = 0.067 ; //  muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+  const double visible_sample_fraction_HCALIN = 0.0631283 ; //, /gpfs/mnt/gpfs04/sphenix/user/jinhuang/prod_analysis/hadron_shower_res_nightly/./G4Hits_sPHENIX_pi-_eta0_16GeV-0000.root_qa.rootQA_Draw_HCALIN_G4Hit.pdf
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
   TowerCalibration->Detector("HCALIN");

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -128,22 +128,7 @@ void HCALInner_Towers(int verbosity = 0) {
   TowerBuilder->Verbosity(verbosity);
   se->registerSubsystem( TowerBuilder );
 
-//  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
-//  TowerDigitizer->Detector("HCALIN");
-//  TowerDigitizer->Verbosity(verbosity);
-//  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-//  se->registerSubsystem( TowerDigitizer );
-
-//  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
-//  TowerCalibration->Detector("HCALIN");
-//  TowerCalibration->Verbosity(verbosity);
-//  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-//  TowerCalibration->set_calib_const_GeV_ADC(1./0.067);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
-//  TowerCalibration->set_pedstal_ADC(0);
-//  se->registerSubsystem( TowerCalibration );
-
   // From 2016 Test beam sim
-
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
   TowerDigitizer->Detector("HCALIN");
 //  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -128,19 +128,46 @@ void HCALInner_Towers(int verbosity = 0) {
   TowerBuilder->Verbosity(verbosity);
   se->registerSubsystem( TowerBuilder );
 
+//  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
+//  TowerDigitizer->Detector("HCALIN");
+//  TowerDigitizer->Verbosity(verbosity);
+//  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer );
+
+//  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
+//  TowerCalibration->Detector("HCALIN");
+//  TowerCalibration->Verbosity(verbosity);
+//  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration->set_calib_const_GeV_ADC(1./0.067);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+//  TowerCalibration->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration );
+
+  // From 2016 Test beam sim
+
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
   TowerDigitizer->Detector("HCALIN");
-  TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer );
+//  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");
+  TowerDigitizer->set_digi_algorithm(
+       RawTowerDigitizer::kSimple_photon_digitalization);
+  TowerDigitizer->set_pedstal_central_ADC(0);
+  TowerDigitizer->set_pedstal_width_ADC(1); // From Jin's guess. No EMCal High Gain data yet! TODO: update
+  TowerDigitizer->set_photonelec_ADC(32. / 5.);
+  TowerDigitizer->set_photonelec_yield_visible_GeV(32. / 5 / (0.4e-3));
+  TowerDigitizer->set_zero_suppression_ADC(-0); // no-zero suppression
+  se->registerSubsystem(TowerDigitizer);
+
+  const double visible_sample_fraction_HCALIN = 0.067 ; //  muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
   TowerCalibration->Detector("HCALIN");
-  TowerCalibration->Verbosity(verbosity);
+//  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
+//  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1./0.067);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+  TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
   TowerCalibration->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration );
+  TowerCalibration->set_zero_suppression_GeV(-1); // no-zero suppression
+  se->registerSubsystem(TowerCalibration);
+
   return;
 }
 

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -91,21 +91,7 @@ void HCALOuter_Towers(int verbosity = 0) {
   TowerBuilder->Verbosity(verbosity);
   se->registerSubsystem( TowerBuilder );
 
-//  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
-//  TowerDigitizer->Detector("HCALOUT");
-//  TowerDigitizer->Verbosity(verbosity);
-//  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-//  se->registerSubsystem( TowerDigitizer );
-//
-//  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
-//  TowerCalibration->Detector("HCALOUT");
-//  TowerCalibration->Verbosity(verbosity);
-//  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-//  TowerCalibration->set_calib_const_GeV_ADC(1./0.0305);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
-//  TowerCalibration->set_pedstal_ADC(0);
-//  se->registerSubsystem( TowerCalibration );
-
-
+  // From 2016 Test beam sim
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
   TowerDigitizer->Detector("HCALOUT");
 //  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -118,7 +118,7 @@ void HCALOuter_Towers(int verbosity = 0) {
   TowerDigitizer->set_zero_suppression_ADC(-0); // no-zero suppression
   se->registerSubsystem(TowerDigitizer);
 
-  const double visible_sample_fraction_HCALOUT = 0.0305 ; //  muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+  const double visible_sample_fraction_HCALOUT = 3.38021e-02; // /gpfs/mnt/gpfs04/sphenix/user/jinhuang/prod_analysis/hadron_shower_res_nightly/./G4Hits_sPHENIX_pi-_eta0_16GeV.root_qa.rootQA_Draw_HCALOUT_G4Hit.pdf
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
   TowerCalibration->Detector("HCALOUT");

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -91,19 +91,45 @@ void HCALOuter_Towers(int verbosity = 0) {
   TowerBuilder->Verbosity(verbosity);
   se->registerSubsystem( TowerBuilder );
 
+//  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
+//  TowerDigitizer->Detector("HCALOUT");
+//  TowerDigitizer->Verbosity(verbosity);
+//  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer );
+//
+//  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
+//  TowerCalibration->Detector("HCALOUT");
+//  TowerCalibration->Verbosity(verbosity);
+//  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration->set_calib_const_GeV_ADC(1./0.0305);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+//  TowerCalibration->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration );
+
+
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
   TowerDigitizer->Detector("HCALOUT");
-  TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer );
+//  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");
+  TowerDigitizer->set_digi_algorithm(
+       RawTowerDigitizer::kSimple_photon_digitalization);
+  TowerDigitizer->set_pedstal_central_ADC(0);
+  TowerDigitizer->set_pedstal_width_ADC(1); // From Jin's guess. No EMCal High Gain data yet! TODO: update
+  TowerDigitizer->set_photonelec_ADC(16. / 5.);
+  TowerDigitizer->set_photonelec_yield_visible_GeV(16. / 5 / (0.2e-3));
+  TowerDigitizer->set_zero_suppression_ADC(-0); // no-zero suppression
+  se->registerSubsystem(TowerDigitizer);
+
+  const double visible_sample_fraction_HCALOUT = 0.0305 ; //  muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
   TowerCalibration->Detector("HCALOUT");
-  TowerCalibration->Verbosity(verbosity);
+//  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
+//  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1./0.0305);// muon sampling fraction from Abhisek Sen, 2015 SBU simulation workfest
+  TowerCalibration->set_calib_const_GeV_ADC(0.2e-3 / visible_sample_fraction_HCALOUT);
   TowerCalibration->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration );
+  TowerCalibration->set_zero_suppression_GeV(-1); // no-zero suppression
+  se->registerSubsystem(TowerCalibration);
+
   return;
 }
 


### PR DESCRIPTION
This is for discussion in the HCal meeting: introduce digitization step for HCal simulation in full sPHENIX setting. 

# Introduction

Digitization step (photon statistics, ADC discretization and zero suppression) for HCal simulation was implemented in 2016 and 2017 HCal prototype simulations [arXiv:1704.01461](https://arxiv.org/abs/1704.01461). But it was never enabled in full sPHENIX simulation. The difference is small, as HCal resolution is dominated by sampling fluctuation. 

Nevertheless, as we go to new stage of studies, it is probably good time to introduce it. Also the sampling fraction is updated with visible sampling fraction for 16 GeV pions from the latest simulation production, which further improves the energy resolution (previous sampling fraction is muon sampling fraction from 2015 SBU simulation workfest). 

As shown in the next section, in combination of digitization and update sampling fraction, this poll request should lightly improve the HCal energy resolution for hadronic showers.

# Checks

Check energy response and resolution by comparing three different configurations  toanalyze the last production data
1. Default macro - no digitization
2. Introduce digitization
3. This pull request: digitization + update sampling fraction
For this analysis
* The production data set is : /sphenix/data/data02/review_2017-08-02/vtx_z_10_1.4T/single_particle/spacal2d/fieldmap
* Reconstruction with the Standardized QA module for analysis: e.g. https://github.com/blackcathj/macros/blob/SinglePart_master_readhit_hadronCheck_HCalDigi_PionSampling/macros/g4simulations/Fun4All_G4_sPHENIX.C
* The plot macro is https://github.com/sPHENIX-Collaboration/analysis/blob/master/Calorimeter/macros/DrawHadronShowers.C

## Cluster size dependence
Note the resolution heavily depend on the cluster size. The test beam data is corresponding to track-based 4x4 clusters. 

### 1. Default macro - no digitization
![image](https://user-images.githubusercontent.com/7947083/29096638-c2482f0c-7c63-11e7-9922-3a4eb43c4104.png)


### 2. Introduce digitization
![image](https://user-images.githubusercontent.com/7947083/29096663-e7a932fa-7c63-11e7-9f33-d9c28b89fe55.png)


### 3. This pull request: digitization + update sampling fraction

![image](https://user-images.githubusercontent.com/7947083/29096666-ed0b16fa-7c63-11e7-8297-7d8ee3d68a5f.png)



## PID dependence. 
_Note_ NO position-dependent energy correction is applied to electron sample:
### 1. Default macro - no digitization

![image](https://user-images.githubusercontent.com/7947083/29096644-c9d1d804-7c63-11e7-990a-101bd46b2a74.png)


### 2. Introduce digitization
![image](https://user-images.githubusercontent.com/7947083/29096660-e1b1478e-7c63-11e7-8d06-4d963fd2457c.png)


### 3. This pull request: digitization + update sampling fraction
![image](https://user-images.githubusercontent.com/7947083/29096672-f3562f2c-7c63-11e7-8940-ce3f54fe3bb8.png)


## Eta dependence: 
_Note_ the leaked energy at eta=0.9 for 5x5 clusters as the last row of cluster is outside the acceptance. 
### 1. Default macro - no digitization
![image](https://user-images.githubusercontent.com/7947083/29096651-cf69dad2-7c63-11e7-9b30-64ea13d1e116.png)


### 2. Introduce digitization

![image](https://user-images.githubusercontent.com/7947083/29096655-dbf36cdc-7c63-11e7-878c-06d59a6dfbe8.png)



### 3. This pull request: digitization + update sampling fraction

![image](https://user-images.githubusercontent.com/7947083/29096677-f9b0c684-7c63-11e7-8857-19cd8a1d3405.png)

