### PR TITLE
Enabling INTT 4% deadmap by default

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -687,7 +687,7 @@ void Svtx_Reco(int verbosity = 0)
     }
     se->registerSubsystem(digiintt);
 
-    digiintt->Verbosity(1);
+//    digiintt->Verbosity(1);
   }
 
   // TPC layers use the Svtx digitizer

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -661,9 +661,9 @@ void Svtx_Reco(int verbosity = 0)
     for (int i = 0; i < n_intt_layer; i++)
     {
       string DeadMapConfigName = Form("LadderType%d_RndSeed%d/", laddertype[i], i);
-      string DeadMapPath =
-          string(getenv("CALIBRATIONROOT")) +
-          string("/Tracking/INTT/DeadMap_4Percent/") + DeadMapConfigName;
+      string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_4Percent/"); //4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
+//      string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_8Percent/"); // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
+      DeadMapPath +=  DeadMapConfigName;
       deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
     }
     se->registerSubsystem(deadMapINTT);
@@ -703,23 +703,24 @@ void Svtx_Reco(int verbosity = 0)
   
   //-------------------------------------
   // Apply Live Area Inefficiency to Hits
+  // This is obsolete, please use PHG4SvtxDeadMapLoader instead for pre-defined deadmap
   //-------------------------------------
   // defaults to 1.0 (fully active)
 
-  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
-
-  for (int i = 0; i < n_maps_layer; i++)
-  {
-    deadarea->Verbosity(verbosity);
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  se->registerSubsystem(deadarea);
+//  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
+//
+//  for (int i = 0; i < n_maps_layer; i++)
+//  {
+//    deadarea->Verbosity(verbosity);
+//    //deadarea->set_hit_efficiency(i,0.99);
+//    deadarea->set_hit_efficiency(i, 1.0);
+//  }
+//  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
+//  {
+//    //deadarea->set_hit_efficiency(i,0.99);
+//    deadarea->set_hit_efficiency(i, 1.0);
+//  }
+//  se->registerSubsystem(deadarea);
 
   //-----------------------------
   // Apply MIP thresholds to Hits

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -655,6 +655,19 @@ void Svtx_Reco(int verbosity = 0)
   if (n_intt_layer > 0)
   {
     // INTT
+
+    // Load pre-defined deadmaps
+    PHG4SvtxDeadMapLoader* deadMapINTT = new PHG4SvtxDeadMapLoader("SILICON_TRACKER");
+    for (int i = 0; i < n_intt_layer; i++)
+    {
+      string DeadMapConfigName = Form("LadderType%d_RndSeed%d/", laddertype[i], i);
+      string DeadMapPath =
+          string(getenv("CALIBRATIONROOT")) +
+          string("/Tracking/INTT/DeadMap_4Percent/") + DeadMapConfigName;
+      deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
+    }
+    se->registerSubsystem(deadMapINTT);
+
     std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
     // these should be used for the INTT
     userrange.push_back(0.05);
@@ -673,6 +686,8 @@ void Svtx_Reco(int verbosity = 0)
       digiintt->set_adc_scale(n_maps_layer + i, userrange);
     }
     se->registerSubsystem(digiintt);
+
+    digiintt->Verbosity(1);
   }
 
   // TPC layers use the Svtx digitizer

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -349,6 +349,20 @@ void Tracking_Reco(int verbosity = 0)
 
   if (n_intt_layer > 0)
   {
+
+    // Load pre-defined deadmaps
+    PHG4SvtxDeadMapLoader* deadMapINTT = new PHG4SvtxDeadMapLoader("SILICON_TRACKER");
+    for (int i = 0; i < n_intt_layer; i++)
+    {
+      const int database_strip_type = (laddertype[i] == PHG4SiliconTrackerDefs::SEGMENTATION_Z) ? 0 : 1;
+      string DeadMapConfigName = Form("LadderType%d_RndSeed%d/", database_strip_type, i);
+      string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_4Percent/"); //4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
+//      string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_8Percent/"); // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
+      DeadMapPath +=  DeadMapConfigName;
+      deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
+    }
+    se->registerSubsystem(deadMapINTT);
+
     // INTT
     // these should be used for the INTT
     /*

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -418,23 +418,24 @@ DAC0-7 threshold as fraction to MIP voltage are set to PHG4SiliconTrackerDigitiz
 
   //-------------------------------------
   // Apply Live Area Inefficiency to Hits
+  // This is obsolete, please use PHG4SvtxDeadMapLoader instead for pre-defined deadmap
   //-------------------------------------
   // defaults to 1.0 (fully active)
 
-  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
-
-  for (int i = 0; i < n_maps_layer; i++)
-  {
-    deadarea->Verbosity(verbosity);
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  se->registerSubsystem(deadarea);
+//  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
+//
+//  for (int i = 0; i < n_maps_layer; i++)
+//  {
+//    deadarea->Verbosity(verbosity);
+//    //deadarea->set_hit_efficiency(i,0.99);
+//    deadarea->set_hit_efficiency(i, 1.0);
+//  }
+//  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
+//  {
+//    //deadarea->set_hit_efficiency(i,0.99);
+//    deadarea->set_hit_efficiency(i, 1.0);
+//  }
+//  se->registerSubsystem(deadarea);
 
   //-----------------------------
   // Apply MIP thresholds to Hits


### PR DESCRIPTION
Following discussion in simulation meeting yesterday, enabling INTT 4% deadmap by default in the tracking macro `macros/g4simulations/G4_Tracking.C`. 

A global flag is introduced on the top of the tracking macro for tracking expert to choose which deadmap to run : 
```c++
// Dead map options for INTT
enum enu_INTTDeadMapType
{
  kINTTNoDeadMap = 0,       // All channel in INTT is alive
  kINTT4PercentDeadMap = 4, // 4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
  kINTT8PercentDeadMap = 8  // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
};

// Choose INTT deadmap here
enu_INTTDeadMapType INTTDeadMapOption = kINTT4PercentDeadMap;

```

Default is 4% dead area which was the operation condition for the FVTX detector in PHENIX. 

See also https://github.com/sPHENIX-Collaboration/coresoftware/pull/470 and https://github.com/sPHENIX-Collaboration/calibrations/pull/41 , which initially introduced this capability.