### PR TITLE
Set INTT threshold based on FPHX documentation - Try 2

### DIFF
--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -407,12 +407,7 @@ DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitiz
     // Note the non-use of set_using_thickness here, this is so that the shortest dimension of the cell sets the mip energy loss
     thresholds->set_threshold(i, -1);
   }
-  // INTT
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    thresholds->set_threshold(i, 0.1);
-    thresholds->set_use_thickness_mip(i, true);
-  }
+  // INTT: Does not need PHG4SvtxThresholds as the new digitizer handle the zero-suppression threshold with in ASIC
 
   se->registerSubsystem(thresholds);
 

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -331,7 +331,6 @@ Four part information goes to the threshold calculation:
 The result threshold table based on FPHX default value is as following
 | FPHX Register Address | Name            | Default value | Voltage - Vref (mV) | To electrons based on calibration | Electrons | Fraction to MIP |
 |-----------------------|-----------------|---------------|---------------------|-----------------------------------|-----------|-----------------|
-| 3                     | Vref            | 1             | 210                 | 16406                             |           | 3.84E-01        |
 | 4                     | Threshold DAC 0 | 8             | 32                  | 2500                              | 2000      | 5.85E-02        |
 | 5                     | Threshold DAC 1 | 16            | 64                  | 5000                              | 4000      | 1.17E-01        |
 | 6                     | Threshold DAC 2 | 32            | 128                 | 10000                             | 8000      | 2.34E-01        |
@@ -340,7 +339,6 @@ The result threshold table based on FPHX default value is as following
 | 9                     | Threshold DAC 5 | 112           | 448                 | 35000                             | 28000     | 8.18E-01        |
 | 10                    | Threshold DAC 6 | 144           | 576                 | 45000                             | 36000     | 1.05E+00        |
 | 11                    | Threshold DAC 7 | 176           | 704                 | 55000                             | 44000     | 1.29E+00        |
-You can now import Markdown table code directly using File/Paste table data... dialog.
 DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.
      */
     std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -320,16 +320,38 @@ void Tracking_Reco(int verbosity = 0)
   if (n_intt_layer > 0)
   {
     // INTT
-    std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
     // these should be used for the INTT
-    userrange.push_back(0.05);
-    userrange.push_back(0.10);
-    userrange.push_back(0.15);
-    userrange.push_back(0.20);
-    userrange.push_back(0.25);
-    userrange.push_back(0.30);
-    userrange.push_back(0.35);
-    userrange.push_back(0.40);
+    /*
+How threshold are calculated based on default FPHX settings
+Four part information goes to the threshold calculation:
+1. In 320 um thick silicon, the MIP e-h pair for a nominally indenting tracking is 3.87 MeV/cm * 320 um / 3.62 eV/e-h = 3.4e4 e-h pairs
+2. From DOI: 10.1016/j.nima.2014.04.017, FPHX integrator amplifier gain is 100mV / fC. That translate MIP voltage to 550 mV.
+3. From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc), the DAC0-7 setting for 8-ADC thresholds above the V_ref, as in Table 2 - Register Addresses and Defaults
+4, From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc) section Front-end Program Bits, the formula to translate DAC setting to comparitor voltages.
+The result threshold table based on FPHX default value is as following
+| FPHX Register Address | Name            | Default value | Voltage - Vref (mV) | To electrons based on calibration | Electrons | Fraction to MIP |
+|-----------------------|-----------------|---------------|---------------------|-----------------------------------|-----------|-----------------|
+| 3                     | Vref            | 1             | 210                 | 16406                             |           | 3.84E-01        |
+| 4                     | Threshold DAC 0 | 8             | 32                  | 2500                              | 2000      | 5.85E-02        |
+| 5                     | Threshold DAC 1 | 16            | 64                  | 5000                              | 4000      | 1.17E-01        |
+| 6                     | Threshold DAC 2 | 32            | 128                 | 10000                             | 8000      | 2.34E-01        |
+| 7                     | Threshold DAC 3 | 48            | 192                 | 15000                             | 12000     | 3.51E-01        |
+| 8                     | Threshold DAC 4 | 80            | 320                 | 25000                             | 20000     | 5.85E-01        |
+| 9                     | Threshold DAC 5 | 112           | 448                 | 35000                             | 28000     | 8.18E-01        |
+| 10                    | Threshold DAC 6 | 144           | 576                 | 45000                             | 36000     | 1.05E+00        |
+| 11                    | Threshold DAC 7 | 176           | 704                 | 55000                             | 44000     | 1.29E+00        |
+You can now import Markdown table code directly using File/Paste table data... dialog.
+DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.
+     */
+    std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
+    userrange.push_back(0.0584625322997416);
+    userrange.push_back(0.116925064599483);
+    userrange.push_back(0.233850129198966);
+    userrange.push_back(0.35077519379845);
+    userrange.push_back(0.584625322997416);
+    userrange.push_back(0.818475452196383);
+    userrange.push_back(1.05232558139535);
+    userrange.push_back(1.28617571059432);
 
     PHG4SiliconTrackerDigitizer* digiintt = new PHG4SiliconTrackerDigitizer();
     digiintt->Verbosity(verbosity);
@@ -383,7 +405,7 @@ void Tracking_Reco(int verbosity = 0)
   {
     // reduced by x2.5 when going from cylinder maps with 50 microns thickness to actual maps with 18 microns thickness
     // Note the non-use of set_using_thickness here, this is so that the shortest dimension of the cell sets the mip energy loss
-    thresholds->set_threshold(i, 0.1);
+    thresholds->set_threshold(i, -1);
   }
   // INTT
   for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)


