### PR TITLE
Tracking macro updates

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -7,8 +7,6 @@ int Fun4All_G4_sPHENIX(
     const char *outputFile = "G4sPHENIX.root",
     const char *embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list")
 {
-  // Set the number of TPC layer
-  const int n_TPC_layers = 40;  // use 60 for backward compatibility only
 
   //===============
   // Input options
@@ -115,7 +113,7 @@ int Fun4All_G4_sPHENIX(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, n_TPC_layers);
+  G4Init(do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -9,8 +9,8 @@ void G4Init(const bool do_svtx = true,
 	    const bool do_magnet = true,
 	    const bool do_hcalout = true,
 	    const bool do_pipe = true,
-      const bool do_plugdoor = false,
-      const int n_TPC_layers = 40)
+	    const bool do_plugdoor = false
+	    )
   {
 
   // load detector/material macros and execute Init() function
@@ -23,7 +23,7 @@ void G4Init(const bool do_svtx = true,
   if (do_svtx)
     {
       gROOT->LoadMacro("G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C"); 
-      SvtxInit(n_TPC_layers);
+      SvtxInit();
     }
 
   if (do_pstof) 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -292,7 +292,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     radius = intt_radius_max * 0.1;
   }
 
-  int verbosity = 1;
+//  int verbosity = 1;
 
   // time projection chamber layers --------------------------------------------
 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -1,5 +1,8 @@
 #include <vector>
 
+// ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
+bool tpc_layers_40  = false;
+
 // if true, refit tracks with primary vertex included in track fit  - good for analysis of prompt tracks only
 // Adds second node to node tree, keeps original track node undisturbed
 // Adds second evaluator to process refitted tracks and outputs separate ntuples
@@ -289,7 +292,18 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     radius = intt_radius_max * 0.1;
   }
 
+  int verbosity = 1;
+
   // time projection chamber layers --------------------------------------------
+
+  // switch ONLY for backward compatibility with 40 layer hits files!
+  if (tpc_layers_40)
+    {
+      n_tpc_layer_inner = 8;
+      tpc_layer_thick_inner = 1.25;
+      tpc_layer_rphi_count_inner = 1152;
+      cout << "Using 8 inner_layers for backward comatibility" << endl;
+    }
 
   PHG4CylinderSubsystem* cyl;
 


### PR DESCRIPTION
Update of the tracking macros to set up the TPC configuration we plan to build, i.e. 16 inner layers, 16 mid layers, 16 outer layers.
Removed obsolete lines allowing backward compatibility with ancient 60 layer hits files.

Added a switch at the top of tracking macro to allow backward compatibility with 40 layer hits files.

The configuration of the readout here is what will be used with zigzag pads. However the macro is backward compatible with the existing rectangular pad cell reco code. In the new cell reco code (PR#417) zigzag pads are used by default, so nothing has to be set in the tracking macro.