### PR TITLE
Updated macros for 2-iteration UE determination, subtraction & HI jet reco

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -90,10 +90,10 @@ int Fun4All_G4_sPHENIX(
   bool do_jet_reco = true;
   bool do_jet_eval = do_jet_reco && true;
 
-  // HI Jet Reco for jet simulations in Au+Au (default is false for
-  // single particle / p+p simulations, or for Au+Au simulations which
-  // don't care about jets)
-  bool do_HIjetreco = false && do_jet_reco && do_cemc_twr && do_hcalin_twr && do_hcalout_twr;
+  // HI Jet Reco for p+Au / Au+Au collisions (default is false for
+  // single particle / p+p-only simulations, or for p+Au / Au+Au
+  // simulations which don't particularly care about jets)
+  bool do_HIjetreco = false && do_cemc_twr && do_hcalin_twr && do_hcalout_twr;
 
   bool do_dst_compress = false;
 

--- a/macros/g4simulations/G4_HIJetReco.C
+++ b/macros/g4simulations/G4_HIJetReco.C
@@ -16,11 +16,31 @@ void HIJetReco(int verbosity = 0) {
   rcemc->Verbosity( verbosity );
   se->registerSubsystem( rcemc );
 
+  JetReco *towerjetreco = new JetReco();
+  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER_RETOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER));
+  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Tower_HIRecoSeedsRaw_r02");
+  towerjetreco->set_algo_node("ANTIKT");
+  towerjetreco->set_input_node("TOWER");
+  towerjetreco->Verbosity( verbosity );
+  se->registerSubsystem(towerjetreco);
+
   DetermineTowerBackground *dtb = new DetermineTowerBackground();
   dtb->SetBackgroundOutputName("TowerBackground_Sub1");
-  dtb->SetSeedType( 1 );
+  dtb->SetSeedType( 0 );
   dtb->Verbosity( verbosity );
   se->registerSubsystem( dtb );
+
+  CopyAndSubtractJets *casj = new CopyAndSubtractJets();
+  casj->Verbosity( verbosity );
+  se->registerSubsystem( casj );
+
+  DetermineTowerBackground *dtb2 = new DetermineTowerBackground();
+  dtb2->SetBackgroundOutputName("TowerBackground_Sub2");
+  dtb2->SetSeedType( 1 );
+  dtb2->Verbosity( verbosity );
+  se->registerSubsystem( dtb2 );
   
   SubtractTowers *st = new SubtractTowers();
   st->Verbosity( verbosity );


### PR DESCRIPTION
These changes are in parallel with pull request 395 in the coresoftware repository: https://github.com/sPHENIX-Collaboration/coresoftware/pull/395

Summary: 
* in the main Fun4All module, HI jets no longer need the pp-style tower reco to be run (they now run their own reco using a retowerzized-CEMC before subtraction)
* the HI jet reco module now implements the full "2-iteration" UE removal procedure as described in nucl-ex/1203.1353