### PR TITLE
Increase of TPC time window to match drift speed used in simulation

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -465,7 +465,7 @@ int Fun4All_G4_sPHENIX(
     pileup->AddFile("/sphenix/sim/sim01/sHijing/sHijing_0-12fm.dat");  // HepMC events used in pile up collisions. You can add multiple files, and the file list will be reused.
     //pileup->set_vertex_distribution_width(100e-4,100e-4,30,5);//override collision smear in space time
     //pileup->set_vertex_distribution_mean(0,0,0,0);//override collision central position shift in space time
-    //pileup->set_time_window(-17500.,+17500.); // override timing window in ns
+    pileup->set_time_window(-35000.,+35000.); // override timing window in ns
     //pileup->set_collision_rate(100e3); // override collisions rate in Hz
   }
 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -310,7 +310,7 @@ void Svtx_Cells(int verbosity = 0)
   // set cylinder cell TPC cell sizes
   for (int i=n_maps_layer + n_intt_layer;i<Max_si_layer;++i) {
     svtx_cells->cellsize(i, tpc_cell_x, tpc_cell_y);
-    svtx_cells->set_timing_window(i, -14000.0, +14000.0);
+    svtx_cells->set_timing_window(i, -35000.0, +35000.0);
   }
   
   se->registerSubsystem(svtx_cells);


### PR DESCRIPTION
Change time window setting for PHG4CylinderCellTPCReco and for the pileup input manager to 35 microseconds, to match the drift speed currently used in the simulation.