### PR TITLE
fix to use the enum to set cluster finding window in INTT

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -771,7 +771,7 @@ void Svtx_Reco(int verbosity = 0)
     
     for(int i = 0;i<n_intt_layer;i++)
       {
-	if(laddertype[i] == 0)
+	if(laddertype[i] == PHG4SiliconTrackerDefs::SEGMENTATION_Z)
 	  {
 	    // strip length is along phi
 	    kalman_pat_rec->set_max_search_win_theta_intt(i, 0.010);


### PR DESCRIPTION
fix to use the enum to set the sensor type dependent cluster finding window in INTT