### PR TITLE
Reverse magnetic field direction to use a positive B_z field

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -114,7 +114,7 @@ int Fun4All_G4_sPHENIX(
   int absorberactive = 1; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
   const string magfield = "/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
-  const float magfield_rescale = 1.4/1.5; // scale the map to a 1.4 T field
+  const float magfield_rescale = -1.4/1.5; // scale the map to a 1.4 T field
 
   //---------------
   // Fun4All server


### PR DESCRIPTION
RAVE vertex finder has a known bug preventing it from handling a negative magnetic field along z-axis. Reversing the default field map direction in both simulation and reconstruction to make the B_z component positive in the vertex region.

Intend to be used with https://github.com/sPHENIX-Collaboration/coresoftware/pull/349 