### PR TITLE
make it work under root6

### DIFF
--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -9,19 +9,20 @@
 #include "G4_HcalOut_ref.C"
 #include "G4_PlugDoor.C"
 
-#include <g4eval/PHG4DstCompressReco.h>
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <g4decayer/EDecayType.hh>
 #include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/HepMCNodeReader.h>
+#include <g4eval/PHG4DstCompressReco.h>
 #include <g4main/PHG4TruthSubsystem.h>
 #include <g4main/PHG4Reco.h>
 #include <phfield/PHFieldConfig.h>
-#include <g4main/HepMCNodeReader.h>
 class SubsysReco;
 R__LOAD_LIBRARY(libg4decayer.so)
 R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libphg4hit.so)
 #else
 bool overlapcheck = false; // set to true if you want to check for overlaps
 double no_overlapp = 0.0001; // added to radii to avoid overlapping volumes

--- a/macros/g4simulations/G4_HIJetReco.C
+++ b/macros/g4simulations/G4_HIJetReco.C
@@ -83,7 +83,7 @@ void HIJetReco(int verbosity = 0, bool do_flow = false, bool do_CS = false ) {
   st->Verbosity( verbosity );
   se->registerSubsystem( st );
 
-  JetReco *towerjetreco = new JetReco();
+  towerjetreco = new JetReco();
   towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER_SUB1));
   towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER_SUB1));
   towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER_SUB1));

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -5,7 +5,6 @@
 #include <g4intt/PHG4INTTCellReco.h>
 #include <g4intt/PHG4INTTDefs.h>
 #include <g4intt/PHG4INTTSubsystem.h>
-#include <g4detectors/PHG4TPCSpaceChargeDistortion.h>
 #include <g4eval/SvtxEvaluator.h>
 #include <g4hough/PHG4GenFitTrackProjection.h>
 #include <g4hough/PHG4KalmanPatRec.h>
@@ -17,6 +16,7 @@
 #include <g4tpc/PHG4TPCElectronDrift.h>
 #include <g4tpc/PHG4TPCPadPlane.h>
 #include <g4tpc/PHG4TPCPadPlaneReadout.h>
+#include <g4tpc/PHG4TPCSpaceChargeDistortion.h>
 #include <g4tpc/PHG4TPCSubsystem.h>
 #include <g4mvtx/PHG4MVTXCellReco.h>
 #include <g4mvtx/PHG4MVTXSubsystem.h>
@@ -30,8 +30,11 @@ R__LOAD_LIBRARY(libg4tpc.so)
 R__LOAD_LIBRARY(libg4intt.so)
 R__LOAD_LIBRARY(libg4mvtx.so)
 R__LOAD_LIBRARY(libg4hough.so)
-R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libintt.so)
+R__LOAD_LIBRARY(libmvtx.so)
+R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libtrack_reco.so)
 #endif
 
 #include <vector>
@@ -376,6 +379,7 @@ void Tracking_Reco(int verbosity = 0)
   if (n_intt_layer > 0)
   {
 
+#ifdef SVTXDEADMAP
     if (INTTDeadMapOption != kINTTNoDeadMap)
     {
       // Load pre-defined deadmaps
@@ -411,6 +415,7 @@ void Tracking_Reco(int verbosity = 0)
 //      deadMapINTT -> Verbosity(1);
       se->registerSubsystem(deadMapINTT);
     }
+#endif // SVTXDEADMAP
 
     // INTT
     // these should be used for the INTT


### PR DESCRIPTION
small macro fixes for root6, the main change is an
#ifdef SVTXDEADMAP
around the PHG4SvtxDeadMapLoader since  this class does not exist and cling refuses to accept missing classes in a macro. With the PR in the coresoftware this show runs under root6 again