### PR TITLE
Switch default clusterizer to the template-based clusterizer

### DIFF
--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -8,6 +8,18 @@ int Max_cemc_layer = 1;
 //   2D azimuthal projective SPACAL (slow)
 int Cemc_spacal_configuration = PHG4CylinderGeom_Spacalv1::k2DProjectiveSpacal;
 
+enum enu_Cemc_clusterizer
+{
+  kCemcGraphClusterizer,
+
+  kCemcTemplateClusterizer
+};
+
+//! template clusterizer, RawClusterBuilderv1, as developed by Sasha Bazilevsky
+enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
+//! graph clusterizer, RawClusterBuilder
+//enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
+
 #include <iostream>
 
 // just a dummy parameter used by the tilted plate geom
@@ -369,10 +381,26 @@ void CEMC_Clusters(int verbosity = 0)
   gSystem->Load("libg4detectors.so");
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  RawClusterBuilder *ClusterBuilder = new RawClusterBuilder("EmcRawClusterBuilder");
-  ClusterBuilder->Detector("CEMC");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem(ClusterBuilder);
+  if (Cemc_clusterizer == kCemcTemplateClusterizer)
+  {
+    RawClusterBuilderv1 *ClusterBuilder = new RawClusterBuilderv1("EmcRawClusterBuilder");
+    ClusterBuilder->Detector("CEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (Cemc_clusterizer == kCemcGraphClusterizer)
+  {
+    RawClusterBuilder *ClusterBuilder = new RawClusterBuilder("EmcRawClusterBuilder");
+    ClusterBuilder->Detector("CEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout <<"CEMC_Clusters - unkonwn clusterizer setting!"<<endl;
+    exit(1);
+  }
+
 
   RawClusterPositionCorrection *clusterCorrection = new RawClusterPositionCorrection("CEMC");
   clusterCorrection->GetCalibrationParameters().ReadFromFile("CEMC_RECALIB","xml",0,0,

--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -397,7 +397,7 @@ void CEMC_Clusters(int verbosity = 0)
   }
   else
   {
-    cout <<"CEMC_Clusters - unkonwn clusterizer setting!"<<endl;
+    cout <<"CEMC_Clusters - unknown clusterizer setting!"<<endl;
     exit(1);
   }
 

--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -383,14 +383,14 @@ void CEMC_Clusters(int verbosity = 0)
 
   if (Cemc_clusterizer == kCemcTemplateClusterizer)
   {
-    RawClusterBuilderv1 *ClusterBuilder = new RawClusterBuilderv1("EmcRawClusterBuilder");
+    RawClusterBuilderv1 *ClusterBuilder = new RawClusterBuilderv1("EmcRawClusterBuilderTemplate");
     ClusterBuilder->Detector("CEMC");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }
   else if (Cemc_clusterizer == kCemcGraphClusterizer)
   {
-    RawClusterBuilder *ClusterBuilder = new RawClusterBuilder("EmcRawClusterBuilder");
+    RawClusterBuilder *ClusterBuilder = new RawClusterBuilder("EmcRawClusterBuilderGraph");
     ClusterBuilder->Detector("CEMC");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -205,7 +205,7 @@ void HCALInner_Clusters(int verbosity = 0) {
   
   if (HCalIn_clusterizer == kHCalInTemplateClusterizer)
   {
-    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalInRawClusterBuilder");
+    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalInRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALIN");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );
@@ -213,7 +213,7 @@ void HCALInner_Clusters(int verbosity = 0) {
   }
   else if (HCalIn_clusterizer == kHCalInGraphClusterizer)
   {
-    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalInRawClusterBuilder");
+    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalInRawClusterBuilderGraph");
     ClusterBuilder->Detector("HCALIN");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -5,6 +5,20 @@
 //true - Choose if you want Aluminum
 const bool inner_hcal_material_Al = false;
 
+
+enum enu_HCalIn_clusterizer
+{
+  kHCalInGraphClusterizer,
+
+  kHCalInTemplateClusterizer
+};
+
+//! template clusterizer, RawClusterBuilderv1, as developed by Sasha Bazilevsky
+enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInTemplateClusterizer;
+//! graph clusterizer, RawClusterBuilder
+//enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInGraphClusterizer;
+
+
 // Init is called by G4Setup.C
 void HCalInnerInit() {}
 
@@ -189,11 +203,27 @@ void HCALInner_Clusters(int verbosity = 0) {
   gSystem->Load("libg4detectors.so");
   Fun4AllServer *se = Fun4AllServer::instance();
   
-  RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalInRawClusterBuilder");
-  ClusterBuilder->Detector("HCALIN");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem( ClusterBuilder );
-  
+  if (HCalIn_clusterizer == kHCalInTemplateClusterizer)
+  {
+    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalInRawClusterBuilder");
+    ClusterBuilder->Detector("HCALIN");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem( ClusterBuilder );
+
+  }
+  else if (HCalIn_clusterizer == kHCalInGraphClusterizer)
+  {
+    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalInRawClusterBuilder");
+    ClusterBuilder->Detector("HCALIN");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem( ClusterBuilder );
+
+  }
+  else
+  {
+    cout <<"HCalIn_Clusters - unknown clusterizer setting!"<<endl;
+    exit(1);
+  }
   return;
 }
 

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -150,14 +150,14 @@ void HCALOuter_Clusters(int verbosity = 0) {
 
   if (HCalOut_clusterizer == kHCalOutTemplateClusterizer)
   {
-    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalOutRawClusterBuilder");
+    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalOutRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALOUT");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );
   }
   else if (HCalOut_clusterizer == kHCalOutGraphClusterizer)
   {
-    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalOutRawClusterBuilder");
+    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalOutRawClusterBuilderGraph");
     ClusterBuilder->Detector("HCALOUT");
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -1,3 +1,17 @@
+
+
+enum enu_HCalOut_clusterizer
+{
+  kHCalOutGraphClusterizer,
+
+  kHCalOutTemplateClusterizer
+};
+
+//! template clusterizer, RawClusterBuilderv1, as developed by Sasha Bazilevsky
+enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutTemplateClusterizer;
+//! graph clusterizer, RawClusterBuilder
+//enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutGraphClusterizer;
+
 // Init is called by G4Setup.C
 void HCalOuterInit(){}
 
@@ -133,10 +147,27 @@ void HCALOuter_Clusters(int verbosity = 0) {
   gSystem->Load("libg4detectors.so");
   Fun4AllServer *se = Fun4AllServer::instance();
   
-  RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalOutRawClusterBuilder");
-  ClusterBuilder->Detector("HCALOUT");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem( ClusterBuilder );
+
+  if (HCalOut_clusterizer == kHCalOutTemplateClusterizer)
+  {
+    RawClusterBuilderv1* ClusterBuilder = new RawClusterBuilderv1("HcalOutRawClusterBuilder");
+    ClusterBuilder->Detector("HCALOUT");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem( ClusterBuilder );
+  }
+  else if (HCalOut_clusterizer == kHCalOutGraphClusterizer)
+  {
+    RawClusterBuilder* ClusterBuilder = new RawClusterBuilder("HcalOutRawClusterBuilder");
+    ClusterBuilder->Detector("HCALOUT");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem( ClusterBuilder );
+  }
+  else
+  {
+    cout <<"HCALOuter_Clusters - unknown clusterizer setting!"<<endl;
+    exit(1);
+  }
+
   
   return;
 }


### PR DESCRIPTION
As discussed in the simulation meeting today, this pull request switch to use the template-based clusterizer, or PHENIX clusterizer by Sasha Bazilevsky, for all three central calorimeter layers. A switch is added to each of the calorimeter macros to allow easy switch between graph and template-based clusterizer for comparisons. 

Tests are welcomed. 

Related developments:
* https://github.com/sPHENIX-Collaboration/coresoftware/pull/377 
* https://github.com/sPHENIX-Collaboration/coresoftware/pull/396
* https://github.com/sPHENIX-Collaboration/coresoftware/pull/397 

Related studies:
* https://indico.bnl.gov/contributionDisplay.py?contribId=2&confId=2724 
* https://indico.bnl.gov/contributionDisplay.py?contribId=1&confId=2723 
* https://indico.bnl.gov/contributionDisplay.py?contribId=1&confId=2721
* https://indico.bnl.gov/contributionDisplay.py?contribId=1&confId=2718