### PR TITLE
Accumulated fixes on the EIC/fsPHENIX fast tracking module - macros repository

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -80,9 +80,9 @@ int Fun4All_G4_EICDetector(
 
   // Besides the above flags. One can further choose to further put in following particles in Geant4 simulation
   // Use multi-particle generator (PHG4SimpleEventGenerator), see the code block below to choose particle species and kinematics
-  const bool particles = false && !readhits;
+  const bool particles = true && !readhits;
   // or gun/ very simple single particle gun generator
-  const bool usegun = true && !readhits;
+  const bool usegun = false && !readhits;
   // Throw single Upsilons, may be embedded in Hijing by setting readhepmc flag also  (note, careful to set Z vertex equal to Hijing events)
   const bool upsilons = false && !readhits;
 
@@ -91,14 +91,14 @@ int Fun4All_G4_EICDetector(
   //======================
 
   // sPHENIX barrel
-  bool do_bbc = false;
+  bool do_bbc = true;
 
   bool do_pipe = true;
 
-  bool do_svtx = true;
-  bool do_svtx_cell = do_svtx && true;
-  bool do_svtx_track = do_svtx_cell && true;
-  bool do_svtx_eval = do_svtx_track && false; // in order to use this evaluation, please build this analysis module analysis/blob/master/Tracking/FastTrackingEval/
+  bool do_tracking = true;
+  bool do_tracking_cell = do_tracking && true;
+  bool do_tracking_track = do_tracking_cell && true;
+  bool do_tracking_eval = do_tracking_track && true; // in order to use this evaluation, please build this analysis module analysis/blob/master/Tracking/FastTrackingEval/
 
   bool do_pstof = false;
 
@@ -188,7 +188,7 @@ int Fun4All_G4_EICDetector(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_EICDetector.C");
-  G4Init(do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel);
+  G4Init(do_tracking,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel);
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
@@ -200,7 +200,7 @@ int Fun4All_G4_EICDetector(
   //---------------
 
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(0); // uncomment for batch production running with minimal output messages
+//  se->Verbosity(01); // uncomment for batch production running with minimal output messages
   // se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // uncomment for some info for interactive running
 
   // just if we set some flags somewhere in this macro
@@ -311,7 +311,7 @@ int Fun4All_G4_EICDetector(
         }
       gen->set_vertex_size_function(PHG4SimpleEventGenerator::Uniform);
       gen->set_vertex_size_parameters(0.0, 0.0);
-      gen->set_eta_range(-1.0, 1.0);
+      gen->set_eta_range(-3, 3);
       gen->set_phi_range(-1.0 * TMath::Pi(), 1.0 * TMath::Pi());
       //gen->set_pt_range(0.1, 50.0);
       gen->set_pt_range(0.1, 20.0);
@@ -394,12 +394,12 @@ int Fun4All_G4_EICDetector(
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
       G4Setup(absorberactive, magfield, EDecayType::kAll,
-              do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,
+              do_tracking,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,
               do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel,
               magfield_rescale);
 #else
       G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-              do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,
+              do_tracking,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_plugdoor,
               do_FEMC,do_FHCAL,do_EEMC,do_DIRC,do_RICH,do_Aerogel,
               magfield_rescale);
 #endif
@@ -421,7 +421,7 @@ int Fun4All_G4_EICDetector(
   // Detector Division
   //------------------
 
-  if (do_svtx_cell) Svtx_Cells();
+  if (do_tracking_cell) Svtx_Cells();
 
   if (do_cemc_cell) CEMC_Cells();
 
@@ -471,7 +471,7 @@ int Fun4All_G4_EICDetector(
   // SVTX tracking
   //--------------
 
-  if (do_svtx_track) Tracking_Reco();
+  if (do_tracking_track) Tracking_Reco();
 
   //-----------------
   // Global Vertexing
@@ -523,9 +523,7 @@ int Fun4All_G4_EICDetector(
   //----------------------
   // Simulation evaluation
   //----------------------
-// commented out because
-// Fast_Tracking_Eval function uses a library which is not part of our build
-//  if (do_svtx_eval) Fast_Tracking_Eval(string(outputFile) + "_g4svtx_eval.root");
+  if (do_tracking_eval) Tracking_Eval(string(outputFile) + "_g4tracking_eval.root");
 
   if (do_cemc_eval) CEMC_Eval(string(outputFile) + "_g4cemc_eval.root");
 
@@ -575,7 +573,7 @@ int Fun4All_G4_EICDetector(
 
       G4DSTreader_EICDetector( outputFile, //
                                /*int*/ absorberactive ,
-                               /*bool*/ do_svtx ,
+                               /*bool*/ do_tracking ,
                                /*bool*/ do_cemc ,
                                /*bool*/ do_hcalin ,
                                /*bool*/ do_magnet ,

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -70,11 +70,13 @@ int Fun4All_G4_fsPHENIX(
   
   bool do_pipe = true;
   
-  bool do_svtx = true;
-  bool do_svtx_cell = do_svtx && true;
-  bool do_svtx_track = do_svtx_cell && true;
-  bool do_svtx_eval = do_svtx_track && false;
+  // central tracking
+  bool do_tracking = true;
+  bool do_tracking_cell = do_tracking && true;
+  bool do_tracking_track = do_tracking_cell && true;
+  bool do_tracking_eval = do_tracking_track && true;
 
+  // central calorimeters, which is a detailed simulation and slow to run
   bool do_cemc = true;
   bool do_cemc_cell = do_cemc && true;
   bool do_cemc_twr = do_cemc_cell && true;
@@ -137,7 +139,7 @@ int Fun4All_G4_fsPHENIX(
 
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_fsPHENIX.C");
-  G4Init(do_svtx,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_FEMC,do_FHCAL,n_TPC_layers);
+  G4Init(do_tracking,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_FEMC,do_FHCAL,n_TPC_layers);
 
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
@@ -156,7 +158,7 @@ int Fun4All_G4_fsPHENIX(
 
   Fun4AllServer *se = Fun4AllServer::instance();
 //  se->Verbosity(0); // uncomment for batch production running with minimal output messages
-  se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // uncomment for some info for interactive running
+//  se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // uncomment for some info for interactive running
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();
   // By default every random number generator uses
@@ -167,7 +169,7 @@ int Fun4All_G4_fsPHENIX(
   // this would be:
   //  rc->set_IntFlag("RANDOMSEED",PHRandomSeed());
   // or set it to a fixed value so you can debug your code
-  // rc->set_IntFlag("RANDOMSEED", 12345);
+//   rc->set_IntFlag("RANDOMSEED", 12345);
 
   //-----------------
   // Event generation
@@ -241,12 +243,12 @@ int Fun4All_G4_fsPHENIX(
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
       G4Setup(absorberactive, magfield, EDecayType::kAll,
-	      do_svtx, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,
+	      do_tracking, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,
 	      do_FGEM, do_FEMC, do_FHCAL,
 	      magfield_rescale);
 #else
       G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-	      do_svtx, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,
+	      do_tracking, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,
 	      do_FGEM, do_FEMC, do_FHCAL,
 	      magfield_rescale);
 #endif
@@ -267,7 +269,7 @@ int Fun4All_G4_fsPHENIX(
   // Detector Division
   //------------------
 
-  if (do_svtx_cell) Tracking_Cells();
+  if (do_tracking_cell) Tracking_Cells();
 
   if (do_cemc_cell) CEMC_Cells();
 
@@ -307,7 +309,7 @@ int Fun4All_G4_fsPHENIX(
   // SVTX tracking
   //--------------
 
-  if (do_svtx_track) Tracking_Reco();
+  if (do_tracking_track) Tracking_Reco();
 
   //--------------
   // FGEM tracking
@@ -350,7 +352,7 @@ int Fun4All_G4_fsPHENIX(
   // Simulation evaluation
   //----------------------
 
-  if (do_svtx_eval) Tracking_Eval("g4svtx_eval.root");
+  if (do_tracking_eval) Tracking_Eval("g4tracking_eval.root");
 
   if (do_cemc_eval) CEMC_Eval("g4cemc_eval.root");
 
@@ -362,7 +364,7 @@ int Fun4All_G4_fsPHENIX(
 
   if (do_fwd_jet_eval) Jet_FwdEval("g4fwdjet_eval.root");
 
-  if (do_FGEM_eval) FGEM_FastSim_Reco("g4fwdjet_eval.root");
+  if (do_FGEM_eval) FGEM_FastSim_Eval("g4tracking_fgem_eval.root");
 
   //-------------- 
   // IO management
@@ -409,7 +411,7 @@ int Fun4All_G4_fsPHENIX(
 
       G4DSTreader_fsPHENIX( outputFile, //
           /*int*/ absorberactive ,
-          /*bool*/ do_svtx ,
+          /*bool*/ do_tracking ,
           /*bool*/ do_cemc ,
           /*bool*/ do_hcalin ,
           /*bool*/ do_magnet ,

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -108,6 +108,7 @@ int Fun4All_G4_fsPHENIX(
 
   bool do_FGEM = true;
   bool do_FGEM_track = do_FGEM &&  true;
+  bool do_FGEM_eval = do_FGEM_track &&  true;
 
   bool do_FEMC = true;
   bool do_FEMC_cell = do_FEMC && true;
@@ -141,7 +142,7 @@ int Fun4All_G4_fsPHENIX(
   int absorberactive = 0; // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
   const string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root"); // default map from the calibration database
-  const float magfield_rescale = 1.0; // already adjusted to 1.4T central field
+  const float magfield_rescale = -1.4/1.5; // make consistent with Fun4All_G4_sPHENIX()
 
   //---------------
   // Fun4All server
@@ -360,6 +361,8 @@ int Fun4All_G4_fsPHENIX(
   if (do_jet_eval) Jet_Eval("g4jet_eval.root");
 
   if (do_fwd_jet_eval) Jet_FwdEval("g4fwdjet_eval.root");
+
+  if (do_FGEM_eval) FGEM_FastSim_Reco("g4fwdjet_eval.root");
 
   //-------------- 
   // IO management

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -147,6 +147,12 @@ int Fun4All_G4_fsPHENIX(
   // Fun4All server
   //---------------
 
+  bool display_on = false;
+  if(display_on)
+    {
+      gROOT->LoadMacro("DisplayOn.C");
+    }
+
   Fun4AllServer *se = Fun4AllServer::instance();
 //  se->Verbosity(0); // uncomment for batch production running with minimal output messages
   se->Verbosity(Fun4AllServer::VERBOSITY_SOME); // uncomment for some info for interactive running
@@ -260,7 +266,7 @@ int Fun4All_G4_fsPHENIX(
   // Detector Division
   //------------------
 
-  if (do_svtx_cell) Svtx_Cells();
+  if (do_svtx_cell) Tracking_Cells();
 
   if (do_cemc_cell) CEMC_Cells();
 
@@ -300,7 +306,7 @@ int Fun4All_G4_fsPHENIX(
   // SVTX tracking
   //--------------
 
-  if (do_svtx_track) Svtx_Reco();
+  if (do_svtx_track) Tracking_Reco();
 
   //--------------
   // FGEM tracking
@@ -343,7 +349,7 @@ int Fun4All_G4_fsPHENIX(
   // Simulation evaluation
   //----------------------
 
-  if (do_svtx_eval) Svtx_Eval("g4svtx_eval.root");
+  if (do_svtx_eval) Tracking_Eval("g4svtx_eval.root");
 
   if (do_cemc_eval) CEMC_Eval("g4cemc_eval.root");
 
@@ -420,51 +426,42 @@ int Fun4All_G4_fsPHENIX(
   //if (do_dst_compress) DstCompress(out);
   //se->registerOutputManager(out);
 
-  if (nEvents == 0 && !readhits && !readhepmc)
-    {
-      cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
-      cout << "it will run forever, so I just return without running anything" << endl;
-      return 0;
-    }
-
+  //-----------------
+  // Event processing
+  //-----------------
   if (nEvents < 0)
-    {
-      PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
-      g4->ApplyCommand("/control/execute vis.mac");
-      //g4->StartGui();
-      se->run(1);
-
-      se->End();
-      std::cout << "All done" << std::endl;
-
-
-      std::cout << "==== Useful display commands ==" << std::endl;
-      cout << "draw axis: " << endl;
-      cout << " G4Cmd(\"/vis/scene/add/axes 0 0 0 50 cm\")" << endl;
-      cout << "zoom" << endl;
-      cout << " G4Cmd(\"/vis/viewer/zoom 1\")" << endl;
-      cout << "viewpoint:" << endl;
-      cout << " G4Cmd(\"/vis/viewer/set/viewpointThetaPhi 0 0\")" << endl;
-      cout << "panTo:" << endl;
-      cout << " G4Cmd(\"/vis/viewer/panTo 0 0 cm\")" << endl;
-      cout << "print to eps:" << endl;
-      cout << " G4Cmd(\"/vis/ogl/printEPS\")" << endl;
-      cout << "set background color:" << endl;
-      cout << " G4Cmd(\"/vis/viewer/set/background white\")" << endl;
-      std::cout << "===============================" << std::endl;
-    }
-  else
-    {
-
-      se->run(nEvents);
-
-      se->End();
-      std::cout << "All done" << std::endl;
-      delete se;
-      gSystem->Exit(0);
-      return 0;
-    }
+  {
     return 0;
+  }
+  // if we run the particle generator and use 0 it'll run forever
+  if (nEvents == 0 && !readhits && !readhepmc)
+  {
+    cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
+    cout << "it will run forever, so I just return without running anything" << endl;
+    return 0;
+  }
+
+  if(display_on)
+    {
+      DisplayOn();
+      // prevent macro from finishing so can see display
+      int i;
+      cout << "***** Enter any integer to proceed" << endl;
+      cin >> i;
+    }
+
+  se->run(nEvents);
+
+  //-----
+  // Exit
+  //-----
+
+
+  se->End();
+  std::cout << "All done" << std::endl;
+  delete se;
+  gSystem->Exit(0);
+  return 0;
 }
 
 

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -2,7 +2,7 @@
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include "GlobalVariables.C"
 #include "G4_Pipe.C"
-#include "G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C"
+#include "G4_Tracking.C"
 #include "G4_CEmc_Spacal.C"
 #include "G4_HcalIn_ref.C"
 #include "G4_Magnet.C"
@@ -47,8 +47,8 @@ void G4Init(bool do_svtx = true,
     }
   if (do_svtx)
     {
-      gROOT->LoadMacro("G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C"); 
-      SvtxInit(n_TPC_layers);
+      gROOT->LoadMacro("G4_Tracking.C");
+      TrackingInit(n_TPC_layers);
     }
 
   if (do_cemc)
@@ -167,7 +167,7 @@ int G4Setup(const int absorberactive = 0,
   
   //----------------------------------------
   // SVTX
-  if (do_svtx) radius = Svtx(g4Reco, radius, absorberactive);
+  if (do_svtx) radius = Tracking(g4Reco, radius, absorberactive);
 
   //----------------------------------------
   // CEMC
@@ -208,7 +208,7 @@ int G4Setup(const int absorberactive = 0,
   if ( do_FHCAL )
     FHCALSetup(g4Reco, absorberactive);
 
-  // sPHENIX forward flux return(s)
+  // sPHENIX forward flux return(s) with reduced thickness
   PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FWDFLUXRET", 0);
   flux_return_plus->set_int_param("lengthviarapidity",0);
   flux_return_plus->set_double_param("length",10.2);

--- a/macros/g4simulations/G4Setup_fsPHENIX.C
+++ b/macros/g4simulations/G4Setup_fsPHENIX.C
@@ -235,11 +235,13 @@ int G4Setup(const int absorberactive = 0,
 
   //----------------------------------------
   // piston magnet
-  make_piston("magpiston", g4Reco);
+//  make_piston("magpiston", g4Reco);
 
   //----------------------------------------
   // BLACKHOLE
-  
+  // minimal space for forward instrumentation
+  if (radius<270) radius = 270;
+
   // swallow all particles coming out of the backend of sPHENIX
   PHG4CylinderSubsystem *blackhole = new PHG4CylinderSubsystem("BH", 1);
 blackhole->set_double_param("radius",radius + 10); // add 10 cm

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -272,11 +272,6 @@ void FGEM_FastSim_Reco(int verbosity = 0)
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
 
-//  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
-  kalman->set_fit_alg_name("DafRef");  //
-  kalman->set_primary_assumption_pid(13);
-  kalman->set_do_evt_display(false);
-
   //   MAPS in MVTX detector
   kalman->add_phg4hits(
       "G4HIT_MVTX",                //      const std::string& phg4hitsNames,

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -300,7 +300,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
 
   // MAPS
   kalman->add_phg4hits(
-      "G4HIT_MAPS",                //      const std::string& phg4hitsNames,
+      "G4HIT_MVTX",                //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
       5e-4,                        //      const float radres,
       5e-4,                        //      const float phires,
@@ -379,7 +379,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
   se->registerSubsystem(kalman);
 }
 
-void Fast_Tracking_Eval(std::string outputfile, int verbosity = 0)
+void FGEM_FastSim_Eval(std::string outputfile, int verbosity = 0)
 {
   gSystem->Load("libfun4all.so");
   gSystem->Load("libg4trackfastsim.so");

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -302,7 +302,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
       "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
       1. / sqrt(12),                     //      const float radres,
-      70 - 4,                            //      const float phires,
+      70e-4,                            //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -269,14 +269,14 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
   return 0;
 }
 
-void FGEM_FastSim_Reco(int verbosity = 0) {
-
+void FGEM_FastSim_Reco(int verbosity = 0)
+{
   //---------------
   // Load libraries
   //---------------
 
   gSystem->Load("libfun4all.so");
-  gSystem->Load("libg4hough.so");
+  gSystem->Load("libg4trackfastsim.so");
 
   //---------------
   // Fun4All server
@@ -284,34 +284,111 @@ void FGEM_FastSim_Reco(int verbosity = 0) {
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  PHG4TrackFastSim* kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
-  kalman->Verbosity(0);
+  PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
+  kalman->Verbosity(verbosity);
 
   kalman->set_use_vertex_in_fitting(true);
   kalman->set_vertex_xy_resolution(50E-4);
   kalman->set_vertex_z_resolution(50E-4);
 
-  kalman->set_detector_type(PHG4TrackFastSim::Vertical_Plane); // Vertical_Plane, Cylinder
-  kalman->set_phi_resolution(50E-4);
-  kalman->set_r_resolution(1.);
-
-  kalman->set_pat_rec_hit_finding_eff(1.);
-  kalman->set_pat_rec_noise_prob(0.);
-
-  std::string phg4hits_names[] = {"G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
-  kalman->set_phg4hits_names(phg4hits_names, 5);
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
 
-  // Saved track states (projections)
-  std::string state_names[] = {"FEMC","FHCAL"};
-  kalman->set_state_names(state_names, 2);
-
-  kalman->set_fit_alg_name("KalmanFitterRefTrack");//
+  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
   kalman->set_primary_assumption_pid(13);
   kalman->set_do_evt_display(false);
 
-  se->registerSubsystem(kalman);
+  // MAPS
+  kalman->add_phg4hits(
+      "G4HIT_MAPS",                //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                        //      const float radres,
+      5e-4,                        //      const float phires,
+      5e-4,                        //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
 
+  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12),                     //      const float radres,
+      70 - 4,                            //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12),                     //      const float radres,
+      70 - 4,                            //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // TPC
+  kalman->add_phg4hits(
+      "G4HIT_TPC",                 //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      1,                           //      const float radres,
+      200e-4,                      //      const float phires,
+      500e-4,                      //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
+
+  // GEM2, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12),                     //      const float radres,
+      70 - 4,                            //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM3, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12),                     //      const float radres,
+      70 - 4,                            //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM4, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12),                     //      const float radres,
+      70 - 4,                            //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // Saved track states (projections)
+  kalman->add_state_name("FEMC");
+  kalman->add_state_name("FHCAL");
+
+  se->registerSubsystem(kalman);
 }
 
+void Fast_Tracking_Eval(std::string outputfile, int verbosity = 0)
+{
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4trackfastsim.so");
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
+  fast_sim_eval->set_filename(outputfile.c_str());
+  se->registerSubsystem(fast_sim_eval);
+
+  return;
+}

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -272,7 +272,8 @@ void FGEM_FastSim_Reco(int verbosity = 0)
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
 
-  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
+//  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
+  kalman->set_fit_alg_name("DafRef");  //
   kalman->set_primary_assumption_pid(13);
   kalman->set_do_evt_display(false);
 

--- a/macros/g4simulations/G4_FGEM_fsPHENIX.C
+++ b/macros/g4simulations/G4_FGEM_fsPHENIX.C
@@ -1,23 +1,21 @@
 #pragma once
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
-#include "GlobalVariables.C"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
 #include <fun4all/Fun4AllServer.h>
 #include <g4detectors/PHG4SectorSubsystem.h>
 #include <g4detectors/PHG4SiliconTrackerSubsystem.h>
+#include <g4eval/SvtxEvaluator.h>
 #include <g4hough/PHG4SiliconTrackerDigitizer.h>
 #include <g4hough/PHG4TrackFastSim.h>
-#include <g4eval/SvtxEvaluator.h>
 #include <g4main/PHG4Reco.h>
+#include "GlobalVariables.C"
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4hough.so)
-int
-make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-		 double etamax,  const int N_Sector = 8);
-void
-AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8);
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
 #endif
-// $Id: G4_FGEM_fsPHENIX.C,v 1.2 2014/01/22 01:44:13 jinhuang Exp $                                                                                             
+// $Id: G4_FGEM_fsPHENIX.C,v 1.2 2014/01/22 01:44:13 jinhuang Exp $
 
 /*!
  * \file G4_FGEM_fsPHENIX.C
@@ -29,18 +27,14 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
 
 using namespace std;
 
-void
-FGEM_Init()
+void FGEM_Init()
 {
-
 }
 
-void
-FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-    const double min_eta = 1.45 //
-    )
+void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
+               const double min_eta = 1.45                //
+)
 {
-
   const double tilt = .1;
 
   string name;
@@ -105,15 +99,10 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
-  zpos = zpos
-      - (zpos * sin(tilt)
-          + zpos * cos(tilt)
-              * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-          * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
 
   gem->get_geometry().set_normal_polar_angle(
-      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-          + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
   gem->get_geometry().set_normal_start(
       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
@@ -156,18 +145,13 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
 
-  zpos = zpos
-      - (zpos * sin(tilt)
-          + zpos * cos(tilt)
-              * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-          * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
 
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
   gem->get_geometry().set_normal_polar_angle(
-      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-          + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
   gem->get_geometry().set_normal_start(
       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
@@ -186,12 +170,10 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   g4Reco->registerSubsystem(gem);
 
   ///////////////////////////////////////////////////////////////////////////
-
 }
 
 //! Add drift layers to mini TPC
-void
-AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
 {
   assert(gem);
 
@@ -199,49 +181,45 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
 
-//  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
-  const int N_Layers = 1; // simplified setup
+  //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
+  const int N_Layers = 1;  // simplified setup
   const double thickness = 2 * cm;
 
   gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false,
-      100);
+                               100);
   gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
 
   for (int d = 1; d <= N_Layers; d++)
-    {
-      stringstream s;
-      s << "DriftLayer_";
-      s << d;
+  {
+    stringstream s;
+    s << "DriftLayer_";
+    s << d;
 
-      gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
-          true);
-
-    }
+    gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
+                                 true);
+  }
 }
 
-int
-make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-    double etamax,  const int N_Sector = 8)
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8)
 {
-
-//  cout
-//      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
-//      << name << endl;
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
 
   double polar_angle = 0;
 
   if (zpos < 0)
-    {
-      zpos = -zpos;
-      polar_angle = TMath::Pi();
-
-    }
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
   if (etamax < etamin)
-    {
-      double t = etamax;
-      etamax = etamin;
-      etamin = t;
-    }
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
 
   PHG4SectorSubsystem *gem;
   gem = new PHG4SectorSubsystem(name.c_str());
@@ -298,7 +276,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
   kalman->set_primary_assumption_pid(13);
   kalman->set_do_evt_display(false);
 
-  // MAPS
+  //   MAPS in MVTX detector
   kalman->add_phg4hits(
       "G4HIT_MVTX",                //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
@@ -314,7 +292,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
       "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
       1. / sqrt(12),                     //      const float radres,
-      70 - 4,                            //      const float phires,
+      70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
@@ -346,7 +324,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
       "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
       1. / sqrt(12),                     //      const float radres,
-      70 - 4,                            //      const float phires,
+      70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
@@ -356,7 +334,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
       "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
       1. / sqrt(12),                     //      const float radres,
-      70 - 4,                            //      const float phires,
+      70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
@@ -366,7 +344,7 @@ void FGEM_FastSim_Reco(int verbosity = 0)
       "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
       1. / sqrt(12),                     //      const float radres,
-      70 - 4,                            //      const float phires,
+      70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -67,7 +67,8 @@ FHCALSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 void FHCAL_Towers(int verbosity = 0) {
 
   gSystem->Load("libfun4all.so");
-  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4calo.so");
+  gSystem->Load("libcalo_reco.so");
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_fhcal;

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -47,52 +47,6 @@ int nladder[4] = {34, 30, 36, 42};  // default
 double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};  // inner staggered radius for layer default
 double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};  // outer staggered radius for layer  default
 
-// Optionally reconfigure the INTT
-//========================================================================
-// example re-configurations of INTT - uncomment one to get the reconfiguration
-// n_intt must be 0-4, setting it to zero will remove the INTT completely,  otherwise it gives you n layers
-//========================================================================
-/*
-// Four layers, laddertypes 1-1-0-1
-n_intt_layer = 4;
-laddertype[0] = 1;    laddertype[1] = 1;  laddertype[2] = 0; laddertype[3] = 1; 
-nladder[0] = 22;       nladder[1] = 30;  nladder[2] = 52;  nladder[3] = 42;
-sensor_radius_inner[0] = 6.876; sensor_radius_inner[1] = 8.987; sensor_radius_inner[2] = 10.835;    sensor_radius_inner[3] = 12.676; 
-sensor_radius_outer[0] = 7.462; sensor_radius_outer[1] = 9.545; sensor_radius_outer[2] = 11.361;    sensor_radius_outer[3] = 13.179; 
-*/
-/*
-// Three outer layers, laddertypes 1-0-1 
-n_intt_layer = 3;
-laddertype[0] = 1;    laddertype[1] = 0;  laddertype[2] = 1;
-nladder[0] = 30;  nladder[1] = 52;  nladder[2] = 42;
-sensor_radius_inner[0] = 8.987; sensor_radius_inner[1] = 10.835;    sensor_radius_inner[2] = 12.676; 
-sensor_radius_outer[0] = 9.545; sensor_radius_outer[1] = 11.361;    sensor_radius_outer[2] = 13.179; 
-*/
-/*
-// Three outer layers, laddertypes 1-1-1 
-n_intt_layer = 3;
-laddertype[0] = 1;    laddertype[1] = 1;  laddertype[2] = 1;
-nladder[0] = 30;  nladder[1] = 36;  nladder[2] = 42;
-sensor_radius_inner[0] = 8.987; sensor_radius_inner[1] = 10.835;    sensor_radius_inner[2] = 12.676; 
-sensor_radius_outer[0] = 9.545; sensor_radius_outer[1] = 11.361;    sensor_radius_outer[2] = 13.179; 
-*/
-/*
-// Two outer layers, laddertype 0-1
-n_intt_layer = 2;
-laddertype[0] = 0;    laddertype[1] = 1; 
-nladder[0] = 52;       nladder[1] = 42;
-sensor_radius_inner[0] = 10.835;    sensor_radius_inner[1] = 12.676; 
-sensor_radius_outer[0] = 11.361;    sensor_radius_outer[1] = 13.179; 
-*/
-/*
-// Two outer layers, laddertype 1-1
-n_intt_layer = 2;
-laddertype[0] = 1;    laddertype[1] = 1; 
-nladder[0] = 36;       nladder[1] = 42;
-sensor_radius_inner[0] = 10.835;    sensor_radius_inner[1] = 12.676; 
-sensor_radius_outer[0] = 11.361;    sensor_radius_outer[1] = 13.179; 
-*/
-
 int n_tpc_layer_inner = 16;
 double tpc_layer_thick_inner = 1.25; // EIC- recover default inner radius of TPC vol.
 int tpc_layer_rphi_count_inner = 1152;
@@ -165,6 +119,7 @@ double TPC_SmearZ;
 int Max_si_layer;
 
 void SvtxInit(int verbosity = 0)
+{
 {
   Max_si_layer = n_maps_layer + n_intt_layer + n_gas_layer;
 
@@ -285,12 +240,16 @@ double Svtx(PHG4Reco* g4Reco, double radius,
       // MAPS inner barrel layers
       //======================================================
       
-      double maps_layer_radius[3] = {24.61, 32.59, 39.88}; // mm - numbers from Walt 6 Aug 2018
-      
+      // Y. Corrales Morales 4Feb2019
+      // New MVTX configuration to give 2.0 mm clearance from sPHENIX beam-pipe (Walt 3 Jan 2018)
+      //TODO: Add function to estimate stave tilt angle from values given by Walt (Rmin, Rmid, Rmax and sensor width)
+      //TODO: Add default values in PHG4MVTXSubsystem or PHG4MVTXDetector
+      double maps_layer_radius[3] = {25.69, 33.735, 41.475}; // mm - numbers from Walt 3 Jan 2019 (Rmid)
+      double phi_tilt[3] = {0.295, 0.303, 0.298};  // radians - numbers calculated from values given by Walt 3 Jan 2019
+
       // D. McGlinchey 6Aug2018 - type no longer is used, included here because I was too lazy to remove it from the code
       int stave_type[3] = {0, 0, 0};
       int staves_in_layer[3] = {12, 16, 20};       // Number of staves per layer in sPHENIX MVTX
-      double phi_tilt[3] = {0.300, 0.305, 0.300}; // radians - numbers from Walt 6 Aug 2018
       
       for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
 	{
@@ -299,7 +258,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 		 << " pixel size 30 x 30 microns "
 		 << " active pixel thickness 0.0018 microns" << endl;
 	  
-	  PHG4MapsSubsystem* lyr = new PHG4MapsSubsystem("MAPS", ilayer, stave_type[ilayer]);
+	  PHG4MVTXSubsystem* lyr = new PHG4MVTXSubsystem("MVTX", ilayer, stave_type[ilayer]);
 	  lyr->Verbosity(verbosity);
 	  
 	  lyr->set_double_param("layer_nominal_radius", maps_layer_radius[ilayer]);  // thickness in cm
@@ -314,7 +273,6 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 	  lyr->set_int_param("active", 1);
 	  lyr->OverlapCheck(maps_overlapcheck);
 	  
-	  //lyr->set_string_param("stave_geometry_file", "/phenix/hhj3/dcm07e/sPHENIX/macros/macros/g4simulations/mvtx_stave_v01.gdml");
 	  lyr->set_string_param("stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v01.gdml"));
 
 	  g4Reco->registerSubsystem(lyr);
@@ -323,52 +281,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 	}
     }
   
-  if (n_intt_layer > 0)
-    {
-      //-------------------
-      // INTT ladders
-      //-------------------
-      
-      bool intt_overlapcheck = false;  // set to true if you want to check for overlaps
-      
-      // instantiate the Silicon tracker subsystem and register it
-      // We make one instance of PHG4TrackerSubsystem for all four layers of tracker
-      // dimensions are in mm, angles are in radians
-      
-      // PHG4SiliconTrackerSubsystem creates the detetor layer using PHG4SiliconTrackerDetector
-      // and instantiates the appropriate PHG4SteppingAction
-      const double intt_radius_max = 140.;  // including stagger radius (mm)
-      
-      // The length of vpair is used to determine the number of layers
-      std::vector<std::pair<int, int>> vpair;  // (sphxlayer, inttlayer)
-      for (int i = 0; i < n_intt_layer; i++)
-	{
-	  // We want the sPHENIX layer numbers for the INTT to be from n_maps_layer to n_maps_layer+n_intt_layer - 1
-	  vpair.push_back(std::make_pair(n_maps_layer + i, i));  // sphxlayer=n_maps_layer+i corresponding to inttlayer=i
-	  if (verbosity) cout << "Create strip tracker layer " << vpair[i].second << " as  sphenix layer  " << vpair[i].first << endl;
-	}
-      
-      // This is a temporary workaround using an alternative constructor for problem with parameter class not updating doubles 
-//      PHG4SiliconTrackerSubsystem* sitrack = new PHG4SiliconTrackerSubsystem(sensor_radius_inner, sensor_radius_outer, "SILICON_TRACKER", vpair);
-      PHG4SiliconTrackerSubsystem* sitrack = new PHG4SiliconTrackerSubsystem("SILICON_TRACKER", vpair);
-      sitrack->Verbosity(verbosity);
-      sitrack->SetActive(1);
-      sitrack->OverlapCheck(intt_overlapcheck);
-      g4Reco->registerSubsystem(sitrack);
-      
-      // Update the laddertype and ladder spacing configuration
-      for(int i=0;i<n_intt_layer;i++)
-	{
-	  sitrack->set_int_param(i, "laddertype", laddertype[i]);
-	  sitrack->set_int_param(i, "nladder", nladder[i]);
-	  // These are set above in the constructor for now, due to a problem with the parameter class
-	  //sitrack->set_double_param(i,"sensor_radius_inner", sensor_radius_inner[i]*10.0);  // expecting mm
-	  //sitrack->set_double_param(i,"sensor_radius_outer", sensor_radius_outer[i]*10.0);
-	}
-      
-      // outer radius marker (translation back to cm)
-      radius = intt_radius_max * 0.1;
-    }
+  assert (n_intt_layer == 0);
   
   //  int verbosity = 1;
   
@@ -504,6 +417,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
   return radius;
 }
 
+// Central detector cell reco is disabled as EIC setup use the fast tracking sim for now
 void Svtx_Cells(int verbosity = 0)
 {
   // runs the cellularization of the energy deposits (g4hits)
@@ -526,136 +440,11 @@ void Svtx_Cells(int verbosity = 0)
   // SVTX cells
   //-----------
 
-  if (verbosity)
-  {
-    cout << "  TPC Drift Velocity: " << TPCDriftVelocity << " cm/nsec" << endl;
-    cout << "  TPC Transverse Diffusion: " << TPC_Trans_Diffusion << " cm/SQRT(cm)" << endl;
-    cout << "  TPC Longitudinal Diffusion: " << TPC_Long_Diffusion << " cm/SQRT(cm)" << endl;
-    cout << "  TPC dE/dx: " << TPC_dEdx << " keV/cm" << endl;
-    cout << "  TPC N Primary: " << TPC_NPri << " electrons/cm" << endl;
-    cout << "  TPC N Total: " << TPC_NTot << " electrons/cm" << endl;
-    cout << "  TPC Electrons Per keV: " << TPC_ElectronsPerKeV << " electrons/keV" << endl;
-    cout << "  TPC ADC Clock: " << TPCADCClock << " nsec" << endl;
-    cout << "  TPC ADC Rate: " << 1000.0 / TPCADCClock << " MHZ" << endl;
-    cout << "  TPC Shaping Lead: " << TPCShapingRMSLead << " nsec" << endl;
-    cout << "  TPC Shaping Tail: " << TPCShapingRMSTail << " nsec" << endl;
-    cout << "  TPC z cell " << tpc_cell_z << " cm" << endl;
-    cout << "  TPC Smear R-Phi " << TPC_SmearRPhi << " cm" << endl;
-    cout << "  TPC Smear Z " << TPC_SmearZ << " cm" << endl;
-  }
-
-  if (n_maps_layer > 0)
-  {
-    // MAPS cells
-    PHG4MapsCellReco* maps_cells = new PHG4MapsCellReco("MAPS");
-    maps_cells->Verbosity(verbosity);
-    for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
-    {
-      maps_cells->set_timing_window(ilayer, -5000, 5000);
-    }
-    se->registerSubsystem(maps_cells);
-  }
-
-  if (n_intt_layer > 0)
-  {
-    // INTT cells
-    PHG4SiliconTrackerCellReco* reco = new PHG4SiliconTrackerCellReco("SILICON_TRACKER");
-    // The timing windows are hard-coded in the INTT ladder model
-    reco->Verbosity(verbosity);
-    se->registerSubsystem(reco);
-  }
-
-  // Main switch for TPC distortion
-  const bool do_tpc_distortion = true;
-  PHG4TPCSpaceChargeDistortion* tpc_distortion = NULL;
-  if (do_tpc_distortion)
-  {
-    if (inner_cage_radius != 20. && inner_cage_radius != 30.)
-    {
-      cout << "Svtx_Cells - Fatal Error - TPC distortion required that "
-              "inner_cage_radius is either 20 or 30 cm."
-           << endl;
-      exit(3);
-    }
-
-    string TPC_distortion_file =
-        string(getenv("CALIBRATIONROOT")) +
-        Form("/Tracking/TPC/SpaceChargeDistortion/TPCCAGE_20_78_211_2.root");
-     tpc_distortion =
-        new PHG4TPCSpaceChargeDistortion(TPC_distortion_file);
-    //tpc_distortion -> setAccuracy(0); // option to over write default  factors
-    //tpc_distortion -> setPrecision(0.001); // option to over write default  factors      // default is 0.001
-  }
-
-  PHG4CylinderCellTPCReco* svtx_cells = new PHG4CylinderCellTPCReco(n_maps_layer + n_intt_layer);
-  svtx_cells->Detector("SVTX");
-  svtx_cells->setDistortion(tpc_distortion);
-  //svtx_cells->setZigzags(true);  // set zigzag pads option on if true, use rectangular pads if false  (not required, defaults to true in code).
-  svtx_cells->setDiffusionT(TPC_Trans_Diffusion);
-  svtx_cells->setDiffusionL(TPC_Long_Diffusion);
-  svtx_cells->setSigmaT(TPC_SigmaT);  
-  svtx_cells->setShapingRMSLead(TPCShapingRMSLead * TPCDriftVelocity);
-  svtx_cells->setShapingRMSTail(TPCShapingRMSTail * TPCDriftVelocity);
-  // Expected cluster resolutions:
-  //     r-phi: diffusion + GEM smearing = 750 microns, assume resolution is 20% of that => 150 microns
-  //    Tune TPC_SmearRPhi and TPC_SmearZ to get 150 microns in the outer layers
-  svtx_cells->setSmearRPhi(TPC_SmearRPhi);  // additional random displacement of cloud positions wrt hits
-  svtx_cells->setSmearZ(TPC_SmearZ);        // additional random displacement of cloud positions wrt hits
-  svtx_cells->set_drift_velocity(TPCDriftVelocity);
-  svtx_cells->setHalfLength(105.5);
-  svtx_cells->setElectronsPerKeV(TPC_ElectronsPerKeV);
-  svtx_cells->Verbosity(0);
-
-  // The maps cell size is set when the detector is constructed because it is needed by the geometry object
-  // The INTT ladder cell size is set in the detector construction code
-
-  // set cylinder cell TPC cell sizes
-  //======================
-
-  double tpc_timing_window = 105.5 / TPCDriftVelocity;  // half length in cm / Vd in cm/ns => ns
-
-  // inner layers
-  double radius_layer = inner_readout_radius ;
-  for (int i = n_maps_layer + n_intt_layer; i < n_maps_layer + n_intt_layer + n_tpc_layer_inner; i++)
-  {
-    // this calculates the radius at the middle of the layer
-    double tpc_cell_rphi = 2 * TMath::Pi() * radius_layer / (double) tpc_layer_rphi_count_inner;
-    svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
-    svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
-    if (verbosity)
-      cout << "TPC cells inner: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
-    radius_layer += tpc_layer_thick_inner;
-  }
-
-
-  // mid layers
-  for (int i = n_maps_layer + n_intt_layer + n_tpc_layer_inner; i < n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid; i++)
-  {
-    double tpc_cell_rphi = 2 * TMath::Pi() * radius_layer / (double) tpc_layer_rphi_count_mid;
-    svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
-    svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
-    if (verbosity)
-      cout << "TPC cells mid: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
-    radius_layer += tpc_layer_thick_mid;
-  }
-
-  // outer layers
-  for (int i = n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid; i < n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer; i++)
-  {
-    double tpc_cell_rphi = 2 * TMath::Pi() * radius_layer / (double) tpc_layer_rphi_count_outer;
-    svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
-    svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
-    if (verbosity)
-      cout << "TPC cells outer: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
-
-    radius_layer += tpc_layer_thick_outer;
-  }
-
-  se->registerSubsystem(svtx_cells);
 
   return;
 }
 
+// Central detector  reco is disabled as EIC setup use the fast tracking sim for now
 void Svtx_Reco(int verbosity = 0)
 {
   //---------------
@@ -671,247 +460,9 @@ void Svtx_Reco(int verbosity = 0)
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  //----------------------------------
-  // Digitize the cell energy into ADC
-  //----------------------------------
-  PHG4SvtxDigitizer* digi = new PHG4SvtxDigitizer();
-  digi->Verbosity(0);
-  for (int i = 0; i < n_maps_layer; ++i)
-  {
-    digi->set_adc_scale(i, 255, 0.4e-6);  // reduced by a factor of 2.5 when going from maps thickess of 50 microns to 18 microns
-  }
-
-  if (n_intt_layer > 0)
-  {
-    // INTT
-    std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
-    // these should be used for the INTT
-    userrange.push_back(0.05);
-    userrange.push_back(0.10);
-    userrange.push_back(0.15);
-    userrange.push_back(0.20);
-    userrange.push_back(0.25);
-    userrange.push_back(0.30);
-    userrange.push_back(0.35);
-    userrange.push_back(0.40);
-
-    PHG4SiliconTrackerDigitizer* digiintt = new PHG4SiliconTrackerDigitizer();
-    digiintt->Verbosity(verbosity);
-    for (int i = 0; i < n_intt_layer; i++)
-    {
-      digiintt->set_adc_scale(n_maps_layer + i, userrange);
-    }
-    se->registerSubsystem(digiintt);
-  }
-
-  // TPC layers use the Svtx digitizer
-  digi->SetTPCMinLayer(n_maps_layer + n_intt_layer);
-  double ENC = 670.0;  // standard
-  digi->SetENC(ENC);  
-  double ADC_threshold = 4.0*ENC; 
-  digi->SetADCThreshold(ADC_threshold);  // 4 * ENC seems OK
-    cout << " TPC digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold 
-       << " maps+INTT layers set to " << n_maps_layer + n_intt_layer << endl;
- 
-  se->registerSubsystem(digi);
-  
-  //-------------------------------------
-  // Apply Live Area Inefficiency to Hits
-  //-------------------------------------
-  // defaults to 1.0 (fully active)
-
-  PHG4SvtxDeadArea* deadarea = new PHG4SvtxDeadArea();
-
-  for (int i = 0; i < n_maps_layer; i++)
-  {
-    deadarea->Verbosity(verbosity);
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    //deadarea->set_hit_efficiency(i,0.99);
-    deadarea->set_hit_efficiency(i, 1.0);
-  }
-  se->registerSubsystem(deadarea);
-
-  //-----------------------------
-  // Apply MIP thresholds to Hits
-  //-----------------------------
-
-  PHG4SvtxThresholds* thresholds = new PHG4SvtxThresholds();
-  thresholds->Verbosity(verbosity);
-
-  // maps
-  for (int i = 0; i < n_maps_layer; i++)
-  {
-    // reduced by x2.5 when going from cylinder maps with 50 microns thickness to actual maps with 18 microns thickness
-    // Note the non-use of set_using_thickness here, this is so that the shortest dimension of the cell sets the mip energy loss
-    thresholds->set_threshold(i, 0.1);
-  }
-  // INTT
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    thresholds->set_threshold(i, 0.1);
-    thresholds->set_use_thickness_mip(i, true);
-  }
-
-  se->registerSubsystem(thresholds);
-
-  //-------------
-  // Cluster Hits
-  //-------------
-
-  PHG4SvtxClusterizer* clusterizer = new PHG4SvtxClusterizer("PHG4SvtxClusterizer", 0, n_maps_layer + n_intt_layer - 1);
-  clusterizer->Verbosity(verbosity);
-  // Reduced by 2 relative to the cylinder cell maps macro. I found this necessary to get full efficiency
-  // Many hits in the present simulation are single cell hits, so it is not clear why the cluster threshold should be higher than the cell threshold
-  clusterizer->set_threshold(0.1);  // fraction of a mip
-
-  // no Z clustering for INTT type 1 layers (we DO want Z clustering for type 0 layers)
-  // turning off phi clustering for type 0 layers is not necessary, there is only one strip per sensor in phi
-  for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
-  {
-    if(laddertype[i-n_maps_layer] == 1)
-      clusterizer->set_z_clustering(i, false);
-  }
-
-  se->registerSubsystem(clusterizer);
-
-  PHG4TPCClusterizer* tpcclusterizer = new PHG4TPCClusterizer();
-  tpcclusterizer->Verbosity(0);
-  tpcclusterizer->setRangeLayers(n_maps_layer + n_intt_layer, Max_si_layer);
-  tpcclusterizer->setEnergyCut(15 /*adc*/);
-  tpcclusterizer->setFitWindowSigmas(0.0150, 0.0160);  // should be changed when TPC cluster resolution changes
-  tpcclusterizer->setFitWindowMax(5 /*rphibins*/, 5 /*zbins*/);
-  se->registerSubsystem(tpcclusterizer);
-
-  // This should be true for everything except testing!
-  const bool use_kalman_pat_rec = true;
-  if (use_kalman_pat_rec)
-  {
-    //---------------------
-    // PHG4KalmanPatRec
-    //---------------------
-
-    PHG4KalmanPatRec* kalman_pat_rec = new PHG4KalmanPatRec("PHG4KalmanPatRec", n_maps_layer, n_intt_layer, n_gas_layer);
-    kalman_pat_rec->Verbosity(0);
-    
-    for(int i = 0;i<n_intt_layer;i++)
-      {
-	if(laddertype[i] == 0)
-	  {
-	    // strip length is along phi
-	    kalman_pat_rec->set_max_search_win_theta_intt(i, 0.010);
-	    kalman_pat_rec->set_min_search_win_theta_intt(i, 0.00);
-	    kalman_pat_rec->set_max_search_win_phi_intt(i, 0.20);
-	    kalman_pat_rec->set_min_search_win_phi_intt(i, 0.20);
-	  }
-	else
-	  {
-	    // strip length is along theta
-	    kalman_pat_rec->set_max_search_win_theta_intt(i, 0.200);
-	    kalman_pat_rec->set_min_search_win_theta_intt(i, 0.200);
-	    kalman_pat_rec->set_max_search_win_phi_intt(i, 0.0050);
-	    kalman_pat_rec->set_min_search_win_phi_intt(i, 0.000);
-	  }
-      }
-    
-    se->registerSubsystem(kalman_pat_rec);
-  }
-  else
-  {
-    //---------------------
-    // Truth Pattern Recognition
-    //---------------------
-    PHG4TruthPatRec* pat_rec = new PHG4TruthPatRec();
-    se->registerSubsystem(pat_rec);
-  }
-
-  //---------------------
-  // Kalman Filter
-  //---------------------
-
-  PHG4TrackKalmanFitter* kalman = new PHG4TrackKalmanFitter();
-  kalman->Verbosity(0);
-  if (use_primary_vertex)
-    kalman->set_fit_primary_tracks(true);  // include primary vertex in track fit if true
-  se->registerSubsystem(kalman);
-
-  //------------------
-  // Track Projections
-  //------------------
-  PHG4GenFitTrackProjection* projection = new PHG4GenFitTrackProjection();
-  projection->Verbosity(verbosity);
-  se->registerSubsystem(projection);
-
-  /*  
-  //----------------------
-  // Beam Spot Calculation
-  //----------------------
-  PHG4SvtxBeamSpotReco* beamspot = new PHG4SvtxBeamSpotReco();
-  beamspot->Verbosity(verbosity);
-  se->registerSubsystem( beamspot );
-  */
-
   return;
 }
 
-void G4_Svtx_Reco()
-{
-  cout << "\033[31;1m"
-       << "Warning: G4_Svtx_Reco() was moved to G4_Svtx.C and renamed to Svtx_Reco(), please update macros"
-       << "\033[0m" << endl;
-  Svtx_Reco();
-
-  return;
-}
-
-void Svtx_Eval(std::string outputfile, int verbosity = 0)
-{
-  //---------------
-  // Load libraries
-  //---------------
-
-  gSystem->Load("libfun4all.so");
-  gSystem->Load("libg4detectors.so");
-  gSystem->Load("libg4hough.so");
-  gSystem->Load("libg4eval.so");
-
-  //---------------
-  // Fun4All server
-  //---------------
-
-  Fun4AllServer* se = Fun4AllServer::instance();
-
-  //----------------
-  // SVTX evaluation
-  //----------------
-
-  SvtxEvaluator* eval;
-  eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str());
-  eval->do_cluster_eval(true);
-  eval->do_g4hit_eval(true);
-  eval->do_hit_eval(true);  // enable to see the hits that includes the chamber physics...
-  eval->do_gpoint_eval(false);
-  eval->scan_for_embedded(false);  // take all tracks if false - take only embedded tracks if true
-  eval->Verbosity(verbosity);
-  se->registerSubsystem(eval);
-
-  if (use_primary_vertex)
-  {
-    // make a second evaluator that records tracks fitted with primary vertex included
-    // good for analysis of prompt tracks, particularly if MVTX is not present
-    SvtxEvaluator* evalp;
-    evalp = new SvtxEvaluator("SVTXEVALUATOR", string(outputfile.c_str()) + "_primary_eval.root", "PrimaryTrackMap");
-    evalp->do_cluster_eval(true);
-    evalp->do_g4hit_eval(true);
-    evalp->do_hit_eval(false);
-    evalp->do_gpoint_eval(false);
-    evalp->scan_for_embedded(true);  // take all tracks if false - take only embedded tracks if true
-    evalp->Verbosity(0);
-    se->registerSubsystem(evalp);
-  }
 
   // MomentumEvaluator* eval = new MomentumEvaluator(outputfile.c_str(),0.2,0.4,Max_si_layer,2,Max_si_layer-4,10.,80.);
   // se->registerSubsystem( eval );

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -1,5 +1,5 @@
 #pragma once
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
 #include <fun4all/Fun4AllServer.h>
 #include <g4eval/SvtxEvaluator.h>
 #include <g4hough/PHG4TrackFastSim.h>
@@ -10,6 +10,9 @@ R__LOAD_LIBRARY(libg4eval.so)
 #include <vector>
 
 #include "G4_GEM_EIC.C"
+
+// load the version of central travker macro with cylindrical approximation of the TPC
+// This is required for fast tracking to properly count hits in TPC
 #include "G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C"
 
 void TrackingInit(int verbosity = 0)
@@ -24,9 +27,9 @@ void TrackingInit(int verbosity = 0)
   SvtxInit();
 }
 
-double Tracking(PHG4Reco* g4Reco, double radius,
-            const int absorberactive = 0,
-            int verbosity = 0)
+double Tracking(PHG4Reco *g4Reco, double radius,
+                const int absorberactive = 0,
+                int verbosity = 0)
 {
   /* Place electron-going side tracking detectors */
   EGEMSetup(g4Reco);
@@ -47,60 +50,147 @@ void Tracking_Reco(int verbosity = 0)
   //---------------
 
   gSystem->Load("libfun4all.so");
-  gSystem->Load("libg4hough.so");
+  gSystem->Load("libg4trackfastsim.so");
 
   //---------------
   // Fun4All server
   //---------------
 
-  Fun4AllServer* se = Fun4AllServer::instance();
+  Fun4AllServer *se = Fun4AllServer::instance();
 
-  //---------------------
-  // Kalman Filter
-  //---------------------
-
-  PHG4TrackFastSim* kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
-  kalman->Verbosity(10);
+  PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
+  kalman->Verbosity(verbosity);
 
   kalman->set_use_vertex_in_fitting(true);
   kalman->set_vertex_xy_resolution(50E-4);
   kalman->set_vertex_z_resolution(50E-4);
 
-  //kalman->set_detector_type(PHG4TrackFastSim::Vertical_Plane); // Vertical_Plane, Cylinder
-  //kalman->set_phi_resolution(50E-4);
-  //kalman->set_r_resolution(1.);
-  //kalman->set_pat_rec_hit_finding_eff(1.);
-  //kalman->set_pat_rec_noise_prob(0.);
-  std::string phg4hits_names[] = {"G4HIT_SVTX","G4HIT_MAPS","G4HIT_EGEM_0","G4HIT_EGEM_1","G4HIT_EGEM_2","G4HIT_EGEM_3","G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
-  const PHG4TrackFastSim::DETECTOR_TYPE dettypes[] = {PHG4TrackFastSim::Cylinder,PHG4TrackFastSim::Cylinder,
-		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
-		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
-		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
-		    PHG4TrackFastSim::Vertical_Plane,PHG4TrackFastSim::Vertical_Plane,
-		    PHG4TrackFastSim::Vertical_Plane };
-  float rad[] = {5.0,  100,  100,  100,  100,  100,  100,  100,  100,  100,  100};
-  float phi[] = {5.0,  150,  100,  100,  100,  100,  100,  100,  100,  100,  100};
-  float lon[] = {5.0,  200,  100,  100,  100,  100,  100,  100,  100,  100,  100};
-  for(int i=0; i!=11; ++i) { // from um to cm
-    rad[i] *= 1e-4;
-    phi[i] *= 1e-4;
-    lon[i] *= 1e-4;
-  }
-  float eff[] = {1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0,  1.0};
-  float noi[] = {0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0};
-  kalman->set_phg4hits_names(phg4hits_names, dettypes, rad, phi, lon, eff, noi, 11);
-
-  //std::string phg4hits_names[] = {"G4HIT_EGEM_0","G4HIT_EGEM_1","G4HIT_EGEM_2","G4HIT_EGEM_3","G4HIT_FGEM_0","G4HIT_FGEM_1","G4HIT_FGEM_2","G4HIT_FGEM_3","G4HIT_FGEM_4"};
-  //kalman->set_phg4hits_names(phg4hits_names, 9);
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
 
-  //std::string state_names[] = {"FEMC","FHCAL"};
-  //kalman->set_state_names(state_names, 2);
-
-  kalman->set_fit_alg_name("KalmanFitterRefTrack");//
+  //  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
+  kalman->set_fit_alg_name("DafRef");  //
   kalman->set_primary_assumption_pid(13);
   kalman->set_do_evt_display(false);
+
+  //   MAPS
+  kalman->add_phg4hits(
+      "G4HIT_MVTX",                //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                        //      const float radres,
+      5e-4,                        //      const float phires,
+      5e-4,                        //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
+
+  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_EGEM_0",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_EGEM_1",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM2, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_EGEM_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM3, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_EGEM_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  //
+  // TPC
+  kalman->add_phg4hits(
+      "G4HIT_SVTX",                //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+      1,                           //      const float radres,
+      200e-4,                      //      const float phires,
+      500e-4,                      //      const float lonres,
+      1,                           //      const float eff,
+      0                            //      const float noise
+  );
+
+  // GEM2, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM3, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+  // GEM4, 70um azimuthal resolution, 1cm radial strips
+  kalman->add_phg4hits(
+      "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      1. / sqrt(12.),                    //      const float radres,
+      70e-4,                             //      const float phires,
+      100e-4,                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
+  // Saved track states (projections)
+  kalman->add_state_name("FEMC");
+  kalman->add_state_name("FHCAL");
 
   se->registerSubsystem(kalman);
 
@@ -115,45 +205,33 @@ void Tracking_Eval(std::string outputfile, int verbosity = 0)
 
   gSystem->Load("libfun4all.so");
   gSystem->Load("libg4detectors.so");
-  gSystem->Load("libg4hough.so");
+  gSystem->Load("libg4trackfastsim.so");
   gSystem->Load("libg4eval.so");
 
   //---------------
   // Fun4All server
   //---------------
 
-  Fun4AllServer* se = Fun4AllServer::instance();
+  Fun4AllServer *se = Fun4AllServer::instance();
 
   //----------------
   // SVTX evaluation
   //----------------
 
-  SvtxEvaluator* eval;
-  eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str());
-  eval->do_cluster_eval(false);
-  eval->do_g4hit_eval(false);
-  eval->do_hit_eval(false);  // enable to see the hits that includes the chamber physics...
-  eval->do_gpoint_eval(false);
-  eval->scan_for_embedded(false);  // take all tracks if false - take only embedded tracks if true
-  eval->Verbosity(verbosity);
-  se->registerSubsystem(eval);
+  //  SvtxEvaluator* eval;
+  //  eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile.c_str());
+  //  eval->do_cluster_eval(false);
+  //  eval->do_g4hit_eval(false);
+  //  eval->do_hit_eval(false);  // enable to see the hits that includes the chamber physics...
+  //  eval->do_gpoint_eval(false);
+  //  eval->scan_for_embedded(false);  // take all tracks if false - take only embedded tracks if true
+  //  eval->Verbosity(verbosity);
+  //  se->registerSubsystem(eval);
 
   // MomentumEvaluator* eval = new MomentumEvaluator(outputfile.c_str(),0.2,0.4,Max_si_layer,2,Max_si_layer-4,10.,80.);
   // se->registerSubsystem( eval );
 
+  PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
+  fast_sim_eval->set_filename(outputfile.c_str());
+  se->registerSubsystem(fast_sim_eval);
 }
-// this uses a library which is not in our build
-/*
-void Fast_Tracking_Eval(std::string outputfile, int verbosity = 0)
-{
-  gSystem->Load("libFastTrackingEval.so");
-
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  FastTrackingEval *fast_sim_eval = new FastTrackingEval("FastTrackingEval");
-  fast_sim_eval->set_filename( outputfile.c_str() );
-  se->registerSubsystem( fast_sim_eval );
-
-  return;
-}
-*/

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -68,11 +68,6 @@ void Tracking_Reco(int verbosity = 0)
   kalman->set_sub_top_node_name("SVTX");
   kalman->set_trackmap_out_name("SvtxTrackMap");
 
-  //  kalman->set_fit_alg_name("KalmanFitterRefTrack");  //
-  kalman->set_fit_alg_name("DafRef");  //
-  kalman->set_primary_assumption_pid(13);
-  kalman->set_do_evt_display(false);
-
   //   MAPS
   kalman->add_phg4hits(
       "G4HIT_MVTX",                //      const std::string& phg4hitsNames,

--- a/macros/sPHENIXStyle/sPhenixStyle.C
+++ b/macros/sPHENIXStyle/sPhenixStyle.C
@@ -2,11 +2,13 @@
 // sPHENIX Style, based on a style file from BaBar, v0.1
 //
 
-#include <iostream>
 
 #include "sPhenixStyle.h"
 
-#include "TROOT.h"
+#include <TROOT.h>
+#include <TColor.h>
+
+#include <iostream>
 
 void SetsPhenixStyle ()
 {

--- a/macros/sPHENIXStyle/sPhenixStyle.h
+++ b/macros/sPHENIXStyle/sPhenixStyle.h
@@ -13,7 +13,7 @@
 #ifndef  __SPHENIXSTYLE_H
 #define __SPHENIXSTYLE_H
 
-#include "TStyle.h"
+#include <TStyle.h>
 
 //! \brief sPHENIX Style, based on a style file from ATLAS by Peter Steinberg
 /*


### PR DESCRIPTION
In the recent tracking code reorganization (in particular, single vol TPC upgrade https://github.com/sPHENIX-Collaboration/coresoftware/pull/529 ), the EIC/fsPHENIX fast tracking simulation has been broken. This pull request is trying to fix both of them. 

Besides accumulated fixes on the EIC/fsPHENIX tracking setup, this pull request also changes the following aspect of the macros:
* Update GEM tracker to use 70um azimuthal resolution and 1cm radial strip, which has more dependable performance quote when compared with 50um as in the previous simulation. 
* Comment out the magnetic piston material in the fsPHENIX simulation, as it is not compatible with the jet program and current field map. 
* Make fsPHENIX use the same procedure for event display as sPHENIX and EIC
* Add header files for sPHENIX style file

Test require the corresponding update in the `coresoftware`