### PR TITLE
Add field return

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -82,6 +82,9 @@ int Fun4All_G4_sPHENIX(
   bool do_hcalout_cluster = do_hcalout_twr && true;
   bool do_hcalout_eval = do_hcalout_cluster && true;
 
+  //! forward flux return plug door. Out of acceptance and off by default.
+  bool do_plugdoor = false;
+
   bool do_global = true;
   bool do_global_fastsim = true;
 
@@ -112,7 +115,7 @@ int Fun4All_G4_sPHENIX(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, n_TPC_layers);
+  G4Init(do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, n_TPC_layers);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
@@ -296,7 +299,7 @@ int Fun4All_G4_sPHENIX(
     //---------------------
 
     G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-            do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, magfield_rescale);
+            do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, magfield_rescale);
   }
 
   //---------

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -67,6 +67,7 @@ int G4Setup(const int absorberactive = 0,
 	    const bool do_magnet = true,
 	    const bool do_hcalout = true,
 	    const bool do_pipe = true,
+//	    const bool do_plugdoor = true,
 	    const float magfield_rescale = 1.0) {
   
   //---------------
@@ -145,6 +146,42 @@ int G4Setup(const int absorberactive = 0,
   // HCALOUT
   
   if (do_hcalout) radius = HCalOuter(g4Reco, radius, 4, absorberactive);
+
+
+
+
+  //----------------------------------------
+  // sPHENIX forward flux return(s)
+  // define via four cornors in the engineering drawing
+  const double z_1  = 330.81;
+  const double z_2  = 360.81;
+  const double r_1  = 30;
+  const double r_2  = 263.5;
+
+  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_plus->set_int_param("lengthviarapidity",0);
+  flux_return_minus->set_double_param("length",360.81 - 330.81);
+  flux_return_minus->set_double_param("radius",30);
+  flux_return_minus->set_double_param("place_z",(330.81 + 360.81)/2.);
+  flux_return_minus->set_double_param("thickness",263.5 - 30);
+  flux_return_plus->set_string_param("material","G4_Fe");
+  flux_return_plus->SetActive(false);
+  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+  flux_return_plus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_plus);
+
+  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
+  flux_return_minus->set_int_param("lengthviarapidity",0);
+  flux_return_minus->set_double_param("length",360.81 - 330.81);
+  flux_return_minus->set_double_param("radius",30);
+  flux_return_minus->set_double_param("place_z",-(330.81 + 360.81)/2.);
+  flux_return_minus->set_double_param("thickness",263.5 - 30);
+  flux_return_minus->set_string_param("material","G4_Fe");
+  flux_return_minus->SetActive(false);
+  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+  flux_return_minus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_minus);
+
 
   //----------------------------------------
   // BLACKHOLE

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -2,14 +2,15 @@
 double no_overlapp = 0.0001; // added to radii to avoid overlapping volumes
 bool overlapcheck = false; // set to true if you want to check for overlaps
 
-void G4Init(bool do_svtx = true,
-	    bool do_pstof = true,
-	    bool do_cemc = true,
-	    bool do_hcalin = true,
-	    bool do_magnet = true,
-	    bool do_hcalout = true,
-	    bool do_pipe = true,
-	    int n_TPC_layers = 40)
+void G4Init(const bool do_svtx = true,
+      const bool do_pstof = true,
+	    const bool do_cemc = true,
+	    const bool do_hcalin = true,
+	    const bool do_magnet = true,
+	    const bool do_hcalout = true,
+	    const bool do_pipe = true,
+      const bool do_plugdoor = false,
+      const int n_TPC_layers = 40)
   {
 
   // load detector/material macros and execute Init() function
@@ -54,6 +55,11 @@ void G4Init(bool do_svtx = true,
       HCalOuterInit();
     }
 
+  if (do_pipe)
+    {
+      gROOT->LoadMacro("G4_PlugDoor.C");
+      PlugDoorInit();
+    }
 }
 
 
