### PR TITLE
sPHENIX 2018 SPACAL design, 9-degree-tilted approximate projective design

### DIFF
--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -228,7 +228,7 @@ CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings,
     cemc->Verbosity(0);
 
     cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
-    cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2017ProjTilted/"));
+    cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2018ProjTilted/"));
     cemc->set_double_param("radius", radius);            // overwrite minimal radius
     cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness
 


### PR DESCRIPTION
## Introduction 

This pull request would enable by default the 2018 SPACAL design, which increased tilt angle for 90 mrad to 9-degree. This is for discussion in the coming EMCal meetings. 

More details on mechanical discussion see Dan's talk https://indico.bnl.gov/event/4725/ . To use this macro, please run from a new log on into RCF which would pick up the recent calibration repository update as merged in https://github.com/sPHENIX-Collaboration/calibrations/pull/36

## Geometry checks

### e+ /e- shower 

e+ (blue) /e- (red) shower in the EMCal. Both has pT = 5 GeV/c and launched at phi = 0:


Full detector view: 
![spacal2019](https://user-images.githubusercontent.com/7947083/42391203-93025a60-811c-11e8-8478-5c9ed9499c94.png)

Zoom into +x side: 
![spacal2021](https://user-images.githubusercontent.com/7947083/42391078-228e8736-811c-11e8-9369-6ca8bf5618f0.png)

EMCal Zoom-in:
![spacal2022](https://user-images.githubusercontent.com/7947083/42391124-50d0b330-811c-11e8-8f65-031b9b06a5d8.png)

### Muon checks

Further using muon to check the magnetic/geometric property without inducing showers. 

Here muons of both charges (red for mu- and blue for mu+) with pT = 0.5, 1, 2, 4 GeV is launched from vertex at phi = pi/2. A geantino is also sent from phi = pi/2 to mark the vertical radial line. Some findings are:
- Just from energy loss and magnetic bending, <pT=0.5 GeV/c charged muon does not reach outter HCal. And pT<= 1 GeV/c charged muon can not penetrate through the full calorimeter stack
- In the current field configuration, negatively charged particle does not bend towards tunneling in the EMCal. Tunneling may affect positively charged particle between 1< pT < 2 GeV/c
- With a combination of magnetic bending and energy loss, particle just above 1 GeV/c in pT suffer from max tunneling in EMCal and outer HCal. But they multiple scattering at this low energy would reduce such effect and they are not expected to punch through the calorimeter stack just from the ionizing energy loss. 

Full detector view: 
![spacal2023](https://user-images.githubusercontent.com/7947083/42391678-2f02ca5c-811e-11e8-98ab-7ab9d73abe38.png)

+y region zoom-in. From left to right is mu- of pT = 0.5, 1, 2, 4 GeV/c, geantino, and mu+ of pT = 4, 2, 1, 0.5 GeV/c:
![spacal2025](https://user-images.githubusercontent.com/7947083/42391745-6dbfe9dc-811e-11e8-8208-5b6ab591373f.png)
![spacal2026](https://user-images.githubusercontent.com/7947083/42391753-7666b2aa-811e-11e8-8b54-d056e2dd1bce.png)

EMCal and inner HCal zoom-in:
![spacal2027](https://user-images.githubusercontent.com/7947083/42391775-82fbe314-811e-11e8-9eb0-93e1f427fe2f.png)


## Response checks

Comparing 2018 design (blue data point) to the 2017 design (green band, current default) with 24 GeV electron between 0.3<eta<0.4 

The sampling property has remained similar in the Geant4 info QA check:
![g4sphenix root_qa rootqa_draw_cemc_g4hit](https://user-images.githubusercontent.com/7947083/42390963-b8ca7e04-811b-11e8-9fee-e8abc4f606eb.png)

There is slightly increased azimuthal deviation in the tower/cluster QA check, which probably related to the increased azimuthal tilt and require further offline corrections after clustering:
![g4sphenix root_qa rootqa_draw_cemc_towercluster](https://user-images.githubusercontent.com/7947083/42391006-ddf19d2a-811b-11e8-8928-5754a88c460c.png)
