### PR TITLE
Update tracking macro

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -481,8 +481,8 @@ int Fun4All_G4_sPHENIX(
     se->registerInputManager(pileup);
 
     const string pileupfile("/sphenix/sim/sim01/sHijing/sHijing_0-12fm.dat");
-		//background files for p+p pileup sim
-		//const string pileupfile("/gpfs/mnt/gpfs04/sphenix/user/shlim/04.InnerTrackerTaskForce/01.PythiaGen/list_pythia8_mb.dat");
+    //background files for p+p pileup sim
+    //const string pileupfile("/gpfs/mnt/gpfs04/sphenix/user/shlim/04.InnerTrackerTaskForce/01.PythiaGen/list_pythia8_mb.dat");
     pileup->AddFile(pileupfile);  // HepMC events used in pile up collisions. You can add multiple files, and the file list will be reused.
     //pileup->set_vertex_distribution_width(100e-4,100e-4,30,5);//override collision smear in space time
     //pileup->set_vertex_distribution_mean(0,0,0,0);//override collision central position shift in space time
@@ -493,6 +493,7 @@ int Fun4All_G4_sPHENIX(
 
     if (do_tracking)
     {
+      // This gets the default drift velocity only! 
       PHG4TPCElectronDrift *dr = (PHG4TPCElectronDrift *)se->getSubsysReco("PHG4TPCElectronDrift");
       assert(dr);
       double TPCDriftVelocity = dr->get_double_param("drift_velocity");

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -493,10 +493,9 @@ int Fun4All_G4_sPHENIX(
 
     if (do_tracking)
     {
-      // double TPCDriftVelocity = 6.0 / 1000.0; // cm/ns, which is loaded from G4_SVTX*.C macros
-			PHG4TPCElectronDrift *dr = (PHG4TPCElectronDrift *)se->getSubsysReco("PHG4TPCElectronDrift");
-			assert(dr);
-			double TPCDriftVelocity = dr->get_double_param("drift_velocity");
+      PHG4TPCElectronDrift *dr = (PHG4TPCElectronDrift *)se->getSubsysReco("PHG4TPCElectronDrift");
+      assert(dr);
+      double TPCDriftVelocity = dr->get_double_param("drift_velocity");
       time_window_minus = -105.5 / TPCDriftVelocity;  // ns
       time_window_plus = 105.5 / TPCDriftVelocity;    // ns;
     }

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -41,6 +41,7 @@ int Fun4All_G4_sPHENIX(
   const bool usegun = false && !readhits;
   // Throw single Upsilons, may be embedded in Hijing by setting readhepmc flag also  (note, careful to set Z vertex equal to Hijing events)
   const bool upsilons = false && !readhits;
+  const int num_upsilons_per_event = 1;  // can set more than 1 upsilon per event, each has a unique embed flag
   // Event pile up simulation with collision rate in Hz MB collisions.
   // Note please follow up the macro to verify the settings for beam parameters
   const double pileup_collision_rate = 0;  // 100e3 for 100kHz nominal AuAu collision rate.
@@ -248,50 +249,56 @@ int Fun4All_G4_sPHENIX(
     // If "readhepMC" is also set, the Upsilons will be embedded in Hijing events, if 'particles" is set, the Upsilons will be embedded in whatever particles are thrown
     if (upsilons)
     {
-      // run upsilons for momentum, dca performance, alone or embedded in Hijing
-
-      PHG4ParticleGeneratorVectorMeson *vgen = new PHG4ParticleGeneratorVectorMeson();
-      vgen->add_decay_particles("e+", "e-", 0);  // i = decay id
-      // event vertex
-      if (readhepmc || do_embedding || particles || runpythia8 || runpythia6)
-      {
-        vgen->set_reuse_existing_vertex(true);
-      }
-      else
-      {
-        vgen->set_vtx_zrange(-10.0, +10.0);
-      }
-
-      // Note: this rapidity range completely fills the acceptance of eta = +/- 1 unit
-      vgen->set_rapidity_range(-1.0, +1.0);
-      vgen->set_pt_range(0.0, 10.0);
-
-      int istate = 1;
-
-      if (istate == 1)
-      {
-        // Upsilon(1S)
-        vgen->set_mass(9.46);
-        vgen->set_width(54.02e-6);
-      }
-      else if (istate == 2)
-      {
-        // Upsilon(2S)
-        vgen->set_mass(10.0233);
-        vgen->set_width(31.98e-6);
-      }
-      else
-      {
-        // Upsilon(3S)
-        vgen->set_mass(10.3552);
-        vgen->set_width(20.32e-6);
-      }
-
-      vgen->Verbosity(0);
-      vgen->Embed(3);
-      se->registerSubsystem(vgen);
-
-      cout << "Upsilon generator for istate = " << istate << " created and registered " << endl;
+     // run upsilons for momentum, dca performance, alone or embedded in Hijing
+      for(int iups = 0; iups < num_upsilons_per_event;iups++)
+	{
+	  PHG4ParticleGeneratorVectorMeson *vgen = new PHG4ParticleGeneratorVectorMeson();
+	  vgen->add_decay_particles("e+", "e-", 0);  // i = decay id
+	  // event vertex
+	  if (readhepmc || do_embedding || particles || runpythia8 || runpythia6 || iups > 0)
+	    {
+	      vgen->set_reuse_existing_vertex(true);
+	    }
+	  else
+	    {
+	      vgen->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+						    PHG4SimpleEventGenerator::Uniform,
+						    PHG4SimpleEventGenerator::Uniform);
+	      vgen->set_vertex_distribution_mean(0.0, 0.0, 0.0);
+	      vgen->set_vertex_distribution_width(0.0, 0.0, 5.0); 
+	    }
+	  
+	  // Note: this rapidity range completely fills the acceptance of eta = +/- 1 unit
+	  vgen->set_rapidity_range(-1.0, +1.0);
+	  vgen->set_pt_range(0.0, 10.0);
+	  
+	  int istate = 1;
+	  
+	  if (istate == 1)
+	    {
+	      // Upsilon(1S)
+	      vgen->set_mass(9.46);
+	      vgen->set_width(54.02e-6);
+	    }
+	  else if (istate == 2)
+	    {
+	      // Upsilon(2S)
+	      vgen->set_mass(10.0233);
+	      vgen->set_width(31.98e-6);
+	    }
+	  else
+	    {
+	      // Upsilon(3S)
+	      vgen->set_mass(10.3552);
+	      vgen->set_width(20.32e-6);
+	    }
+	  
+	  vgen->Verbosity(0);
+	  vgen->Embed(iups+3);  // unique gembed for each upsilon
+	  se->registerSubsystem(vgen);
+	  
+	  cout << "Upsilon generator for istate = " << istate << " created and registered " << endl;
+	}
     }
   }
 

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -32,7 +32,7 @@ R__LOAD_LIBRARY(libg4eval.so)
 #include <vector>
 // define INTTLADDER8, INTTLADDER6, INTTLADDER4_ZP or INTTLADDER4_PP, INTTLADDER0 to get 8, 6, 4 or 0 layers
 // one and only one of these has to be defined, because #elseif does not seem to work properly in the interpreter
-#define INTTLADDER0
+#define INTTLADDER4_PP
 
 
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -30,6 +30,10 @@ R__LOAD_LIBRARY(libg4eval.so)
 #endif
 
 #include <vector>
+// define INTTLADDER8, INTTLADDER6, INTTLADDER4_ZP or INTTLADDER4_PP, INTTLADDER0 to get 8, 6, 4 or 0 layers
+// one and only one of these has to be defined, because #elseif does not seem to work properly in the interpreter
+#define INTTLADDER0
+
 
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
 bool tpc_layers_40  = false;
@@ -41,7 +45,8 @@ bool use_primary_vertex = false;
 
 const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
 
-// default setup for the INTT - please don't change this. The configuration can be redone later in the macro if desired
+// Configure the INTT layers
+// offsetphi is in deg, every other layer is offset by one half of the phi spacing between ladders
 #ifdef INTTLADDER8
 int n_intt_layer = 8;  
 // default layer configuration
@@ -55,50 +60,43 @@ int laddertype[8] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z,
 		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};  // default
 int nladder[8] = {17,  17, 15, 15, 18, 18, 21, 21};  // default
 double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
-// offsetphi is in deg, every other layer is offset by one half of the phi spacing between ladders
 double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
-#else
-// Optionally reconfigure the INTT
-//========================================================================
-// example re-configurations of INTT - uncomment to get the reconfiguration
-// n_intt must be 0-8, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
-// To get hermetic coverage, need to configure these layers in pairs with the same nladder values!
-//========================================================================
-
-// Four layers, laddertypes 0-0-1-1
-int n_intt_layer = 4;
-//
-int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
-		     PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
-		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
-		     PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
-int nladder[4] = {17,17, 21,21};  
-double sensor_radius[4] = {6.876, 7.462, 12.676, 13.179};
-double offsetphi[4] = {0., 0.5 * 360.0 / nladder[1], 0., 0.5 * 360.0 / nladder[3]};
 #endif
-/*
-// Four layers, laddertypes 0-0-1-1
-n_intt_layer = 4;
-//
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_Z;    laddertype[1] =   PHG4SiliconTrackerDefs::SEGMENTATION_Z;  
-nladder[0] = 17;       nladder[1] = 17;  
-sensor_radius[0] = 6.876; sensor_radius[1] = 7.462; 
-offsetphi[0] = 0.0;   offsetphi[1] = 0.5 * 360.0 / nladder[1];
-//
-laddertype[2] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;  laddertype[3] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI; 
-nladder[2] = 18;  nladder[3] = 18;
-sensor_radius[2] = 10.835; sensor_radius[3] = 11.361; 
-offsetphi[2] = 0.0;   offsetphi[3] = 0.5 * 360.0 / nladder[3];
-*/
-/*
-// single layer for testing
-n_intt_layer = 1;
-//
-laddertype[0] =  PHG4SiliconTrackerDefs::SEGMENTATION_PHI;
-nladder[0] = 15;       
-sensor_radius[0] = 8.987;
-offsetphi[0] = 12.0; 
-*/
+#ifdef INTTLADDER6
+int n_intt_layer = 6;
+int laddertype[6] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI };
+int nladder[6] = {17,  17, 15, 15, 18, 18}; 
+double sensor_radius[6] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361};  // radius of center of sensor for layer default
+double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5]};
+#endif
+#ifdef INTTLADDER4_ZP
+int n_intt_layer = 4;
+int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_Z, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
+int nladder[4] = {17,  17, 18, 18}; 
+double sensor_radius[6] = {6.876, 7.462, 10.835, 11.361};  // radius of center of sensor for layer default
+double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3]};
+#endif
+#ifdef INTTLADDER4_PP
+int n_intt_layer = 4;
+int laddertype[4] = {PHG4SiliconTrackerDefs::SEGMENTATION_PHI, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI, 
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI,
+		       PHG4SiliconTrackerDefs::SEGMENTATION_PHI};
+int nladder[4] = {15,  15, 18, 18}; 
+double sensor_radius[6] = { 8.987, 9.545, 10.835, 11.361};  // radius of center of sensor for layer default
+double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3]};
+#endif
+#ifdef INTTLADDER0
+int n_intt_layer = 0;
+#endif
 
 int n_tpc_layer_inner = 16;
 int tpc_layer_rphi_count_inner = 1152;