@@ -66,7 +72,8 @@ int G4Setup(const int absorberactive = 0,
 	    const bool do_hcalin = true,
 	    const bool do_magnet = true,
 	    const bool do_hcalout = true,
-	    const bool do_pipe = true,
+      const bool do_pipe = true,
+      const bool do_plugdoor = false,
 //	    const bool do_plugdoor = true,
 	    const float magfield_rescale = 1.0) {
   
@@ -147,41 +154,9 @@ int G4Setup(const int absorberactive = 0,
   
   if (do_hcalout) radius = HCalOuter(g4Reco, radius, 4, absorberactive);
 
-
-
-
   //----------------------------------------
-  // sPHENIX forward flux return(s)
-  // define via four cornors in the engineering drawing
-  const double z_1  = 330.81;
-  const double z_2  = 360.81;
-  const double r_1  = 30;
-  const double r_2  = 263.5;
-
-  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
-  flux_return_plus->set_int_param("lengthviarapidity",0);
-  flux_return_plus->set_double_param("length",360.81 - 330.81);
-  flux_return_plus->set_double_param("radius",30);
-  flux_return_plus->set_double_param("place_z",(330.81 + 360.81)/2.);
-  flux_return_plus->set_double_param("thickness",263.5 - 30);
-  flux_return_plus->set_string_param("material","Steel_1006");
-  flux_return_plus->SetActive(false);
-  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
-  flux_return_plus->OverlapCheck(overlapcheck);
-  g4Reco->registerSubsystem(flux_return_plus);
-
-  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
-  flux_return_minus->set_int_param("lengthviarapidity",0);
-  flux_return_minus->set_double_param("length",360.81 - 330.81);
-  flux_return_minus->set_double_param("radius",30);
-  flux_return_minus->set_double_param("place_z",-(330.81 + 360.81)/2.);
-  flux_return_minus->set_double_param("thickness",263.5 - 30);
-  flux_return_minus->set_string_param("material","Steel_1006");
-  flux_return_minus->SetActive(false);
-  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
-  flux_return_minus->OverlapCheck(overlapcheck);
-  g4Reco->registerSubsystem(flux_return_minus);
-
+  // sPHENIX forward flux return door
+  if (do_plugdoor) PlugDoor(g4Reco, absorberactive);
 
   //----------------------------------------
   // BLACKHOLE

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -164,7 +164,7 @@ int G4Setup(const int absorberactive = 0,
   flux_return_plus->set_double_param("radius",30);
   flux_return_plus->set_double_param("place_z",(330.81 + 360.81)/2.);
   flux_return_plus->set_double_param("thickness",263.5 - 30);
-  flux_return_plus->set_string_param("material","G4_Fe");
+  flux_return_plus->set_string_param("material","Steel_1006");
   flux_return_plus->SetActive(false);
   flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
   flux_return_plus->OverlapCheck(overlapcheck);
@@ -176,7 +176,7 @@ int G4Setup(const int absorberactive = 0,
   flux_return_minus->set_double_param("radius",30);
   flux_return_minus->set_double_param("place_z",-(330.81 + 360.81)/2.);
   flux_return_minus->set_double_param("thickness",263.5 - 30);
-  flux_return_minus->set_string_param("material","G4_Fe");
+  flux_return_minus->set_string_param("material","Steel_1006");
   flux_return_minus->SetActive(false);
   flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
   flux_return_minus->OverlapCheck(overlapcheck);

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -160,10 +160,10 @@ int G4Setup(const int absorberactive = 0,
 
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
   flux_return_plus->set_int_param("lengthviarapidity",0);
-  flux_return_minus->set_double_param("length",360.81 - 330.81);
-  flux_return_minus->set_double_param("radius",30);
-  flux_return_minus->set_double_param("place_z",(330.81 + 360.81)/2.);
-  flux_return_minus->set_double_param("thickness",263.5 - 30);
+  flux_return_plus->set_double_param("length",360.81 - 330.81);
+  flux_return_plus->set_double_param("radius",30);
+  flux_return_plus->set_double_param("place_z",(330.81 + 360.81)/2.);
+  flux_return_plus->set_double_param("thickness",263.5 - 30);
   flux_return_plus->set_string_param("material","G4_Fe");
   flux_return_plus->SetActive(false);
   flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");

--- a/macros/g4simulations/G4_PlugDoor.C
+++ b/macros/g4simulations/G4_PlugDoor.C
@@ -1,0 +1,41 @@
+
+void PlugDoorInit() {}
+void PlugDoor(PHG4Reco *g4Reco,
+              const int absorberactive = 0,
+              int verbosity = 0)
+{
+  //----------------------------------------
+  // sPHENIX forward flux return(s)
+  // define via four cornors in the engineering drawing
+  const double z_1 = z_1;
+  const double z_2 = z_2;
+  const double r_1 = r_1;
+  const double r_2 = r_2;
+  const string material("Steel_1006");
+
+  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 0);
+  flux_return_plus->set_int_param("lengthviarapidity", 0);
+  flux_return_plus->set_double_param("length", z_2 - z_1);
+  flux_return_plus->set_double_param("radius", r_1);
+  flux_return_plus->set_double_param("place_z", (z_1 + z_2) / 2.);
+  flux_return_plus->set_double_param("thickness", r_2 - r_1);
+  flux_return_plus->set_string_param("material", material);
+  flux_return_plus->SetActive(absorberactive);
+//  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+  flux_return_plus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_plus);
+
+  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 0);
+  flux_return_minus->set_int_param("lengthviarapidity", 0);
+  flux_return_minus->set_double_param("length", z_2 - z_1);
+  flux_return_minus->set_double_param("radius", r_1);
+  flux_return_minus->set_double_param("place_z", -(z_1 + z_2) / 2.);
+  flux_return_minus->set_double_param("thickness", r_2 - r_1);
+  flux_return_minus->set_string_param("material", material);
+  flux_return_minus->SetActive(absorberactive);
+//  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+  flux_return_minus->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(flux_return_minus);
+
+  return;
+}

--- a/macros/g4simulations/G4_PlugDoor.C
+++ b/macros/g4simulations/G4_PlugDoor.C
@@ -7,11 +7,13 @@ void PlugDoor(PHG4Reco *g4Reco,
   //----------------------------------------
   // sPHENIX forward flux return(s)
   // define via four cornors in the engineering drawing
-  const double z_1 = z_1;
-  const double z_2 = z_2;
-  const double r_1 = r_1;
-  const double r_2 = r_2;
+  const double z_1  = 330.81;
+  const double z_2  = 360.81;
+  const double r_1  = 30;
+  const double r_2  = 263.5;
   const string material("Steel_1006");
+  const int flux_door_active = false;
+
 
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 0);
   flux_return_plus->set_int_param("lengthviarapidity", 0);
@@ -20,7 +22,7 @@ void PlugDoor(PHG4Reco *g4Reco,
   flux_return_plus->set_double_param("place_z", (z_1 + z_2) / 2.);
   flux_return_plus->set_double_param("thickness", r_2 - r_1);
   flux_return_plus->set_string_param("material", material);
-  flux_return_plus->SetActive(absorberactive);
+  flux_return_plus->SetActive(flux_door_active);
 //  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
   flux_return_plus->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(flux_return_plus);
@@ -32,7 +34,7 @@ void PlugDoor(PHG4Reco *g4Reco,
   flux_return_minus->set_double_param("place_z", -(z_1 + z_2) / 2.);
   flux_return_minus->set_double_param("thickness", r_2 - r_1);
   flux_return_minus->set_string_param("material", material);
-  flux_return_minus->SetActive(absorberactive);
+  flux_return_minus->SetActive(flux_door_active);
 //  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
   flux_return_minus->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(flux_return_minus);


### PR DESCRIPTION
Jamie reminded that the flux return plug door of sPHENIX is not implemented in the default sPHENIX simulation (a thinned version is in fsPHENIX and ePHENIX simulation). Although flux return is outside the active acceptance of sPHENIX, recent tracking study does cautious us against albedo background originated from back scattering of heavy materials outside the tracking volume. 

This pull request introduce the plug door to the default sPHENIX simulation. Here is two detector display. The geometry of the plug door come from a preliminary engineering drawing which is about 30 cm thick. 

In engineering drawing:
![image](https://user-images.githubusercontent.com/7947083/35292006-297d82b4-003d-11e8-8544-a8c924e642a9.png)

In simulation:
![image](https://user-images.githubusercontent.com/7947083/35291472-6592416a-003b-11e8-835e-b2005b92dc47.png)
![image](https://user-images.githubusercontent.com/7947083/35291479-69f302e4-003b-11e8-8559-6c4fdef8885d.png)

Checking its effect on TPC tracking background. Since the plug door is far away from the TPC, the change in TPC clsuter multiplicity is minimal. Identical generated collisions and vertex location are used in these comparison, while the Geant4 cycles are independently randomized, which lead to some fluctuation in the difference. 

![image](https://user-images.githubusercontent.com/7947083/35291525-84fd5e7c-003b-11e8-944a-58c2162cc201.png)

Although the change in background is small, still introduce the plug door as an option of the simulation for completeness. The pair of doors are OFF by default, since they does not change tracker backgroudn much and it prolongs the Geant4 simulation by 60% of CPU usage on hadronic showers inside the plug door. 
