### PR TITLE
Fix macros

### DIFF
--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -139,7 +139,7 @@ int Fun4All_G4_fsPHENIX(
   gSystem->Load("libg4testbench.so");
   gSystem->Load("libg4hough.so");
   gSystem->Load("libg4eval.so");
-
+  gSystem->Load("libg4intt.so");
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_fsPHENIX.C");
   G4Init(do_tracking,do_cemc,do_hcalin,do_magnet,do_hcalout,do_pipe,do_FGEM,do_FEMC,do_FHCAL,n_TPC_layers);

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -147,7 +147,7 @@ int Fun4All_G4_sPHENIX(
   gSystem->Load("libg4testbench.so");
   gSystem->Load("libg4hough.so");
   gSystem->Load("libg4eval.so");
-
+  gSystem->Load("libg4intt.so");
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
   G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor);

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -13,6 +13,7 @@
 #include <g4tpc/PHG4TPCSpaceChargeDistortion.h>
 R__LOAD_LIBRARY(libg4hough.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libg4mvtx.so)
 #endif
 
 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -222,6 +222,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
             const int absorberactive = 0,
             int verbosity = 0)
 {
+  gSystem->Load("libg4mvtx.so");
   if (n_maps_layer > 0)
     {
       bool maps_overlapcheck = false;  // set to true if you want to check for overlaps

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -150,6 +150,7 @@ double Tracking(PHG4Reco* g4Reco, double radius,
                 int verbosity = 0)
 {
   // create the three tracker subsystems
+  gSystem->Load("libg4mvtx.so");
 
   if (n_maps_layer > 0)
   {


### PR DESCRIPTION
The new tracking broke the macros for root5 due to missing libraries. This PR should take care of this, Fun4All_G4_sPHENIX.C, Fun4All_G4_fsPHENIX.C and Fun4All_G4_EICDetector.C