### PR TITLE
Root5 root6 combined

### DIFF
--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -1,4 +1,20 @@
-using namespace std;
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <fun4all/Fun4AllServer.h>
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawTowerCalibration.h>
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+#include <g4eval/CaloEvaluator.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
 
 void
 FEMCInit()

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -1,3 +1,22 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <fun4all/Fun4AllServer.h>
+#include <g4detectors/PHG4SectorSubsystem.h>
+#include <g4detectors/PHG4SiliconTrackerSubsystem.h>
+#include <g4hough/PHG4SiliconTrackerDigitizer.h>
+#include <g4hough/PHG4TrackFastSim.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4hough.so)
+int
+make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
+		 double etamax,  const int N_Sector = 8);
+void
+AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+#endif
 // $Id: G4_FGEM_fsPHENIX.C,v 1.2 2014/01/22 01:44:13 jinhuang Exp $                                                                                             
 
 /*!
@@ -247,7 +266,7 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
-
+  return 0;
 }
 
 void FGEM_FastSim_Reco(int verbosity = 0) {

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -1,3 +1,21 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <fun4all/Fun4AllServer.h>
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+#include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawTowerCalibration.h>
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardHcalSubsystem.h>
+#include <g4eval/CaloEvaluator.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libg4calo.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
+
 using namespace std;
 
 void

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -586,7 +586,7 @@ void Svtx_Cells(int verbosity = 0)
     string TPC_distortion_file =
         string(getenv("CALIBRATIONROOT")) +
         Form("/Tracking/TPC/SpaceChargeDistortion/TPCCAGE_20_78_211_2.root");
-    PHG4TPCSpaceChargeDistortion* tpc_distortion =
+    tpc_distortion =
         new PHG4TPCSpaceChargeDistortion(TPC_distortion_file);
     //tpc_distortion -> setAccuracy(0); // option to over write default  factors
     //tpc_distortion -> setPrecision(0.001); // option to over write default  factors      // default is 0.001

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -1,3 +1,31 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include "GlobalVariables.C"
+#include <fun4all/Fun4AllServer.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4CylinderCellTPCReco.h>
+#include <g4detectors/PHG4MapsCellReco.h>
+#include <g4detectors/PHG4MapsSubsystem.h>
+#include <g4detectors/PHG4SiliconTrackerCellReco.h>
+#include <g4detectors/PHG4SiliconTrackerDefs.h>
+#include <g4detectors/PHG4SiliconTrackerSubsystem.h>
+#include <g4detectors/PHG4TPCSpaceChargeDistortion.h>
+#include <g4eval/SvtxEvaluator.h>
+#include <g4hough/PHG4GenFitTrackProjection.h>
+#include <g4hough/PHG4KalmanPatRec.h>
+#include <g4hough/PHG4SiliconTrackerDigitizer.h>
+#include <g4hough/PHG4SvtxClusterizer.h>
+#include <g4hough/PHG4SvtxDeadArea.h>
+#include <g4hough/PHG4SvtxDigitizer.h>
+#include <g4hough/PHG4SvtxThresholds.h>
+#include <g4hough/PHG4TPCClusterizer.h>
+#include <g4hough/PHG4TrackKalmanFitter.h>
+#include <g4hough/PHG4TruthPatRec.h>
+#include <g4main/PHG4Reco.h>
+R__LOAD_LIBRARY(libg4hough.so)
+R__LOAD_LIBRARY(libg4eval.so)
+#endif
+
 #include <vector>
 
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
@@ -538,6 +566,7 @@ void Svtx_Cells(int verbosity = 0)
     PHG4SiliconTrackerCellReco* reco = new PHG4SiliconTrackerCellReco("SILICON_TRACKER");
     // The timing windows are hard-coded in the INTT ladder model
     reco->Verbosity(verbosity);
+    reco->checkenergy(1);
     se->registerSubsystem(reco);
   }
 
@@ -671,7 +700,7 @@ void Svtx_Reco(int verbosity = 0)
       DeadMapPath +=  DeadMapConfigName;
       deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
     }
-    se->registerSubsystem(deadMapINTT);
+//    se->registerSubsystem(deadMapINTT);
 
     std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
     // these should be used for the INTT


### PR DESCRIPTION
this fixes a bug in the G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C which lead to some numerical diffs in the tpc cells. The distortion correction wasn't applied when running under root6 since the class went out of scope (as it should in this construct)