### PR TITLE
Substitute PHG4SvtxTrackProjection with PHG4GenFitTrackProjection

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -487,9 +487,9 @@ void Svtx_Reco(int verbosity = 0)
   //------------------
   // Track Projections
   //------------------
-    PHG4SvtxTrackProjection* projection = new PHG4SvtxTrackProjection();
-    projection->Verbosity(verbosity);
-    se->registerSubsystem( projection );
+  PHG4GenFitTrackProjection *projection = new PHG4GenFitTrackProjection();
+  projection->Verbosity(verbosity);
+  se->registerSubsystem( projection );
 
   /*  
   //----------------------


### PR DESCRIPTION
Change the default track projection module to `PHG4GenFitTrackProjection`.
This module project tracks using GenFit Runge-Kutta swimming instead of helix projection.
This module has been tested by @johnlajoie and Sasha.
It is more stable than `PHG4SvtxTrackProjection`