### PR TITLE
Root6

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -14,8 +14,11 @@
 #include <g4main/PHG4ParticleGun.h>
 #include <g4main/HepMCNodeReader.h>
 #include <g4detectors/PHG4DetectorSubsystem.h>
+#include <phool/recoConsts.h>
 #include <phpythia6/PHPythia6.h>
 #include <phpythia8/PHPythia8.h>
+#include <phhepmc/Fun4AllHepMCPileupInputManager.h>
+#include <phhepmc/Fun4AllHepMCInputManager.h>
 #include "G4Setup_sPHENIX.C"
 #include "G4_Bbc.C"
 #include "G4_Global.C"
@@ -26,6 +29,7 @@
 #include "DisplayOn.C"
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4testbench.so)
+R__LOAD_LIBRARY(libphhepmc.so)
 R__LOAD_LIBRARY(libPHPythia6.so)
 R__LOAD_LIBRARY(libPHPythia8.so)
 #endif

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -29,6 +29,8 @@ R__LOAD_LIBRARY(libg4hough.so)
 R__LOAD_LIBRARY(libg4eval.so)
 #endif
 
+#include <map>
+
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
 bool tpc_layers_40  = false;
 

--- a/macros/g4simulations/GlobalVariables.C
+++ b/macros/g4simulations/GlobalVariables.C
@@ -1,0 +1,5 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+static bool overlapcheck = false;
+static double no_overlapp = 0.0001; // added to radii to avoid overlapping volumes
+#endif


### PR DESCRIPTION
update of G4_Tracking.C - bring back in line with the master repo. There is a difference in the G4_Jets.C but up to them the results are identical between root5 and root6 (except rare last digit diffs in the tracks, likely caused by the use of TMath in the tracking)