### PR DESCRIPTION
# Introduction

This pull request is intended to update the INTT digitization to fix following problems:

1. INTT digitized ADC is wrong (all hits has ADC = 7). Here reconfigure INTT ADC thresholds based on PHENIX/FVTX/FPHX documentation. 
2. This pull request also carry a fix to the threshold module which should not be applied to INTT

In the first try of this fix, https://github.com/sPHENIX-Collaboration/macros/pull/130, I found I misunderstood the use of V_ref in the ASIC circuit (baseline of the signal is shifted to V_ref after shaper and prior to the ADC). This should be fixed in this pull request, which significantly lowered the threshold when compared with #130 . To be sure this time, the digitization method was also applied to INTT test beam and compared with test beam data from Yorito Yamaguchi (Thanks a lot!). 

Note: This need to run with a patch on the coresoftware, which carry fixes on three digitization problem on INTT: https://github.com/sPHENIX-Collaboration/coresoftware/pull/493


# How threshold are calculated based on default FPHX settings

Four part information goes to the threshold calculation:
1. In 320 um thick silicon, the MIP e-h pair for a nominally indenting tracking is 3.87 MeV/cm * 320 um / 3.62 eV/e-h = 3.4e4 e-h pairs
2. From DOI: 10.1016/j.nima.2014.04.017, FPHX integrator amplifier gain is 100mV / fC. That translate MIP voltage to 550 mV.
3. From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc), the DAC0-7 setting for 8-ADC thresholds above the V_ref, as in Table 2 - Register Addresses and Defaults
4, From [FPHX Final Design Document](https://www.phenix.bnl.gov/WWW/fvtx/DetectorHardware/FPHX/FPHX2_June2009Revision.doc) section Front-end Program Bits, the formula to translate DAC setting to comparitor voltages.
The result threshold table based on FPHX default value is as following

| FPHX Register Address | Name            | Default value | Voltage - Vref (mV) | Electrons | Fraction to MIP |
|-----------------------|-----------------|---------------|---------------------|-----------|-----------------|
| 4                     | Threshold DAC 0 | 8             | 32                  | 2000      | 5.85E-02        |
| 5                     | Threshold DAC 1 | 16            | 64                  | 4000      | 1.17E-01        |
| 6                     | Threshold DAC 2 | 32            | 128                 | 8000      | 2.34E-01        |
| 7                     | Threshold DAC 3 | 48            | 192                 | 12000     | 3.51E-01        |
| 8                     | Threshold DAC 4 | 80            | 320                 | 20000     | 5.85E-01        |
| 9                     | Threshold DAC 5 | 112           | 448                 | 28000     | 8.18E-01        |
| 10                    | Threshold DAC 6 | 144           | 576                 | 36000     | 1.05E+00        |
| 11                    | Threshold DAC 7 | 176           | 704                 | 44000     | 1.29E+00        |

DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.

In this new setting, the threshold is 5.8% of MIP energy which is only slightly higher than the current default of 5%. Meanwhile, the MIP peak should be enclose in the higher ADC range of 4-5, instead of above max ADC as in the current default. 

# Test in the sPHENIX settings

Test run with 120 GeV proton almost normal indenting to INTT detector (|eta|<0.1, |z|<10cm)

## ADC spectrum

Now the ADC spectrum on INTT phi-segmented strips hits peaks at ADC = 4. It is higher than the PHENIX/FVTX ADC peak (ADC = 3) partly due to FVTX has charge spread to multiple strip due to slopped tracks. The red curve is for all strips above zero suppression and the blue curve is for strip within single-strip clusters. 

![c1](https://user-images.githubusercontent.com/7947083/47314957-29455d80-d611-11e8-91e5-62589da7e159.png)

ADC vs strip energy showing the non-linear ADC scales and threshold at ADC = 0:

![c1_n3](https://user-images.githubusercontent.com/7947083/47315020-5f82dd00-d611-11e8-941e-fc0b897b3a5d.png)

## Digitized energy vs truth energy in single strips 

Digitized energy vs truth energy in single strips reproduces the linear correlation.
![c1_n2](https://user-images.githubusercontent.com/7947083/47315224-f3ed3f80-d611-11e8-8e7c-fa39181e82e7.png)

# Test in the 2018 INTT test beam settings

To be sure this time, the digitization method was also applied to INTT test beam and compared with test beam data from Yorito Yamaguchi (Thanks a lot!). There are a few notable difference between test beam and the proposed sPHENIX settings: 

* 2018 Test beam used 200 um silicon, while we currently expect 320 us silicon in sPHENIX
* 2018 Test beam used DAC0 = 14 (controls threshold), while I would suggest try DCA0 = 8 in sPHENIX (default threshold and FVTX work point)

In a special sPHENIX simulation test with the aims to qualitatively reproduce INTT test beam response, INTT thickness is reduced to 200 um and threshold is increased to DAC0 = 14. The proton within |eta|<0.01 is used to mimic the beam spread. However, the polar beam spread is likely to be higher in this simulation than that in the beam test. The macro setup is 
https://github.com/blackcathj/macros/blob/newINTT_newMVTX_TestBeam/macros/g4simulations/G4_Tracking.C 

The cluster size is qualitatively consistent. The simulation has more cluster splitting likely due to the larger azimuthal indenting angle spread:

![c1](https://user-images.githubusercontent.com/7947083/47315735-6579bd80-d613-11e8-8619-b1ef4b209c49.png)

In the next test, we use single strip cluster to test MIP energy when compared with ADC scales. The spectrum is qualitatively consistent too. The simulation MIP energy is slightly higher when compared with the ADC scales, which could come from the imperfect number for the gain of the amplifier and the thickness of the active layer of the silicon: 

![c1_n3](https://user-images.githubusercontent.com/7947083/47315799-84784f80-d613-11e8-8394-d34c0e6364ad.png)

# Move forward

Suggest double check with Tony @adfrawley  and Christof @bogui56 . Merge if we have a consensus. 


