### PR TITLE
Use field map from the calibration database

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -151,7 +151,7 @@ int Fun4All_G4_EICDetector(
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = 1.4/1.5; // scale the map to a 1.4 T field
 
   //---------------

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -150,8 +150,8 @@ int Fun4All_G4_EICDetector(
   G4Init(do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel);
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
-  //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = "/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
+  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = 1.4/1.5; // scale the map to a 1.4 T field
 
   //---------------

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -109,7 +109,7 @@ int Fun4All_G4_fsPHENIX(
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = 1.0; // already adjusted to 1.4T central field
 
   //---------------

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -108,8 +108,8 @@ int Fun4All_G4_fsPHENIX(
   G4Init(do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_FEMC,do_FHCAL,n_TPC_layers);
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
-  //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = "/phenix/upgrades/decadal/fieldmaps/fsPHENIX.2d.root"; // fsPHENIX field map by Cesar Luiz da Silva <slash@rcf.rhic.bnl.gov>, sPHENIX + piston
+  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = 1.0; // already adjusted to 1.4T central field
 
   //---------------

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -117,7 +117,7 @@ int Fun4All_G4_sPHENIX(
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = -1.4 / 1.5;                                     // scale the map to a 1.4 T field
 
   //---------------

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -116,8 +116,8 @@ int Fun4All_G4_sPHENIX(
   G4Init(do_svtx, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
-  //  const string magfield = "1.5"; // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
-  const string magfield = "/phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root";  // if like float -> solenoidal field in T, if string use as fieldmap name (including path)
+  //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
+  const string magfield = string(getenv("CALIBRATIONROOT")) + string("Field/Map/sPHENIX.2d.root"); // default map from the calibration database
   const float magfield_rescale = -1.4 / 1.5;                                     // scale the map to a 1.4 T field
 
   //---------------


### PR DESCRIPTION
In preparation of containerized distribution of sPHENIX software outside RCF, the magnetic field map is relocated from the /phenix/upgrades/decadal/fieldmaps/sPHENIX.2d.root to the GitHub-hosted calibration repository (https://github.com/sPHENIX-Collaboration/calibrations/pull/39). This also removed the dependence of sPHENIX macros to the /phenix disk.

The change should be transparent to users. 
