### PR TITLE
Intt sublayer to layer

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,7 +2,7 @@
 using namespace std;
 
 int Fun4All_G4_sPHENIX(
-    const int nEvents = 1,
+    const int nEvents = 10,
     const char *inputFile = "/sphenix/data/data02/review_2017-08-02/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
     const char *outputFile = "G4sPHENIX.root",
     const char *embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list")
@@ -215,7 +215,7 @@ int Fun4All_G4_sPHENIX(
       }
       gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
       gen->set_vertex_size_parameters(0.0, 0.0);
-      gen->set_eta_range(-0.8, 0.8);
+      gen->set_eta_range(-1.0, 1.0);
       gen->set_phi_range(-1.0 * TMath::Pi(), 1.0 * TMath::Pi());
       //gen->set_pt_range(0.1, 50.0);
       gen->set_pt_range(0.1, 20.0);
@@ -537,6 +537,7 @@ int Fun4All_G4_sPHENIX(
       DisplayOn();
       // prevent macro from finishing so can see display
       int i;
+      cout << "***** Enter any integer to proceed" << endl;
       cin >> i;
     }
 

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,7 +2,7 @@
 using namespace std;
 
 int Fun4All_G4_sPHENIX(
-    const int nEvents = 10,
+    const int nEvents = 1,
     const char *inputFile = "/sphenix/data/data02/review_2017-08-02/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
     const char *outputFile = "G4sPHENIX.root",
     const char *embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list")
@@ -60,21 +60,21 @@ int Fun4All_G4_sPHENIX(
 
   bool do_pstof = false;
 
-  bool do_cemc = false;
+  bool do_cemc = true;
   bool do_cemc_cell = do_cemc && true;
   bool do_cemc_twr = do_cemc_cell && true;
   bool do_cemc_cluster = do_cemc_twr && true;
   bool do_cemc_eval = do_cemc_cluster && true;
 
-  bool do_hcalin = false;
+  bool do_hcalin = true;
   bool do_hcalin_cell = do_hcalin && true;
   bool do_hcalin_twr = do_hcalin_cell && true;
   bool do_hcalin_cluster = do_hcalin_twr && true;
   bool do_hcalin_eval = do_hcalin_cluster && true;
 
-  bool do_magnet = false;
+  bool do_magnet = true;
 
-  bool do_hcalout = false;
+  bool do_hcalout = true;
   bool do_hcalout_cell = do_hcalout && true;
   bool do_hcalout_twr = do_hcalout_cell && true;
   bool do_hcalout_cluster = do_hcalout_twr && true;
@@ -88,7 +88,7 @@ int Fun4All_G4_sPHENIX(
 
   bool do_calotrigger = true && do_cemc_twr && do_hcalin_twr && do_hcalout_twr;
 
-  bool do_jet_reco = false;
+  bool do_jet_reco = true;
   bool do_jet_eval = do_jet_reco && true;
 
   // HI Jet Reco for p+Au / Au+Au collisions (default is false for
@@ -198,8 +198,8 @@ int Fun4All_G4_sPHENIX(
     {
       // toss low multiplicity dummy events
       PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-      //gen->add_particles("pi-", 1);  // mu+,e+,proton,pi+,Upsilon
-      gen->add_particles("pi+",100); // 100 pion option
+      gen->add_particles("pi-", 2);  // mu+,e+,proton,pi+,Upsilon
+      //gen->add_particles("pi+",100); // 100 pion option
       if (readhepmc || do_embedding || runpythia8 || runpythia6)
       {
         gen->set_reuse_existing_vertex(true);

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,7 +2,7 @@
 using namespace std;
 
 int Fun4All_G4_sPHENIX(
-    const int nEvents = 10,
+    const int nEvents = 1,
     const char *inputFile = "/sphenix/data/data02/review_2017-08-02/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
     const char *outputFile = "G4sPHENIX.root",
     const char *embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list")
@@ -215,7 +215,7 @@ int Fun4All_G4_sPHENIX(
       }
       gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
       gen->set_vertex_size_parameters(0.0, 0.0);
-      gen->set_eta_range(-1.0, 1.0);
+      gen->set_eta_range(-0.8, 0.8);
       gen->set_phi_range(-1.0 * TMath::Pi(), 1.0 * TMath::Pi());
       //gen->set_pt_range(0.1, 50.0);
       gen->set_pt_range(0.1, 20.0);

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,7 +2,7 @@
 using namespace std;
 
 int Fun4All_G4_sPHENIX(
-    const int nEvents = 1,
+    const int nEvents = 10,
     const char *inputFile = "/sphenix/data/data02/review_2017-08-02/single_particle/spacal2d/fieldmap/G4Hits_sPHENIX_e-_eta0_8GeV-0002.root",
     const char *outputFile = "G4sPHENIX.root",
     const char *embed_input_file = "/sphenix/data/data02/review_2017-08-02/sHijing/fm_0-4.list")
@@ -60,21 +60,21 @@ int Fun4All_G4_sPHENIX(
 
   bool do_pstof = false;
 
-  bool do_cemc = true;
+  bool do_cemc = false;
   bool do_cemc_cell = do_cemc && true;
   bool do_cemc_twr = do_cemc_cell && true;
   bool do_cemc_cluster = do_cemc_twr && true;
   bool do_cemc_eval = do_cemc_cluster && true;
 
-  bool do_hcalin = true;
+  bool do_hcalin = false;
   bool do_hcalin_cell = do_hcalin && true;
   bool do_hcalin_twr = do_hcalin_cell && true;
   bool do_hcalin_cluster = do_hcalin_twr && true;
   bool do_hcalin_eval = do_hcalin_cluster && true;
 
-  bool do_magnet = true;
+  bool do_magnet = false;
 
-  bool do_hcalout = true;
+  bool do_hcalout = false;
   bool do_hcalout_cell = do_hcalout && true;
   bool do_hcalout_twr = do_hcalout_cell && true;
   bool do_hcalout_cluster = do_hcalout_twr && true;
@@ -88,7 +88,7 @@ int Fun4All_G4_sPHENIX(
 
   bool do_calotrigger = true && do_cemc_twr && do_hcalin_twr && do_hcalout_twr;
 
-  bool do_jet_reco = true;
+  bool do_jet_reco = false;
   bool do_jet_eval = do_jet_reco && true;
 
   // HI Jet Reco for p+Au / Au+Au collisions (default is false for
@@ -123,6 +123,12 @@ int Fun4All_G4_sPHENIX(
   //---------------
   // Fun4All server
   //---------------
+
+  bool display_on = false;
+  if(display_on)
+    {
+      gROOT->LoadMacro("DisplayOn.C");
+    }
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
@@ -192,8 +198,8 @@ int Fun4All_G4_sPHENIX(
     {
       // toss low multiplicity dummy events
       PHG4SimpleEventGenerator *gen = new PHG4SimpleEventGenerator();
-      gen->add_particles("pi-", 2);  // mu+,e+,proton,pi+,Upsilon
-      //gen->add_particles("pi+",100); // 100 pion option
+      //gen->add_particles("pi-", 1);  // mu+,e+,proton,pi+,Upsilon
+      gen->add_particles("pi+",100); // 100 pion option
       if (readhepmc || do_embedding || runpythia8 || runpythia6)
       {
         gen->set_reuse_existing_vertex(true);
@@ -526,11 +532,20 @@ int Fun4All_G4_sPHENIX(
     return;
   }
 
+  if(display_on)
+    {
+      DisplayOn();
+      // prevent macro from finishing so can see display
+      int i;
+      cin >> i;
+    }
+
   se->run(nEvents);
 
   //-----
   // Exit
   //-----
+
 
   se->End();
   std::cout << "All done" << std::endl;

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -28,9 +28,25 @@ double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladde
 
 // Optionally reconfigure the INTT
 //========================================================================
-// example re-configuration of INTT - uncomment to get the reconfiguration
+// example re-configurations of INTT - uncomment to get the reconfiguration
 // n_intt must be 0-8, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
 //========================================================================
+
+/*
+// Four layers, laddertypes 0-0-1-1
+n_intt_layer = 4;
+//
+laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
+nladder[0] = 17;       nladder[1] = 17;  
+sensor_radius[0] = 6.876; sensor_radius[1] = 7.462; 
+offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
+//
+laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
+nladder[2] = 21;  nladder[3] = 21;
+sensor_radius[2] = 12.676; sensor_radius[3] = 13.179; 
+offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
+*/
+
 /*
 // Four layers, laddertypes 0-0-1-1
 n_intt_layer = 4;
@@ -42,9 +58,10 @@ offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
 //
 laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
 nladder[2] = 18;  nladder[3] = 18;
-sensor_radius[2] = 12.676; sensor_radius[3] = 13.179; 
+sensor_radius[2] = 10.835; sensor_radius[3] = 11.361; 
 offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
 */
+
 /*
 // single layer for testing
 n_intt_layer = 1;

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -23,7 +23,7 @@ int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};  // default
 int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
 double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
-// offsetphi is in deg, every other layer offset by one half of the phi spacing between ladders
+// offsetphi is in deg, every other layer is offset by one half of the phi spacing between ladders
 double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
 
 // Optionally reconfigure the INTT
@@ -36,13 +36,13 @@ double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladde
 n_intt_layer = 4;
 //
 laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
-nladder[0] = 17;       nladder[1] = 19;  
-sensor_radius[0] = 6.876; sensor_radius[1] = 7.65; 
+nladder[0] = 17;       nladder[1] = 17;  
+sensor_radius[0] = 6.876; sensor_radius[1] = 7.462; 
 offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
 //
 laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[2] = 18;  nladder[3] = 20;
-sensor_radius[2] = 10.835; sensor_radius[3] = 12.10; 
+nladder[2] = 18;  nladder[3] = 18;
+sensor_radius[2] = 12.676; sensor_radius[3] = 13.179; 
 offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
 */
 /*

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -23,7 +23,7 @@ int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};  // default
 int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
 double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
-// offsetphi is in deg
+// offsetphi is in deg, every other layer offset by one half of the phi spacing between ladders
 double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
 
 // Optionally reconfigure the INTT
@@ -31,7 +31,7 @@ double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladde
 // example re-configuration of INTT - uncomment to get the reconfiguration
 // n_intt must be 0-8, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
 //========================================================================
-
+/*
 // Four layers, laddertypes 0-0-1-1
 n_intt_layer = 4;
 //
@@ -44,7 +44,7 @@ laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG
 nladder[2] = 18;  nladder[3] = 20;
 sensor_radius[2] = 10.835; sensor_radius[3] = 12.10; 
 offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
-
+*/
 /*
 // single layer for testing
 n_intt_layer = 1;

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -11,63 +11,48 @@ bool use_primary_vertex = false;
 const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
 
 // default setup for the INTT - please don't change this. The configuration can be redone later in the nacro if desired
-int n_intt_layer = 4;  
+int n_intt_layer = 8;  
 // default layer configuration
-int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		     PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};  // default
-int nladder[4] = {34, 30, 36, 42};  // default
-double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};  // inner staggered radius for layer default
-double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};  // outer staggered radius for layer  default
+int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
+double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
+// offsetphi is in deg
+double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
 
 // Optionally reconfigure the INTT
 //========================================================================
-// example re-configurations of INTT - uncomment one to get the reconfiguration
-// n_intt must be 0-4, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
+// example re-configuration of INTT - uncomment to get the reconfiguration
+// n_intt must be 0-8, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
 //========================================================================
-/*
-// Four layers, laddertypes 1-1-0-1
+
+// Four layers, laddertypes 0-0-1-1
 n_intt_layer = 4;
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  
-laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z; laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[0] = 22;       nladder[1] = 30;  nladder[2] = 52;  nladder[3] = 42;
-sensor_radius_inner[0] = 6.876; sensor_radius_inner[1] = 8.987; sensor_radius_inner[2] = 10.835;    sensor_radius_inner[3] = 12.676; 
-sensor_radius_outer[0] = 7.462; sensor_radius_outer[1] = 9.545; sensor_radius_outer[2] = 11.361;    sensor_radius_outer[3] = 13.179; 
-*/
+//
+laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
+nladder[0] = 17;       nladder[1] = 19;  
+sensor_radius[0] = 6.876; sensor_radius[1] = 7.65; 
+offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
+//
+laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
+nladder[2] = 18;  nladder[3] = 20;
+sensor_radius[2] = 10.835; sensor_radius[3] = 12.10; 
+offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
+
 /*
-// Three outer layers, laddertypes 1-0-1 
-n_intt_layer = 3;
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;    laddertype[1] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
-laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;
-nladder[0] = 30;  nladder[1] = 52;  nladder[2] = 42;
-sensor_radius_inner[0] = 8.987; sensor_radius_inner[1] = 10.835;    sensor_radius_inner[2] = 12.676; 
-sensor_radius_outer[0] = 9.545; sensor_radius_outer[1] = 11.361;    sensor_radius_outer[2] = 13.179; 
-*/
-/*
-// Three outer layers, laddertypes 1-1-1 
-n_intt_layer = 3;
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;    laddertype[1] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  
-laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;
-nladder[0] = 30;  nladder[1] = 36;  nladder[2] = 42;
-sensor_radius_inner[0] = 8.987; sensor_radius_inner[1] = 10.835;    sensor_radius_inner[2] = 12.676; 
-sensor_radius_outer[0] = 9.545; sensor_radius_outer[1] = 11.361;    sensor_radius_outer[2] = 13.179; 
-*/
-/*
-// Two outer layers, laddertype 0-1
-n_intt_layer = 2;
-laddertype[0] = PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] = PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[0] = 52;       nladder[1] = 42;
-sensor_radius_inner[0] = 10.835;    sensor_radius_inner[1] = 12.676; 
-sensor_radius_outer[0] = 11.361;    sensor_radius_outer[1] = 13.179; 
-*/
-/*
-// Two outer layers, laddertype 1-1
-n_intt_layer = 2;
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;    laddertype[1] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[0] = 36;       nladder[1] = 42;
-sensor_radius_inner[0] = 10.835;    sensor_radius_inner[1] = 12.676; 
-sensor_radius_outer[0] = 11.361;    sensor_radius_outer[1] = 13.179; 
+// single layer for testing
+n_intt_layer = 1;
+//
+laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;
+nladder[0] = 15;       
+sensor_radius[0] = 8.987;
+offsetphi[0] = 12.0; 
 */
 
 int n_tpc_layer_inner = 16;
@@ -336,8 +321,8 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 	{
 	  sitrack->set_int_param(i, "laddertype", laddertype[i]);
 	  sitrack->set_int_param(i, "nladder", nladder[i]);
-	  sitrack->set_double_param(i,"sensor_radius_inner", sensor_radius_inner[i]);  // expecting cm
-	  sitrack->set_double_param(i,"sensor_radius_outer", sensor_radius_outer[i]);
+	  sitrack->set_double_param(i,"sensor_radius", sensor_radius[i]);  // expecting cm
+	  sitrack->set_double_param(i,"offsetphi",offsetphi[i]);  // expecting degrees
 	}
       
       // outer radius marker (translation back to cm)

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -29,11 +29,12 @@
 /vis/open OGLSX 1200x900-0+0
 # increase display limit for more complex detectors
 /vis/ogl/set/displayListLimit 500000
-/vis/viewer/set/viewpointThetaPhi 240 -10
-/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+/vis/viewer/set/viewpointThetaPhi 0 0
+/vis/viewer/addCutawayPlane 0 0 0 m 0 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
-/vis/viewer/zoom 1.5
+/vis/viewer/zoom  30
+/vis/viewer/panTo 4 0 cm
 #
 # Use this open statement instead to get a HepRep version 1 file
 # suitable for viewing in WIRED.

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -33,8 +33,8 @@
 /vis/viewer/addCutawayPlane 0 0 0 m 0 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
-/vis/viewer/zoom  30
-/vis/viewer/panTo 4 0 cm
+/vis/viewer/zoom  20
+/vis/viewer/panTo 8 0 cm
 #
 # Use this open statement instead to get a HepRep version 1 file
 # suitable for viewing in WIRED.


### PR DESCRIPTION
Macro changes to go with PR #477. The INTT sub-layers now all have their own layer number.

I also added a few lines to Fun4All_G4_sPHENIX.C so that if the bool "display_on" is set to true, the G4 configuration will be displayed. I changed the parameters in vis.mac to do a beams-eye view of the inner tracker, since that is currently being reconfigured a lot. 