### PR TITLE
add g4->ApplyDisplayAction() to DisplayOn.C

### DIFF
--- a/macros/g4simulations/DisplayOn.C
+++ b/macros/g4simulations/DisplayOn.C
@@ -18,6 +18,7 @@ PHG4Reco * DisplayOn(const char *mac = "vis.mac")
   Fun4AllServer *se = Fun4AllServer::instance();
   PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
   g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
   sprintf(cmd, "/control/execute %s", mac);
   g4->ApplyCommand(cmd);
   return g4;

--- a/macros/prototype2/DisplayOn.C
+++ b/macros/prototype2/DisplayOn.C
@@ -12,6 +12,7 @@ PHG4Reco * DisplayOn(const char *mac = "vis_prototype2.mac")
   Fun4AllServer *se = Fun4AllServer::instance();
   PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
   g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
   sprintf(cmd, "/control/execute %s", mac);
   g4->ApplyCommand(cmd);
   return g4;

--- a/macros/prototype3/DisplayOn.C
+++ b/macros/prototype3/DisplayOn.C
@@ -12,6 +12,7 @@ PHG4Reco * DisplayOn(const char *mac = "vis_prototype3.mac")
   Fun4AllServer *se = Fun4AllServer::instance();
   PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
   g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
   sprintf(cmd, "/control/execute %s", mac);
   g4->ApplyCommand(cmd);
   return g4;

--- a/macros/prototype4/DisplayOn.C
+++ b/macros/prototype4/DisplayOn.C
@@ -18,6 +18,7 @@ PHG4Reco * DisplayOn(const char *mac = "vis_prototype3.mac")
   Fun4AllServer *se = Fun4AllServer::instance();
   PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
   g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
   sprintf(cmd, "/control/execute %s", mac);
   g4->ApplyCommand(cmd);
   return g4;


### PR DESCRIPTION
This PR adds a call to PHG4Reco::ApplyDisplayAction() which is needed to set the G4VisAttributes for subsystem using the new PHG4DisplayAction