### PR TITLE
set number of TPC layers in Fun4All_G4_*.C to 40

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -6,7 +6,7 @@ int Fun4All_G4_EICDetector(
                            )
 {
   // Set the number of TPC layer
-  const int n_TPC_layers = 60;  // use 60 for backward compatibility only
+  const int n_TPC_layers = 40;  // use 60 for backward compatibility only
   //===============
   // Input options
   //===============

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -7,7 +7,7 @@ int Fun4All_G4_fsPHENIX(
 		       )
 {
   // Set the number of TPC layer
-  const int n_TPC_layers = 60;  // use 60 for backward compatibility only
+  const int n_TPC_layers = 40;  // use 60 for backward compatibility only
 
   //===============
   // Input options

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -6,7 +6,7 @@ int Fun4All_G4_sPHENIX(
 		       )
 {
   // Set the number of TPC layer
-  const int n_TPC_layers = 60;  // use 60 for backward compatibility only
+  const int n_TPC_layers = 40;  // use 60 for backward compatibility only
   
   //===============
   // Input options


### PR DESCRIPTION
The new review sims use a 40 layer TPC. In order to read them the Fun4All macros need to be changed. (In general we should read this from the DST and do the right thing, this is an awful kludge)