@@ -135,7 +133,7 @@ double Tracking(PHG4Reco* g4Reco, double radius,
       
       for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
 	{
-	  if (verbosity)
+if (verbosity)
 	    cout << "Create Maps layer " << ilayer << " with radius " << maps_layer_radius[ilayer] << " mm, stave type " << stave_type[ilayer]
 		 << " pixel size 30 x 30 microns "
 		 << " active pixel thickness 0.0018 microns" << endl;
@@ -156,13 +154,13 @@ double Tracking(PHG4Reco* g4Reco, double radius,
 	  lyr->OverlapCheck(maps_overlapcheck);
 	  
 	  lyr->set_string_param("stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v01.gdml"));
-
+	  
 	  g4Reco->registerSubsystem(lyr);
 	  
 	  radius = maps_layer_radius[ilayer];
 	}
     }
-
+  
   if (n_intt_layer > 0)
     {
       //-------------------
@@ -194,9 +192,12 @@ double Tracking(PHG4Reco* g4Reco, double radius,
       sitrack->OverlapCheck(intt_overlapcheck);
       g4Reco->registerSubsystem(sitrack);
       
-      // Update the laddertype and ladder spacing configuration
+      // Set the laddertype and ladder spacing configuration
+      cout << "INTT has " << n_intt_layer << " layers with layer setup:" << endl;
       for(int i=0;i<n_intt_layer;i++)
 	{
+	  cout << " INTT layer " << i << " laddertype " << laddertype[i] << " nladders " << nladder[i] 
+	       << " sensor radius " << sensor_radius[i] << " offsetphi " << offsetphi[i] << endl; 
 	  sitrack->set_int_param(i, "laddertype", laddertype[i]);
 	  sitrack->set_int_param(i, "nladder", nladder[i]);
 	  sitrack->set_double_param(i,"sensor_radius", sensor_radius[i]);  // expecting cm


### PR DESCRIPTION
1) Following the collaboration meeting discussion, I updated G4_Tracking.C to have predefined layer setups for the INTT. The setups are switchable using a #define variable set on line 35. Setups are provided for:
8 sublayers of type ZZ-PP-PP-PP (the default configuration) 
6 sublayers of type ZZ-PP-PP
4 sublayers of type ZZ-PP
4 sublayers of type PP-PP   
0 sublayers (INTT removed)
As committed, the configuration that is enabled is 4 sublayers of type PP-PP.

2) I added to Fun4All_G4_sPHENIX.C the option to embed multiple Upsilons in an event, where each Upsilon has a unique embed flag. This is useful when running collisions with high pileup rate, where memory limitations make it hard to run a lot of events. As committed, one Upsilon per event is used if the "upsilon" flag is set.

Note that I left alone the lines that Jin added today, which determine the pileup time window. This sets the time window to match the default drift velocity in the TPC electron drift code, which is all that we are using right now. Making it possible to update the drift velocity from a macro and then have that carry over to the pileup code would require some code changes, I think.
