### PR TITLE
Shashlik CEMC for sPHENIX-EIC Configuration

### DIFF
--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -40,7 +40,7 @@ void G4Init(bool do_svtx = true,
 
   if (do_cemc)
     {
-      gROOT->LoadMacro("G4_CEmc_Spacal.C");
+      gROOT->LoadMacro("G4_CEmc_EIC.C");
       CEmcInit(72); // make it 2*2*2*3*3 so we can try other combinations
     }
 

--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -1,0 +1,291 @@
+
+double cemcdepth = 9; 
+//tungs to scint width ratio must be ~10:1 
+//for approx 2% sampling fraction
+
+//18 radiation lengths
+double scint_width = 0.049;
+double tungs_width = 0.49;
+
+//fits in 95-104cm but only 15 X_0
+//double scint_width = 0.041;
+//double tungs_width = 0.41;
+
+
+int min_cemc_layer = 1;
+int max_cemc_layer = 21;
+
+double topradius = 104; //cm
+double bottomradius = 95; //cm
+double negrapidity = -1.4;
+double posrapidity = 1.1;
+//this is default set to -1.4<eta<1.1
+//if the user changes these, the z position of the 
+//calorimeter must be changed in the function CEmc 
+
+enum enu_Cemc_clusterizer
+{
+  kCemcGraphClusterizer,
+
+  kCemcTemplateClusterizer
+};
+
+
+//! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
+//! graph clusterizer, RawClusterBuilderGraph
+//enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
+
+
+void CEmcInit(const int nslats = 1)
+{
+ 
+}
+
+
+double CEmc(PHG4Reco *g4Reco, double radius, const int crossings,
+	    const int absorberactive = 0)
+{
+ 
+  if(radius > 95)
+    {
+      cout << "inconsistency, radius: "<<radius 
+	   <<" larger than allowed inner radius for CEMC = 95 cm"<<endl;
+      gSystem->Exit(-1);
+    }
+  
+  radius = 95;
+
+
+
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4testbench.so");
+
+  
+  PHG4CylinderSubsystem *cemc;
+
+  
+
+  //determine the length of the calorimeter
+  //can adjust length coverage by just adjusting these values
+  //rapidity coverage will be determined by z shift of EMCAl
+  //as indicated in the loop below
+ 
+
+  //eta = -ln(tan(theta/2))
+  double theta1 = 2.*TMath::ATan(TMath::Exp(-1 * posrapidity));
+  double theta2 = 2. * TMath::ATan( TMath::Exp(-1 * negrapidity));
+  //get the angle between the beam pipe and negative pseudorapidity axis
+  theta2 = TMath::Pi() - theta2; 
+
+  double z1 = topradius / TMath::Tan(theta1);
+  double z2 = topradius / TMath::Tan(theta2);
+
+  double z3 = bottomradius / TMath::Tan(theta1);
+  double z4 = bottomradius / TMath::Tan(theta2);
+
+  //this is the top layer length
+  double totaltoplength = z1 + z2;
+  //this is the bottom layer length
+  double totalbottomlength = z3 + z4;
+  
+  double height = 0;
+  for(int thislayer = min_cemc_layer; 
+      thislayer <= max_cemc_layer; 
+      thislayer++)
+    {
+    
+      //the length for a particular layer is determined from the bottom length
+      double thislength = totalbottomlength 
+	+ height / TMath::Tan(theta1) 
+	+ height / TMath::Tan(theta2);
+    
+     
+      cemc = new PHG4CylinderSubsystem("ABSORBER_CEMC", thislayer);
+      cemc->set_double_param("radius",radius);
+      cemc->set_string_param("material","Spacal_W_Epoxy");
+      cemc->set_double_param("thickness", tungs_width);
+      cemc->set_double_param("length",thislength); 
+      cemc->set_int_param("lengthviarapidity",0);
+      
+      //starts centered around IP
+      //shift backwards 30 cm for total 340 cm length to cover -1.4<eta<1.1
+      cemc->set_double_param("place_z",-30); 
+      cemc->SuperDetector("ABSORBER_CEMC");
+      if(absorberactive)
+	cemc->SetActive();
+      bool ov1 = cemc->OverlapCheck(overlapcheck);
+      if(ov1)
+	cout<<"THERE IS AN OVERLAP IN THE SHASHLIK EMC:SPACAL_W_EPOXY"<<endl;
+      g4Reco->registerSubsystem(cemc);
+      
+      radius += tungs_width;
+      radius += no_overlapp;
+      
+      height += tungs_width;
+      
+      cemc = new PHG4CylinderSubsystem("CEMC", thislayer);
+      cemc->set_double_param("radius",radius);
+      cemc->set_string_param("material","PMMA");
+      cemc->set_double_param("thickness", scint_width);
+      cemc->set_int_param("lightyield", 1);
+      cemc->set_int_param("lengthviarapidity",0);
+      cemc->set_double_param("length",thislength);
+
+      //shift back -30 cm to cover -1.4<eta<1.1
+      cemc->set_double_param("place_z",-30);
+      cemc->SuperDetector("CEMC");
+     
+      cemc->SetActive();
+      bool ov2 = cemc->OverlapCheck(overlapcheck);
+
+      if(ov2)
+	cout<<"THERE IS AN OVERLAP IN THE SHASHLIK EMC:PMMA"<<endl;
+
+      g4Reco->registerSubsystem(cemc);
+      
+      radius += scint_width;
+      radius += no_overlapp;
+      
+      height += scint_width;
+      
+
+    }
+
+
+
+  PHG4CylinderSubsystem *cemc_cyl = new PHG4CylinderSubsystem("CEMC_ELECTRONICS",0);
+  cemc_cyl->set_double_param("radius",radius);
+  cemc_cyl->set_string_param("material","G4_TEFLON");
+  cemc_cyl->set_double_param("thickness",0.5);
+  
+  double l1 = (radius + 0.5) / TMath::Tan(theta1);
+  double l2 = (radius + 0.5) / TMath::Tan(theta2);
+  cemc_cyl->set_int_param("lengthviarapidity",0);
+  cemc_cyl->set_double_param("length",l1 + l2); 
+  //shift back -30 cm to cover -1.4<eta<1.1
+  cemc_cyl->set_double_param("place_z",-30);
+  if(absorberactive)
+    cemc_cyl->SetActive();
+  cemc_cyl->OverlapCheck(overlapcheck);
+  g4Reco->registerSubsystem(cemc_cyl);
+  
+
+
+
+
+}
+
+
+
+
+void CEMC_Cells(int verbosity = 0)
+{
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4detectors.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+  
+  PHG4CylinderCellReco *cemc_cells = new PHG4CylinderCellReco("CEMCCYLCELLRECO");
+  cemc_cells->Detector("CEMC");
+  cemc_cells->Verbosity(verbosity);
+  double radius = 95;
+  for(int i = min_cemc_layer; i <= max_cemc_layer; i++)
+    {
+      cemc_cells->cellsize(i, 2. * TMath::Pi() / 256. * radius,
+			     2. * TMath::Pi() / 256. * radius);
+      radius += (scint_width + tungs_width);
+    }
+  se->registerSubsystem(cemc_cells);
+  
+  return;
+
+}
+
+
+
+void CEMC_Towers(int verbosity = 0)
+{
+  gSystem->Load("libg4calo.so");
+  gSystem->Load("libcalo_reco.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  
+  RawTowerBuilder *CemcTowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
+  CemcTowerBuilder->Detector("CEMC");
+  CemcTowerBuilder->set_sim_tower_node_prefix("SIM");
+  CemcTowerBuilder->Verbosity(verbosity);
+  se->registerSubsystem(CemcTowerBuilder);
+  
+  const double photoelectron_per_GeV = 500;  //500 photon per total GeV deposition
+  //just set a 2% sampling fraction - already tuned by tungs/scint width ratio
+  double sampling_fraction = 2e-02; 
+  RawTowerDigitizer *CemcTowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
+  CemcTowerDigitizer->Detector("CEMC");
+  CemcTowerDigitizer->Verbosity(verbosity);
+  CemcTowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
+  CemcTowerDigitizer->set_pedstal_central_ADC(0);
+  CemcTowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  CemcTowerDigitizer->set_photonelec_ADC(1);     //not simulating ADC discretization error
+  CemcTowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
+  CemcTowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  se->registerSubsystem(CemcTowerDigitizer);
+  
+  
+  RawTowerCalibration *CemcTowerCalibration = new RawTowerCalibration("EmcRawTowerCalibration");
+  CemcTowerCalibration->Detector("CEMC");
+  CemcTowerCalibration->Verbosity(verbosity);
+  CemcTowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV/0.9715);
+  CemcTowerCalibration->set_pedstal_ADC(0);
+  
+  se->registerSubsystem(CemcTowerCalibration);
+  
+
+  return;
+}
+
+
+
+void CEMC_Clusters(int verbosity = 0)
+{
+
+
+  gSystem->Load("libcalo_reco.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+ 
+  if (Cemc_clusterizer == kCemcTemplateClusterizer)
+    {
+      RawClusterBuilderTemplate *cemc_clusterbuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
+      cemc_clusterbuilder->Detector("CEMC");
+      cemc_clusterbuilder->Verbosity(verbosity);
+      
+      se->registerSubsystem(cemc_clusterbuilder);
+    }
+  else if (Cemc_clusterizer == kCemcGraphClusterizer)
+    {
+      RawClusterBuilderGraph *cemc_clusterbuilder = new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
+      cemc_clusterbuilder->Detector("CEMC");
+      cemc_clusterbuilder->Verbosity(verbosity);
+      
+      se->registerSubsystem(cemc_clusterbuilder);
+    }
+  else
+    {
+      cout<<"CEMC_Clusters - unknown clusterizer setting!! "<<endl;
+      exit(1);
+
+    }
+  return;
+}
+void CEMC_Eval(std::string outputfile, int verbosity = 0)
+{
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4eval.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  CaloEvaluator *eval = new CaloEvaluator("CEMCEVALUATOR", "CEMC", outputfile.c_str());
+  eval->Verbosity(verbosity);
+  se->registerSubsystem(eval);
+
+  return;
+}

--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -1,27 +1,24 @@
 
 double cemcdepth = 9; 
-//tungs to scint width ratio must be ~10:1 
-//for approx 2% sampling fraction
+//tungs to scint width ratio of ~10:1 
+//corresponds to approx 2% sampling fraction
 
-//18 radiation lengths
-double scint_width = 0.049;
-double tungs_width = 0.49;
+//18 radiation lengths for 40 layers
+double scint_width = 0.05;
+double tungs_width = 0.245;
 
-//fits in 95-104cm but only 15 X_0
-//double scint_width = 0.041;
-//double tungs_width = 0.41;
 
 
 int min_cemc_layer = 1;
-int max_cemc_layer = 21;
+int max_cemc_layer = 41;
 
-double topradius = 104; //cm
+double topradius = 106.8; //cm
 double bottomradius = 95; //cm
 double negrapidity = -1.4;
 double posrapidity = 1.1;
 //this is default set to -1.4<eta<1.1
 //if the user changes these, the z position of the 
-//calorimeter must be changed in the function CEmc 
+//calorimeter must be changed in the function CEmc(...)
 
 enum enu_Cemc_clusterizer
 {
@@ -114,9 +111,8 @@ double CEmc(PHG4Reco *g4Reco, double radius, const int crossings,
       cemc->SuperDetector("ABSORBER_CEMC");
       if(absorberactive)
 	cemc->SetActive();
-      bool ov1 = cemc->OverlapCheck(overlapcheck);
-      if(ov1)
-	cout<<"THERE IS AN OVERLAP IN THE SHASHLIK EMC:SPACAL_W_EPOXY"<<endl;
+      cemc->OverlapCheck(overlapcheck);
+    
       g4Reco->registerSubsystem(cemc);
       
       radius += tungs_width;
@@ -137,11 +133,7 @@ double CEmc(PHG4Reco *g4Reco, double radius, const int crossings,
       cemc->SuperDetector("CEMC");
      
       cemc->SetActive();
-      bool ov2 = cemc->OverlapCheck(overlapcheck);
-
-      if(ov2)
-	cout<<"THERE IS AN OVERLAP IN THE SHASHLIK EMC:PMMA"<<endl;
-
+      cemc->OverlapCheck(overlapcheck);
       g4Reco->registerSubsystem(cemc);
       
       radius += scint_width;
@@ -217,8 +209,8 @@ void CEMC_Towers(int verbosity = 0)
   se->registerSubsystem(CemcTowerBuilder);
   
   const double photoelectron_per_GeV = 500;  //500 photon per total GeV deposition
-  //just set a 2% sampling fraction - already tuned by tungs/scint width ratio
-  double sampling_fraction = 2e-02; 
+  //just set a 4% sampling fraction - already tuned by tungs/scint width ratio
+  double sampling_fraction = 4e-02; 
   RawTowerDigitizer *CemcTowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
   CemcTowerDigitizer->Detector("CEMC");
   CemcTowerDigitizer->Verbosity(verbosity);

--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -1,79 +1,63 @@
 
-double cemcdepth = 9; 
-//tungs to scint width ratio of ~10:1 
-//corresponds to approx 2% sampling fraction
+double cemcdepth = 9;
+// tungs to scint width ratio of ~10:1
+// corresponds to approx 2% sampling fraction
 
-//18 radiation lengths for 40 layers
+// 18 radiation lengths for 40 layers
 double scint_width = 0.05;
 double tungs_width = 0.245;
-
-
 
 int min_cemc_layer = 1;
 int max_cemc_layer = 41;
 
-double topradius = 106.8; //cm
-double bottomradius = 95; //cm
+double topradius = 106.8; // cm
+double bottomradius = 95; // cm
 double negrapidity = -1.4;
 double posrapidity = 1.1;
-//this is default set to -1.4<eta<1.1
-//if the user changes these, the z position of the 
-//calorimeter must be changed in the function CEmc(...)
+// this is default set to -1.4<eta<1.1
+// if the user changes these, the z position of the
+// calorimeter must be changed in the function CEmc(...)
 
-enum enu_Cemc_clusterizer
-{
+enum enu_Cemc_clusterizer {
   kCemcGraphClusterizer,
 
   kCemcTemplateClusterizer
 };
 
-
-//! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
+//! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha
+//! Bazilevsky
 enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
 //! graph clusterizer, RawClusterBuilderGraph
-//enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
+// enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
 
-
-void CEmcInit(const int nslats = 1)
-{
- 
-}
-
+void CEmcInit(const int nslats = 1) {}
 
 double CEmc(PHG4Reco *g4Reco, double radius, const int crossings,
-	    const int absorberactive = 0)
-{
- 
-  if(radius > 95)
-    {
-      cout << "inconsistency, radius: "<<radius 
-	   <<" larger than allowed inner radius for CEMC = 95 cm"<<endl;
-      gSystem->Exit(-1);
-    }
-  
+            const int absorberactive = 0) {
+
+  if (radius > 95) {
+    cout << "inconsistency, radius: " << radius
+         << " larger than allowed inner radius for CEMC = 95 cm" << endl;
+    gSystem->Exit(-1);
+  }
+
   radius = 95;
-
-
 
   gSystem->Load("libg4detectors.so");
   gSystem->Load("libg4testbench.so");
 
-  
   PHG4CylinderSubsystem *cemc;
 
-  
+  // determine the length of the calorimeter
+  // can adjust length coverage by just adjusting these values
+  // rapidity coverage will be determined by z shift of EMCAl
+  // as indicated in the loop below
 
-  //determine the length of the calorimeter
-  //can adjust length coverage by just adjusting these values
-  //rapidity coverage will be determined by z shift of EMCAl
-  //as indicated in the loop below
- 
-
-  //eta = -ln(tan(theta/2))
-  double theta1 = 2.*TMath::ATan(TMath::Exp(-1 * posrapidity));
-  double theta2 = 2. * TMath::ATan( TMath::Exp(-1 * negrapidity));
-  //get the angle between the beam pipe and negative pseudorapidity axis
-  theta2 = TMath::Pi() - theta2; 
+  // eta = -ln(tan(theta/2))
+  double theta1 = 2. * TMath::ATan(TMath::Exp(-1 * posrapidity));
+  double theta2 = 2. * TMath::ATan(TMath::Exp(-1 * negrapidity));
+  // get the angle between the beam pipe and negative pseudorapidity axis
+  theta2 = TMath::Pi() - theta2;
 
   double z1 = topradius / TMath::Tan(theta1);
   double z2 = topradius / TMath::Tan(theta2);
@@ -81,201 +65,178 @@ double CEmc(PHG4Reco *g4Reco, double radius, const int crossings,
   double z3 = bottomradius / TMath::Tan(theta1);
   double z4 = bottomradius / TMath::Tan(theta2);
 
-  //this is the top layer length
+  // this is the top layer length
   double totaltoplength = z1 + z2;
-  //this is the bottom layer length
+  // this is the bottom layer length
   double totalbottomlength = z3 + z4;
-  
+
   double height = 0;
-  for(int thislayer = min_cemc_layer; 
-      thislayer <= max_cemc_layer; 
-      thislayer++)
-    {
-    
-      //the length for a particular layer is determined from the bottom length
-      double thislength = totalbottomlength 
-	+ height / TMath::Tan(theta1) 
-	+ height / TMath::Tan(theta2);
-    
-     
-      cemc = new PHG4CylinderSubsystem("ABSORBER_CEMC", thislayer);
-      cemc->set_double_param("radius",radius);
-      cemc->set_string_param("material","Spacal_W_Epoxy");
-      cemc->set_double_param("thickness", tungs_width);
-      cemc->set_double_param("length",thislength); 
-      cemc->set_int_param("lengthviarapidity",0);
-      
-      //starts centered around IP
-      //shift backwards 30 cm for total 340 cm length to cover -1.4<eta<1.1
-      cemc->set_double_param("place_z",-30); 
-      cemc->SuperDetector("ABSORBER_CEMC");
-      if(absorberactive)
-	cemc->SetActive();
-      cemc->OverlapCheck(overlapcheck);
-    
-      g4Reco->registerSubsystem(cemc);
-      
-      radius += tungs_width;
-      radius += no_overlapp;
-      
-      height += tungs_width;
-      
-      cemc = new PHG4CylinderSubsystem("CEMC", thislayer);
-      cemc->set_double_param("radius",radius);
-      cemc->set_string_param("material","PMMA");
-      cemc->set_double_param("thickness", scint_width);
-      cemc->set_int_param("lightyield", 1);
-      cemc->set_int_param("lengthviarapidity",0);
-      cemc->set_double_param("length",thislength);
+  for (int thislayer = min_cemc_layer; thislayer <= max_cemc_layer;
+       thislayer++) {
 
-      //shift back -30 cm to cover -1.4<eta<1.1
-      cemc->set_double_param("place_z",-30);
-      cemc->SuperDetector("CEMC");
-     
+    // the length for a particular layer is determined from the bottom length
+    double thislength = totalbottomlength + height / TMath::Tan(theta1) +
+                        height / TMath::Tan(theta2);
+
+    cemc = new PHG4CylinderSubsystem("ABSORBER_CEMC", thislayer);
+    cemc->set_double_param("radius", radius);
+    cemc->set_string_param("material", "Spacal_W_Epoxy");
+    cemc->set_double_param("thickness", tungs_width);
+    cemc->set_double_param("length", thislength);
+    cemc->set_int_param("lengthviarapidity", 0);
+
+    // starts centered around IP
+    // shift backwards 30 cm for total 340 cm length to cover -1.4<eta<1.1
+    cemc->set_double_param("place_z", -30);
+    cemc->SuperDetector("ABSORBER_CEMC");
+    if (absorberactive)
       cemc->SetActive();
-      cemc->OverlapCheck(overlapcheck);
-      g4Reco->registerSubsystem(cemc);
-      
-      radius += scint_width;
-      radius += no_overlapp;
-      
-      height += scint_width;
-      
+    cemc->OverlapCheck(overlapcheck);
 
-    }
+    g4Reco->registerSubsystem(cemc);
 
+    radius += tungs_width;
+    radius += no_overlapp;
 
+    height += tungs_width;
 
-  PHG4CylinderSubsystem *cemc_cyl = new PHG4CylinderSubsystem("CEMC_ELECTRONICS",0);
-  cemc_cyl->set_double_param("radius",radius);
-  cemc_cyl->set_string_param("material","G4_TEFLON");
-  cemc_cyl->set_double_param("thickness",0.5);
-  
+    cemc = new PHG4CylinderSubsystem("CEMC", thislayer);
+    cemc->set_double_param("radius", radius);
+    cemc->set_string_param("material", "PMMA");
+    cemc->set_double_param("thickness", scint_width);
+    cemc->set_int_param("lightyield", 1);
+    cemc->set_int_param("lengthviarapidity", 0);
+    cemc->set_double_param("length", thislength);
+
+    // shift back -30 cm to cover -1.4<eta<1.1
+    cemc->set_double_param("place_z", -30);
+    cemc->SuperDetector("CEMC");
+
+    cemc->SetActive();
+    cemc->OverlapCheck(overlapcheck);
+    g4Reco->registerSubsystem(cemc);
+
+    radius += scint_width;
+    radius += no_overlapp;
+
+    height += scint_width;
+  }
+
+  PHG4CylinderSubsystem *cemc_cyl =
+      new PHG4CylinderSubsystem("CEMC_ELECTRONICS", 0);
+  cemc_cyl->set_double_param("radius", radius);
+  cemc_cyl->set_string_param("material", "G4_TEFLON");
+  cemc_cyl->set_double_param("thickness", 0.5);
+
   double l1 = (radius + 0.5) / TMath::Tan(theta1);
   double l2 = (radius + 0.5) / TMath::Tan(theta2);
-  cemc_cyl->set_int_param("lengthviarapidity",0);
-  cemc_cyl->set_double_param("length",l1 + l2); 
-  //shift back -30 cm to cover -1.4<eta<1.1
-  cemc_cyl->set_double_param("place_z",-30);
-  if(absorberactive)
+  cemc_cyl->set_int_param("lengthviarapidity", 0);
+  cemc_cyl->set_double_param("length", l1 + l2);
+  // shift back -30 cm to cover -1.4<eta<1.1
+  cemc_cyl->set_double_param("place_z", -30);
+  if (absorberactive)
     cemc_cyl->SetActive();
   cemc_cyl->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(cemc_cyl);
-  
-
-
-
-
 }
 
-
-
-
-void CEMC_Cells(int verbosity = 0)
-{
+void CEMC_Cells(int verbosity = 0) {
   gSystem->Load("libfun4all.so");
   gSystem->Load("libg4detectors.so");
   Fun4AllServer *se = Fun4AllServer::instance();
-  
-  PHG4CylinderCellReco *cemc_cells = new PHG4CylinderCellReco("CEMCCYLCELLRECO");
+
+  PHG4CylinderCellReco *cemc_cells =
+      new PHG4CylinderCellReco("CEMCCYLCELLRECO");
   cemc_cells->Detector("CEMC");
   cemc_cells->Verbosity(verbosity);
   double radius = 95;
-  for(int i = min_cemc_layer; i <= max_cemc_layer; i++)
-    {
-      cemc_cells->cellsize(i, 2. * TMath::Pi() / 256. * radius,
-			     2. * TMath::Pi() / 256. * radius);
-      radius += (scint_width + tungs_width);
-    }
+  for (int i = min_cemc_layer; i <= max_cemc_layer; i++) {
+    cemc_cells->cellsize(i, 2. * TMath::Pi() / 256. * radius,
+                         2. * TMath::Pi() / 256. * radius);
+    radius += (scint_width + tungs_width);
+  }
   se->registerSubsystem(cemc_cells);
-  
-  return;
 
+  return;
 }
 
-
-
-void CEMC_Towers(int verbosity = 0)
-{
+void CEMC_Towers(int verbosity = 0) {
   gSystem->Load("libg4calo.so");
   gSystem->Load("libcalo_reco.so");
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  
   RawTowerBuilder *CemcTowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
   CemcTowerBuilder->Detector("CEMC");
   CemcTowerBuilder->set_sim_tower_node_prefix("SIM");
   CemcTowerBuilder->Verbosity(verbosity);
   se->registerSubsystem(CemcTowerBuilder);
-  
-  const double photoelectron_per_GeV = 500;  //500 photon per total GeV deposition
-  //just set a 4% sampling fraction - already tuned by tungs/scint width ratio
-  double sampling_fraction = 4e-02; 
-  RawTowerDigitizer *CemcTowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
+
+  const double photoelectron_per_GeV =
+      500; // 500 photon per total GeV deposition
+  // just set a 4% sampling fraction - already tuned by tungs/scint width ratio
+  double sampling_fraction = 4e-02;
+  RawTowerDigitizer *CemcTowerDigitizer =
+      new RawTowerDigitizer("EmcRawTowerDigitizer");
   CemcTowerDigitizer->Detector("CEMC");
   CemcTowerDigitizer->Verbosity(verbosity);
-  CemcTowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
+  CemcTowerDigitizer->set_digi_algorithm(
+      RawTowerDigitizer::kSimple_photon_digitization);
   CemcTowerDigitizer->set_pedstal_central_ADC(0);
-  CemcTowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
-  CemcTowerDigitizer->set_photonelec_ADC(1);     //not simulating ADC discretization error
-  CemcTowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
-  CemcTowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  CemcTowerDigitizer->set_pedstal_width_ADC(8); // eRD1 test beam setting
+  CemcTowerDigitizer->set_photonelec_ADC(
+      1); // not simulating ADC discretization error
+  CemcTowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV /
+                                                       sampling_fraction);
+  CemcTowerDigitizer->set_zero_suppression_ADC(16); // eRD1 test beam setting
   se->registerSubsystem(CemcTowerDigitizer);
-  
-  
-  RawTowerCalibration *CemcTowerCalibration = new RawTowerCalibration("EmcRawTowerCalibration");
+
+  RawTowerCalibration *CemcTowerCalibration =
+      new RawTowerCalibration("EmcRawTowerCalibration");
   CemcTowerCalibration->Detector("CEMC");
   CemcTowerCalibration->Verbosity(verbosity);
-  CemcTowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV/0.9715);
+  CemcTowerCalibration->set_calib_algorithm(
+      RawTowerCalibration::kSimple_linear_calibration);
+  CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV /
+                                                0.9715);
   CemcTowerCalibration->set_pedstal_ADC(0);
-  
+
   se->registerSubsystem(CemcTowerCalibration);
-  
 
   return;
 }
 
-
-
-void CEMC_Clusters(int verbosity = 0)
-{
-
+void CEMC_Clusters(int verbosity = 0) {
 
   gSystem->Load("libcalo_reco.so");
   Fun4AllServer *se = Fun4AllServer::instance();
- 
-  if (Cemc_clusterizer == kCemcTemplateClusterizer)
-    {
-      RawClusterBuilderTemplate *cemc_clusterbuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
-      cemc_clusterbuilder->Detector("CEMC");
-      cemc_clusterbuilder->Verbosity(verbosity);
-      
-      se->registerSubsystem(cemc_clusterbuilder);
-    }
-  else if (Cemc_clusterizer == kCemcGraphClusterizer)
-    {
-      RawClusterBuilderGraph *cemc_clusterbuilder = new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
-      cemc_clusterbuilder->Detector("CEMC");
-      cemc_clusterbuilder->Verbosity(verbosity);
-      
-      se->registerSubsystem(cemc_clusterbuilder);
-    }
-  else
-    {
-      cout<<"CEMC_Clusters - unknown clusterizer setting!! "<<endl;
-      exit(1);
 
-    }
+  if (Cemc_clusterizer == kCemcTemplateClusterizer) {
+    RawClusterBuilderTemplate *cemc_clusterbuilder =
+        new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
+    cemc_clusterbuilder->Detector("CEMC");
+    cemc_clusterbuilder->Verbosity(verbosity);
+
+    se->registerSubsystem(cemc_clusterbuilder);
+  } else if (Cemc_clusterizer == kCemcGraphClusterizer) {
+    RawClusterBuilderGraph *cemc_clusterbuilder =
+        new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
+    cemc_clusterbuilder->Detector("CEMC");
+    cemc_clusterbuilder->Verbosity(verbosity);
+
+    se->registerSubsystem(cemc_clusterbuilder);
+  } else {
+    cout << "CEMC_Clusters - unknown clusterizer setting!! " << endl;
+    exit(1);
+  }
   return;
 }
-void CEMC_Eval(std::string outputfile, int verbosity = 0)
-{
+void CEMC_Eval(std::string outputfile, int verbosity = 0) {
   gSystem->Load("libfun4all.so");
   gSystem->Load("libg4eval.so");
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  CaloEvaluator *eval = new CaloEvaluator("CEMCEVALUATOR", "CEMC", outputfile.c_str());
+  CaloEvaluator *eval =
+      new CaloEvaluator("CEMCEVALUATOR", "CEMC", outputfile.c_str());
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 


### PR DESCRIPTION
This PR introduces a shashlik sampling CEMC as an option to replace the default SPACAL CEMC (the actual sPHENIX CEMC). The PR is intended to extend the coverage of the CEMC from -1.1<eta<1.1 (default SPACAL) to -1.4<eta<1.1 to reduce the gap of EMCal coverage in the electron going direction. The calorimeter is composed of 40 layers of alternating SPACAL tungsten-epoxy and PMMA as the scintillator for light collection. 

Here is a picture of the calorimeter by itself:
![shashlik_alone](https://user-images.githubusercontent.com/19910548/41549457-e5cc924c-72f3-11e8-8a29-181c41598fb1.png)

and with the entire sPHENIX-EIC design:

![fulldetector](https://user-images.githubusercontent.com/19910548/41549482-f86b57b2-72f3-11e8-80db-88ede68fd46e.png)

The sampling fraction was tuned to be 4% to better demonstrate the stochastic term in the resolution. The resolution of this new sampling EMCal in simulation alone is shown here:

![shashlik_resolution](https://user-images.githubusercontent.com/19910548/41549734-c8e3f23c-72f4-11e8-8b8f-b5ef0f3cf1a7.png)


