### PR TITLE
Root5 root6 combined

### DIFF
--- a/macros/g4simulations/G4_Bbc.C
+++ b/macros/g4simulations/G4_Bbc.C
@@ -1,3 +1,9 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include <fun4all/Fun4AllServer.h>
+#include <g4bbc/BbcVertexFastSimReco.h>
+R__LOAD_LIBRARY(libg4bbc.so)
+#endif
 
 void BbcInit() {}
 

--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -1,4 +1,30 @@
-
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterPositionCorrection.h>
+#include <fun4all/Fun4AllServer.h>
+#include <g4detectors/PHG4CylinderCellReco.h>
+#include <g4detectors/PHG4CylinderGeom_Spacalv1.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4FullProjSpacalCellReco.h>
+#include <g4detectors/PHG4SpacalSubsystem.h>
+#include <g4calo/RawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <g4eval/CaloEvaluator.h>
+#include <g4main/PHG4Reco.h>
+double
+CEmc_1DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings, const int absorberactive = 0);
+double
+CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings,
+                        const int absorberactive = 0);
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
 int Min_cemc_layer = 1;
 int Max_cemc_layer = 1;
 

--- a/macros/g4simulations/G4_Global.C
+++ b/macros/g4simulations/G4_Global.C
@@ -1,3 +1,12 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include <fun4all/Fun4AllServer.h>
+#include <g4vertex/GlobalVertexReco.h>
+#include <g4vertex/GlobalVertexFastSimReco.h>
+R__LOAD_LIBRARY(libg4vertex.so)
+#endif
+
+void GlobalInit() {}
 
 void Global_Reco(int verbosity = 0) {
   

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -1,10 +1,32 @@
-//Inner HCal construction macro
+//Inner HCal reconstruction macro
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+#include <fun4all/Fun4AllServer.h>
+#include <g4calo/HcalRawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4InnerHcalSubsystem.h>
+#include <g4detectors/PHG4HcalCellReco.h>
+#include <g4eval/CaloEvaluator.h>
+#include <g4main/PHG4Reco.h>
+void HCalInner_SupportRing(PHG4Reco* g4Reco,
+			   const int absorberactive = 0);
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
 
 //Inner HCal absorber material selector:
 //false - Default, absorber material is SS310
 //true - Choose if you want Aluminum
 const bool inner_hcal_material_Al = false;
 
+static int inner_hcal_eic = 0;
 
 enum enu_HCalIn_clusterizer
 {
@@ -20,7 +42,13 @@ enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInTemplateClusterizer;
 
 
 // Init is called by G4Setup.C
-void HCalInnerInit() {}
+void HCalInnerInit(const int iflag = 0) 
+{
+  if (iflag == 1)
+  {
+    inner_hcal_eic = 1;
+  }
+}
 
 double HCalInner(PHG4Reco* g4Reco,
 		 double radius,
@@ -103,16 +131,21 @@ void HCalInner_SupportRing(PHG4Reco* g4Reco,
   const double z_ring1 = (2025 + 2050) / 2. / 10.;
   const double z_ring2 = (2150 + 2175) / 2. / 10.;
   const double dz = 25. / 10.;
-  const double innerradius = 116.;
+  const double innerradius_sphenix = 116.;
+  const double innerradius_ephenix_hadronside = 138.;
   const double maxradius = 178.0 - 0.001; // avoid touching the outer HCal envelop volumne
-
   const double z_rings[] =
-    { -z_ring2, -z_ring1, z_ring1, z_ring2, 0, 0, 0, 0 };
+    { -z_ring2, -z_ring1, z_ring1, z_ring2 };
 
   PHG4CylinderSubsystem *cyl;
 
   for (int i = 0; i < 4; i++)
     {
+      double innerradius = innerradius_sphenix;
+      if ( z_rings[i] > 0 && inner_hcal_eic == 1)
+      {
+        innerradius = innerradius_ephenix_hadronside;
+      }
       cyl = new PHG4CylinderSubsystem("HCALIN_SPT_N1", i);
       cyl->set_double_param("place_z",z_rings[i]);
       cyl->SuperDetector("HCALIN_SPT");

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -1,4 +1,21 @@
-
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <caloreco/RawClusterBuilderGraph.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
+#include <caloreco/RawTowerCalibration.h>
+#include <fun4all/Fun4AllServer.h>
+#include <g4calo/HcalRawTowerBuilder.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <g4detectors/PHG4OuterHcalSubsystem.h>
+#include <g4detectors/PHG4HcalCellReco.h>
+#include <g4eval/CaloEvaluator.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
 
 enum enu_HCalOut_clusterizer
 {

--- a/macros/g4simulations/G4_Magnet.C
+++ b/macros/g4simulations/G4_Magnet.C
@@ -1,3 +1,10 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libg4detectors.so)
+#endif
 
 void MagnetInit() {}
 

--- a/macros/g4simulations/G4_Pipe.C
+++ b/macros/g4simulations/G4_Pipe.C
@@ -1,3 +1,10 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libg4detectors.so)
+#endif
 
 void PipeInit() {}
 

--- a/macros/g4simulations/G4_PlugDoor.C
+++ b/macros/g4simulations/G4_PlugDoor.C
@@ -1,3 +1,10 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libg4detectors.so)
+#endif
 
 void PlugDoorInit() {}
 void PlugDoor(PHG4Reco *g4Reco,

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -1,3 +1,34 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <fun4all/Fun4AllServer.h>
+#include <g4detectors/PHG4MapsCellReco.h>
+#include <g4detectors/PHG4MapsSubsystem.h>
+#include <g4detectors/PHG4SiliconTrackerCellReco.h>
+#include <g4detectors/PHG4SiliconTrackerDefs.h>
+#include <g4detectors/PHG4SiliconTrackerSubsystem.h>
+#include <g4detectors/PHG4TPCSpaceChargeDistortion.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4hough/PHG4GenFitTrackProjection.h>
+#include <g4hough/PHG4KalmanPatRec.h>
+#include <g4hough/PHG4SiliconTrackerDigitizer.h>
+#include <g4hough/PHG4SvtxClusterizer.h>
+#include <g4hough/PHG4SvtxDeadArea.h>
+#include <g4hough/PHG4SvtxDigitizer.h>
+#include <g4hough/PHG4SvtxThresholds.h>
+#include <g4hough/PHG4TPCClusterizer.h>
+#include <g4hough/PHG4TrackKalmanFitter.h>
+#include <g4hough/PHG4TruthPatRec.h>
+#include <g4main/PHG4Reco.h>
+#include <g4tpc/PHG4TPCElectronDrift.h>
+#include <g4tpc/PHG4TPCPadPlane.h>
+#include <g4tpc/PHG4TPCPadPlaneReadout.h>
+#include <g4tpc/PHG4TPCSubsystem.h>
+R__LOAD_LIBRARY(libg4tpc.so)
+R__LOAD_LIBRARY(libg4hough.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
+
 #include <vector>
 
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
@@ -11,6 +42,7 @@ bool use_primary_vertex = false;
 const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
 
 // default setup for the INTT - please don't change this. The configuration can be redone later in the macro if desired
+#ifdef INTTLADDER8
 int n_intt_layer = 8;  
 // default layer configuration
 int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
@@ -25,7 +57,7 @@ int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
 double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
 // offsetphi is in deg, every other layer is offset by one half of the phi spacing between ladders
 double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
-
+#else
 // Optionally reconfigure the INTT
 //========================================================================
 // example re-configurations of INTT - uncomment to get the reconfiguration
@@ -34,18 +66,16 @@ double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladde
 //========================================================================
 
 // Four layers, laddertypes 0-0-1-1
-n_intt_layer = 4;
+int n_intt_layer = 4;
 //
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
-nladder[0] = 17;       nladder[1] = 17;  
-sensor_radius[0] = 6.876; sensor_radius[1] = 7.462; 
-offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
-//
-laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[2] = 21;  nladder[3] = 21;
-sensor_radius[2] = 12.676; sensor_radius[3] = 13.179; 
-offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
-
+int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		     PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
+int nladder[4] = {17,17, 21,21};  
+double sensor_radius[4] = {6.876, 7.462, 12.676, 13.179};
+double offsetphi[4] = {0., 0.5 * 360.0 / nladder[1], 0., 0.5 * 360.0 / nladder[3]};
+#endif
 /*
 // Four layers, laddertypes 0-0-1-1
 n_intt_layer = 4;
@@ -506,16 +536,6 @@ DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitiz
   beamspot->Verbosity(verbosity);
   se->registerSubsystem( beamspot );
   */
-
-  return;
-}
-
-void G4_Svtx_Reco()
-{
-  cout << "\033[31;1m"
-       << "Warning: G4_Svtx_Reco() was moved to G4_Svtx.C and renamed to Svtx_Reco(), please update macros"
-       << "\033[0m" << endl;
-  Svtx_Reco();
 
   return;
 }


### PR DESCRIPTION
First batch of macros to run Fun4AllG4_sPHENIX.C both under root5 and under root6. Tracking has rare last digits diffs in dca2d and dca2d_error, I assume its from the use of TMath (the root5 versions give a warning from TLorentzvector which seems to be suppressed in root6) go figure - really  please DO NOT USE TMATH