### PR TITLE
Tower Energy Cut and Tower Energy Scale prior to Jet Finder

### DIFF
--- a/macros/g4simulations/G4_Jets.C
+++ b/macros/g4simulations/G4_Jets.C
@@ -22,9 +22,9 @@ void Jet_Reco(int verbosity = 0) {
 
   // tower jets
   JetReco *towerjetreco = new JetReco();
-  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER,0.,1.));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER,0.,1.49));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER,0.,1.49));
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Tower_r02");
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.3),"AntiKt_Tower_r03");
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.4),"AntiKt_Tower_r04");


### PR DESCRIPTION
Tower Energy Cut  (default=0MeV) and Tower Energy Scale (default=1 for CEMC, 1.49 for IHCAL and OHCAL) are added. More study will be followed up, but currently, it is still useful to have constant values. (presentation at Jet Topical Meeting: https://indico.bnl.gov/getFile.py/access?contribId=3&resId=0&materialId=slides&confId=3749) 