### PR TITLE
adding support for fast tracking EIC using different detector responses at forward+central stations

### DIFF
--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -23,6 +23,8 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 {
 
   gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4calo.so");
+  gSystem->Load("libcalo_reco.so");
 
   Fun4AllServer *se = Fun4AllServer::instance();
 

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -69,7 +69,7 @@ void Tracking_Reco(int verbosity = 0)
 		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
 		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
 		    PHG4TrackFastSim::Vertical_Plane };
-  float rad[] = {1e4,  1e4,  100,  100,  100,  100,  100,  100,  100,  100,  100};
+  float rad[] = {5.0,  100,  100,  100,  100,  100,  100,  100,  100,  100,  100};
   float phi[] = {5.0,  150,  100,  100,  100,  100,  100,  100,  100,  100,  100};
   float lon[] = {5.0,  200,  100,  100,  100,  100,  100,  100,  100,  100,  100};
   for(int i=0; i!=11; ++i) { // from um to cm

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -57,17 +57,37 @@ void Tracking_Reco(int verbosity = 0)
   kalman->set_vertex_xy_resolution(50E-4);
   kalman->set_vertex_z_resolution(50E-4);
 
-  kalman->set_detector_type(PHG4TrackFastSim::Vertical_Plane); // Vertical_Plane, Cylinder
-  kalman->set_phi_resolution(50E-4);
-  kalman->set_r_resolution(1.);
-
-  kalman->set_pat_rec_hit_finding_eff(1.);
-  kalman->set_pat_rec_noise_prob(0.);
-
+  //kalman->set_detector_type(PHG4TrackFastSim::Vertical_Plane); // Vertical_Plane, Cylinder
+  //kalman->set_phi_resolution(50E-4);
+  //kalman->set_r_resolution(1.);
+  //kalman->set_pat_rec_hit_finding_eff(1.);
+  //kalman->set_pat_rec_noise_prob(0.);
   std::string phg4hits_names[] = {"G4HIT_SVTX","G4HIT_MAPS","G4HIT_EGEM_0","G4HIT_EGEM_1","G4HIT_EGEM_2","G4HIT_EGEM_3","G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
-  kalman->set_phg4hits_names(phg4hits_names, 11);
+  int dettypes[] = {PHG4TrackFastSim::Cylinder,PHG4TrackFastSim::Cylinder,
+		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
+		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
+		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
+		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
+		    PHG4TrackFastSim::Vertical_Plane };
+  float rad[] = {1e4,  1e4,  100,  100,  100,  100,  100,  100,  100,  100,  100};
+  float phi[] = {5.0,  150,  100,  100,  100,  100,  100,  100,  100,  100,  100};
+  float lon[] = {5.0,  200,  100,  100,  100,  100,  100,  100,  100,  100,  100};
+  for(int i=0; i!=11; ++i) { // from um to cm
+    rad[i] *= 1e-4;
+    phi[i] *= 1e-4;
+    lon[i] *= 1e-4;
+  }
+  float eff[] = {1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0};
+  float noi[] = {0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0};
+  kalman->set_phg4hits_names(phg4hits_names, dettypes, rad, phi, lon, eff, noi, 11);
+
+  //std::string phg4hits_names[] = {"G4HIT_EGEM_0","G4HIT_EGEM_1","G4HIT_EGEM_2","G4HIT_EGEM_3","G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
+  //kalman->set_phg4hits_names(phg4hits_names, 9);
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
+
+  //std::string state_names[] = {"FEMC","FHCAL"};
+  //kalman->set_state_names(state_names, 2);
 
   kalman->set_fit_alg_name("KalmanFitterRefTrack");//
   kalman->set_primary_assumption_pid(13);
@@ -111,6 +131,17 @@ void Tracking_Eval(std::string outputfile, int verbosity = 0)
 
   // MomentumEvaluator* eval = new MomentumEvaluator(outputfile.c_str(),0.2,0.4,Max_si_layer,2,Max_si_layer-4,10.,80.);
   // se->registerSubsystem( eval );
+
+}
+void Fast_Tracking_Eval(std::string outputfile, int verbosity = 0)
+{
+  gSystem->Load("libFastTrackingEval.so");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  FastTrackingEval *fast_sim_eval = new FastTrackingEval("FastTrackingEval");
+  fast_sim_eval->set_filename( outputfile.c_str() );
+  se->registerSubsystem( fast_sim_eval );
 
   return;
 }


### PR DESCRIPTION
fasttrack can work at unison with vertical/cylindrical detectors using different resolutions and efficiencies. Mod was needed to do tracking with EIC detectors at forward-central rapidities.

see also pull request #452 
https://github.com/sPHENIX-Collaboration/coresoftware/pull/452
