### PR TITLE
Set INTT threshold based on FPHX documentation

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -660,10 +660,30 @@ void Svtx_Reco(int verbosity = 0)
     // INTT
     // these should be used for the INTT
     /*
-     *
-     *
-     *
-     *
+How threshold are calculated based on default FPHX settings
+
+Four part information goes to the threshold calculation:
+
+1. In 320 um thick silicon, the MIP e-h pair for a nominally indenting tracking is 3.87 MeV/cm * 320 um / 3.62 eV/e-h = 3.4e4 e-h pairs
+2. From DOI: 10.1016/j.nima.2014.04.017, FPHX integrator amplifier gain is 100mV / fC. That translate MIP voltage to 550 mV.
+3. From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc), the reference voltage and DAC0-7 threshold setting for 8-ADC thresholds, as in Table 2 - Register Addresses and Defaults
+4, From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc) section Front-end Program Bits, the formula to translate DAC setting to comparitor voltages.
+
+The result threshold table based on FPHX default value is as following
+
+| FPHX Register Address | Name            | Default value | Voltage (mV) | Fraction to MIP |
+|-----------------------|-----------------|---------------|--------------|-----------------|
+| 3                     | Vref            | 1             | 210          | 3.84E-01        |
+| 4                     | Threshold DAC 0 | 8             | 242          | 4.42E-01        |
+| 5                     | Threshold DAC 1 | 16            | 274          | 5.01E-01        |
+| 6                     | Threshold DAC 2 | 32            | 338          | 6.18E-01        |
+| 7                     | Threshold DAC 3 | 48            | 402          | 7.34E-01        |
+| 8                     | Threshold DAC 4 | 80            | 530          | 9.68E-01        |
+| 9                     | Threshold DAC 5 | 112           | 658          | 1.20E+00        |
+| 10                    | Threshold DAC 6 | 144           | 786          | 1.44E+00        |
+| 11                    | Threshold DAC 7 | 176           | 914          | 1.67E+00        |
+
+DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.
      */
     std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
     userrange.push_back(0.442122900516796);

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -658,16 +658,22 @@ void Svtx_Reco(int verbosity = 0)
   if (n_intt_layer > 0)
   {
     // INTT
-    std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
     // these should be used for the INTT
-    userrange.push_back(0.05);
-    userrange.push_back(0.10);
-    userrange.push_back(0.15);
-    userrange.push_back(0.20);
-    userrange.push_back(0.25);
-    userrange.push_back(0.30);
-    userrange.push_back(0.35);
-    userrange.push_back(0.40);
+    /*
+     *
+     *
+     *
+     *
+     */
+    std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
+    userrange.push_back(0.442122900516796);
+    userrange.push_back(0.500585432816538);
+    userrange.push_back(0.617510497416021);
+    userrange.push_back(0.734435562015504);
+    userrange.push_back(0.968285691214471);
+    userrange.push_back(1.20213582041344);
+    userrange.push_back(1.4359859496124);
+    userrange.push_back(1.66983607881137);
 
     PHG4SiliconTrackerDigitizer* digiintt = new PHG4SiliconTrackerDigitizer();
     digiintt->Verbosity(verbosity);

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -752,8 +752,8 @@ DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitiz
   // INTT
   for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
   {
-    thresholds->set_threshold(i, 0.1);
-    thresholds->set_use_thickness_mip(i, true);
+    thresholds->set_threshold(i, -1); // disable threshold as threshold is applied in FPHX digitization stage
+//    thresholds->set_use_thickness_mip(i, true);
   }
 
   se->registerSubsystem(thresholds);


### PR DESCRIPTION
# Introduction

Following up with the last inner tracker task force meeting: 
1. INTT digitized ADC is wrong (all hits has ADC = 7). Here reconfigure INTT ADC thresholds based on PHENIX/FVTX/FPHX documentation. 
2. It also carry a fix to the threshold module which should not be applied to INTT

The previous INTT ADC threshold was all set below 1*MIP energy, whcih leads to almost all ADC = max FPHX chip ADC = 7. This lead to lower position resolution as amplitude information was lost. This pull request reset the INTT FPHX chip threshold in simulation based on the default chip setting in the PHENIX FVTX FPHX documentations. 

Note: This need to run with a patch on the coresoftware, which carry fixes on three digitization problem on INTT: https://github.com/sPHENIX-Collaboration/coresoftware/pull/493

# How threshold are calculated based on default FPHX settings

Four part information goes to the threshold calculation: 

1. In 320 um thick silicon, the MIP e-h pair for a nominally indenting tracking is 3.87 MeV/cm * 320 um / 3.62 eV/e-h = 3.4e4 e-h pairs
2. From DOI: 10.1016/j.nima.2014.04.017, FPHX integrator amplifier gain is 100mV / fC. That translate MIP voltage to 550 mV. 
3. From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc), the reference voltage and DAC0-7 threshold setting for 8-ADC thresholds, as in Table 2 - Register Addresses and Defaults
4, From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc) section Front-end Program Bits, the formula to translate DAC setting to comparitor voltages.

The result threshold table based on FPHX default value is as following

| FPHX Register Address | Name            | Default value | Voltage (mV) | Fraction to MIP |
|-----------------------|-----------------|---------------|--------------|-----------------|
| 3                     | Vref            | 1             | 210          | 3.84E-01        |
| 4                     | Threshold DAC 0 | 8             | 242          | 4.42E-01        |
| 5                     | Threshold DAC 1 | 16            | 274          | 5.01E-01        |
| 6                     | Threshold DAC 2 | 32            | 338          | 6.18E-01        |
| 7                     | Threshold DAC 3 | 48            | 402          | 7.34E-01        |
| 8                     | Threshold DAC 4 | 80            | 530          | 9.68E-01        |
| 9                     | Threshold DAC 5 | 112           | 658          | 1.20E+00        |
| 10                    | Threshold DAC 6 | 144           | 786          | 1.44E+00        |
| 11                    | Threshold DAC 7 | 176           | 914          | 1.67E+00        |

DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitizer::set_adc_scale as 3-bit flash ADC threshold as fractions to MIP energy deposition. 
 

# Test

The result threshold are compared to Geant4 simulated muon energy deposition in each INTT layer from the `DST/G4HIT_SILICON_TRACKER` hit container. Muons are launched from z = 0 and |eta|<1. 

![image](https://user-images.githubusercontent.com/7947083/46227532-80675380-c32d-11e8-8e44-01bc951c6ed2.png)

## ADC spectrum

Now the ADC specturm on INTT hits look like that from the PHENIX FVTX data: 
![image](https://user-images.githubusercontent.com/7947083/46231486-215c0b80-c33a-11e8-9ff9-c53d5b5164bb.png)

![image](https://user-images.githubusercontent.com/7947083/46236389-828cda80-c34c-11e8-8e18-6e360cdfbce9.png)


## Digitized energy vs truth energy in strip: 

![image](https://user-images.githubusercontent.com/7947083/46236334-4fe2e200-c34c-11e8-8548-7c151f0419d0.png)



# Discussions

Note, this leads to significant increase of ADC-0 or general digitizer threshold from 5% of MIP energy to 44% of MIP energy.  This could lead to loss of MIP efficiency if the energy deposition is low from beginning and split charge over two strips. 
  
However, I think using a lower threshold below the default require justification from the INTT group, in particular the noise rate. 

Need to check the result tracking efficiency and missing hit rate changes @adfrawley @bogui56

