### PR TITLE
Tuned E864_fEMC sampling fraction

### DIFF
--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -148,7 +148,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration3->TowerType(3);
   TowerCalibration3->Verbosity(verbosity);
   TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.03084);  // sampling fraction = 0.03084 
+  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030 
   TowerCalibration3->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration3 );
 
@@ -157,7 +157,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration4->TowerType(4);
   TowerCalibration4->Verbosity(verbosity);
   TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.03084);  // sampling fraction = 0.03084
+  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
   TowerCalibration4->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration4 );
 
@@ -166,7 +166,7 @@ void FEMC_Towers(int verbosity = 0) {
   TowerCalibration5->TowerType(5);
   TowerCalibration5->Verbosity(verbosity);
   TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.03084);  // sampling fraction = 0.03084
+  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
   TowerCalibration5->set_pedstal_ADC(0);
   se->registerSubsystem( TowerCalibration5 );
 


### PR DESCRIPTION
Adjusted the sampling fraction to 3%. 

Here's the fEMC tower energy sum for a sample of 30GeV incident photons 1.3 < eta < 3.0: 

![femc_sum](https://user-images.githubusercontent.com/3042746/50383665-45e82b00-067e-11e9-9c83-f695c7ddf86a.png)

and here's the distribution of the highest energy cluster in each of t he same events: 

![cluster](https://user-images.githubusercontent.com/3042746/50383672-5ac4be80-067e-11e9-835a-3f3275271d5e.png)
