### PR TITLE
Change TPC gas to Ne:CF4 (90:10)

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -151,7 +151,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
   double inner_readout_radius = 30.;
   if (inner_readout_radius<radius)  inner_readout_radius = radius;
 
-  string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4CylinderReco.cc
+  string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4Reco.cc
 
   // Layer of inert TPC gas from 20-30 cm
   if (inner_readout_radius - radius > 0) {

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -151,8 +151,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
   double inner_readout_radius = 30.;
   if (inner_readout_radius<radius)  inner_readout_radius = radius;
 
-  string tpcgas = "G4_Ar";
-  //string tpcgas = "sPHENIX_TPC_Gas";  // leave this change until later - will require some parameter retuning
+  string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4CylinderReco.cc
 
   // Layer of inert TPC gas from 20-30 cm
   if (inner_readout_radius - radius > 0) {


### PR DESCRIPTION
Replaced Argon gas with Ne:CF4 gas. The Ne:CF4 (90:10) gas mixture had already been added by Jin some time ago. Tested, and the results presented in the sims meeting today.