### PR TITLE
Decaps intt mvtx tpc

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -528,11 +528,11 @@ int Fun4All_G4_sPHENIX(
     if (do_tracking)
     {
       // This gets the default drift velocity only! 
-      PHG4TPCElectronDrift *dr = (PHG4TPCElectronDrift *)se->getSubsysReco("PHG4TPCElectronDrift");
+      PHG4TpcElectronDrift *dr = (PHG4TpcElectronDrift *)se->getSubsysReco("PHG4TpcElectronDrift");
       assert(dr);
-      double TPCDriftVelocity = dr->get_double_param("drift_velocity");
-      time_window_minus = -105.5 / TPCDriftVelocity;  // ns
-      time_window_plus = 105.5 / TPCDriftVelocity;    // ns;
+      double TpcDriftVelocity = dr->get_double_param("drift_velocity");
+      time_window_minus = -105.5 / TpcDriftVelocity;  // ns
+      time_window_plus = 105.5 / TpcDriftVelocity;    // ns;
     }
     pileup->set_time_window(time_window_minus, time_window_plus);  // override timing window in ns
     cout << "Collision pileup enabled using file " << pileupfile << " with collision rate " << pileup_collision_rate

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -3,13 +3,13 @@
 #include "GlobalVariables.C"
 #include <fun4all/Fun4AllServer.h>
 #include <g4detectors/PHG4CylinderSubsystem.h>
-#include <g4detectors/PHG4CylinderCellTPCReco.h>
+#include <g4detectors/PHG4CylinderCellTpcReco.h>
 #include <g4detectors/PHG4MapsCellReco.h>
 #include <g4detectors/PHG4MapsSubsystem.h>
 #include <g4detectors/PHG4SiliconTrackerCellReco.h>
 #include <g4detectors/PHG4SiliconTrackerDefs.h>
 #include <g4detectors/PHG4SiliconTrackerSubsystem.h>
-#include <g4detectors/PHG4TPCSpaceChargeDistortion.h>
+#include <g4detectors/PHG4TpcSpaceChargeDistortion.h>
 #include <g4eval/SvtxEvaluator.h>
 #include <g4hough/PHG4GenFitTrackProjection.h>
 #include <g4hough/PHG4KalmanPatRec.h>
@@ -18,7 +18,7 @@
 #include <g4hough/PHG4SvtxDeadArea.h>
 #include <g4hough/PHG4SvtxDigitizer.h>
 #include <g4hough/PHG4SvtxThresholds.h>
-#include <g4hough/PHG4TPCClusterizer.h>
+#include <g4hough/PHG4TpcClusterizer.h>
 #include <g4hough/PHG4TrackKalmanFitter.h>
 #include <g4hough/PHG4TruthPatRec.h>
 #include <g4main/PHG4Reco.h>
@@ -28,7 +28,7 @@ R__LOAD_LIBRARY(libg4eval.so)
 
 #include <vector>
 
-// ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
+// ONLY if backward compatibility with hits files already generated with 8 inner Tpc layers is needed, you can set this to "true"
 bool tpc_layers_40  = false;
 
 // if true, refit tracks with primary vertex included in track fit  - good for analysis of prompt tracks only
@@ -117,10 +117,10 @@ int n_gas_layer = n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer;
 double inner_cage_radius = 20.;
 double inner_readout_radius = 30.;
 
-// TPC gas parameters
+// Tpc gas parameters
 // These are set for a variety of gas choices...
 //==============================================
-enum TPC_Gas
+enum Tpc_Gas
 {
   Ne2K_100,
   Ne2K_400,
@@ -129,8 +129,8 @@ enum TPC_Gas
   NeCF4_400,
   ByHand
 };
-TPC_Gas ether = TPC_Gas::NeCF4_400;
-//TPC_Gas ether = TPC_Gas::ByHand;
+Tpc_Gas ether = Tpc_Gas::NeCF4_400;
+//Tpc_Gas ether = Tpc_Gas::ByHand;
 
 // Data on gasses @20 C and 760 Torr from the following source:
 // http://www.slac.stanford.edu/pubs/icfa/summer98/paper3/paper3.pdf
@@ -146,28 +146,28 @@ double Ne_NTotal = 43;     // Number/cm
 double CF4_NTotal = 100;   // Number/cm
 double iBut_NTotal = 195;  // Number/cm
 
-// TPC Performance Parameter (applies extra smear to mimic the avalanche):
-double TPC_SigmaT = 0.03;  // 0.03 means 300 microns...Prakhar Garg Simulation...desire measurement...
+// Tpc Performance Parameter (applies extra smear to mimic the avalanche):
+double Tpc_SigmaT = 0.03;  // 0.03 means 300 microns...Prakhar Garg Simulation...desire measurement...
 
 // to be overwritten...
-double TPCDriftVelocity;
-double TPC_Trans_Diffusion;
-double TPC_Long_Diffusion;
-double TPC_dEdx;
-double TPC_NPri;
-double TPC_NTot;
-double TPC_ElectronsPerKeV;
+double TpcDriftVelocity;
+double Tpc_Trans_Diffusion;
+double Tpc_Long_Diffusion;
+double Tpc_dEdx;
+double Tpc_NPri;
+double Tpc_NTot;
+double Tpc_ElectronsPerKeV;
 
-// TPC readout shaping time and ADC clock parameters
-// these set the Z size of the TPC cells
+// Tpc readout shaping time and ADC clock parameters
+// these set the Z size of the Tpc cells
 // These need to be set in the init since some of them require the drift velocity...
 //=======================================
-double TPCADCClock;
-double TPCShapingRMSLead;
-double TPCShapingRMSTail;
+double TpcADCClock;
+double TpcShapingRMSLead;
+double TpcShapingRMSTail;
 double tpc_cell_z;
-double TPC_SmearRPhi;
-double TPC_SmearZ;
+double Tpc_SmearRPhi;
+double Tpc_SmearZ;
 
 int Max_si_layer;
 
@@ -178,107 +178,107 @@ void SvtxInit(int verbosity = 0)
   switch (ether)
   {
   // https://www.phenix.bnl.gov/WWW/p/draft/prakhar/tpc/HTML_Gas_Linear/Ne_CF4_IC4H10_95_3_2.html
-  case TPC_Gas::Ne2K_100:
+  case Tpc_Gas::Ne2K_100:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::Ne2K_100" << endl;
-    TPCDriftVelocity = 3.2 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0065;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0300;      // cm/SQRT(cm)
-    TPC_dEdx = 0.95 * Ne_dEdx + 0.03 * CF4_dEdx + 0.02 * iBut_dEdx;
-    TPC_NPri = 0.95 * Ne_NPrimary + 0.03 * CF4_NPrimary + 0.02 * iBut_NPrimary;
-    TPC_NTot = 0.95 * Ne_NTotal + 0.03 * CF4_NTotal + 0.02 * iBut_NTotal;
+      cout << "Gas Choice:  Tpc_Gas::Ne2K_100" << endl;
+    TpcDriftVelocity = 3.2 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0065;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0300;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.95 * Ne_dEdx + 0.03 * CF4_dEdx + 0.02 * iBut_dEdx;
+    Tpc_NPri = 0.95 * Ne_NPrimary + 0.03 * CF4_NPrimary + 0.02 * iBut_NPrimary;
+    Tpc_NTot = 0.95 * Ne_NTotal + 0.03 * CF4_NTotal + 0.02 * iBut_NTotal;
     break;
   }
-  case TPC_Gas::Ne2K_400:
+  case Tpc_Gas::Ne2K_400:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::Ne2K_400" << endl;
-    TPCDriftVelocity = 5.5 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0120;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0175;      // cm/SQRT(cm)
-    TPC_dEdx = 0.95 * Ne_dEdx + 0.03 * CF4_dEdx + 0.02 * iBut_dEdx;
-    TPC_NPri = 0.95 * Ne_NPrimary + 0.03 * CF4_NPrimary + 0.02 * iBut_NPrimary;
-    TPC_NTot = 0.95 * Ne_NTotal + 0.03 * CF4_NTotal + 0.02 * iBut_NTotal;
+      cout << "Gas Choice:  Tpc_Gas::Ne2K_400" << endl;
+    TpcDriftVelocity = 5.5 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0120;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0175;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.95 * Ne_dEdx + 0.03 * CF4_dEdx + 0.02 * iBut_dEdx;
+    Tpc_NPri = 0.95 * Ne_NPrimary + 0.03 * CF4_NPrimary + 0.02 * iBut_NPrimary;
+    Tpc_NTot = 0.95 * Ne_NTotal + 0.03 * CF4_NTotal + 0.02 * iBut_NTotal;
     break;
   }
   // https://www.phenix.bnl.gov/WWW/p/draft/prakhar/tpc/HTML_Gas_Linear/Ne_CF4_90_10.html
-  case TPC_Gas::NeCF4_100:
+  case Tpc_Gas::NeCF4_100:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::NeCF4_100" << endl;
-    TPCDriftVelocity = 4.0 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0045;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0270;      // cm/SQRT(cm)
-    TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-    TPC_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
-    TPC_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+      cout << "Gas Choice:  Tpc_Gas::NeCF4_100" << endl;
+    TpcDriftVelocity = 4.0 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0045;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0270;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+    Tpc_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
+    Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
     break;
   }
-  case TPC_Gas::NeCF4_300:
+  case Tpc_Gas::NeCF4_300:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::NeCF4_300" << endl;
-    TPCDriftVelocity = 7.0 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0052;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0170;      // cm/SQRT(cm)
-    TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-    TPC_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
-    TPC_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+      cout << "Gas Choice:  Tpc_Gas::NeCF4_300" << endl;
+    TpcDriftVelocity = 7.0 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0052;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0170;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+    Tpc_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
+    Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
     break;
   }
-  case TPC_Gas::NeCF4_400:
+  case Tpc_Gas::NeCF4_400:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::NeCF4_400" << endl;
-    TPCDriftVelocity = 8.0 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0060;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0150;      // cm/SQRT(cm)
-    TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-    TPC_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
-    TPC_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+      cout << "Gas Choice:  Tpc_Gas::NeCF4_400" << endl;
+    TpcDriftVelocity = 8.0 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0060;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0150;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+    Tpc_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
+    Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
     break;
   }
-  case TPC_Gas::ByHand:
+  case Tpc_Gas::ByHand:
   {
     if (verbosity)
-      cout << "Gas Choice:  TPC_Gas::ByHand" << endl;
-    TPCDriftVelocity = 6.0 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0130;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0130;      // cm/SQRT(cm)
-    TPC_ElectronsPerKeV = 28.0;
-    TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-    TPC_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
-    TPC_NTot = TPC_ElectronsPerKeV * TPC_dEdx;
+      cout << "Gas Choice:  Tpc_Gas::ByHand" << endl;
+    TpcDriftVelocity = 6.0 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0130;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0130;      // cm/SQRT(cm)
+    Tpc_ElectronsPerKeV = 28.0;
+    Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+    Tpc_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
+    Tpc_NTot = Tpc_ElectronsPerKeV * Tpc_dEdx;
     break;
   }
   default:  // defaults to NeCF4_400
   {
     if (verbosity)
-      cout << "Gas Choice Undefined...using TPC_Gas::NeCF4_400" << endl;
-    TPCDriftVelocity = 8.0 / 1000.0;  // cm/ns
-    TPC_Trans_Diffusion = 0.0060;     // cm/SQRT(cm)
-    TPC_Long_Diffusion = 0.0150;      // cm/SQRT(cm)
-    TPC_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
-    TPC_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
-    TPC_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
+      cout << "Gas Choice Undefined...using Tpc_Gas::NeCF4_400" << endl;
+    TpcDriftVelocity = 8.0 / 1000.0;  // cm/ns
+    Tpc_Trans_Diffusion = 0.0060;     // cm/SQRT(cm)
+    Tpc_Long_Diffusion = 0.0150;      // cm/SQRT(cm)
+    Tpc_dEdx = 0.90 * Ne_dEdx + 0.10 * CF4_dEdx;
+    Tpc_NPri = 0.90 * Ne_NPrimary + 0.10 * CF4_NPrimary;
+    Tpc_NTot = 0.90 * Ne_NTotal + 0.10 * CF4_NTotal;
     break;
   }
   }
 
-  TPC_ElectronsPerKeV = TPC_NTot / TPC_dEdx;
+  Tpc_ElectronsPerKeV = Tpc_NTot / Tpc_dEdx;
 
-  // TPC readout shaping time and ADC clock parameters
-  // these set the Z size of the TPC cells
+  // Tpc readout shaping time and ADC clock parameters
+  // these set the Z size of the Tpc cells
   //=======================================
-  TPCShapingRMSLead = 32.0;  // ns, rising RMS equivalent of shaping amplifier for 80 ns SAMPA
-  TPCShapingRMSTail = 48.0;  // ns, falling RMS equivalent of shaping amplifier for 80 ns SAMPA
-  TPCADCClock = 53.0;                           // ns, corresponds to an ADC clock rate of 18.8 MHz
-  tpc_cell_z = TPCADCClock * TPCDriftVelocity;  // cm
+  TpcShapingRMSLead = 32.0;  // ns, rising RMS equivalent of shaping amplifier for 80 ns SAMPA
+  TpcShapingRMSTail = 48.0;  // ns, falling RMS equivalent of shaping amplifier for 80 ns SAMPA
+  TpcADCClock = 53.0;                           // ns, corresponds to an ADC clock rate of 18.8 MHz
+  tpc_cell_z = TpcADCClock * TpcDriftVelocity;  // cm
 
-   //  these are fudge parameters, tuned to give average of 150 microns r-phi and 500 microns Z resolution in the outer TPC layers with the TPC setup used here and 80 ns SAMPA peaking time
-  TPC_SmearRPhi = 0.25;
-  TPC_SmearZ = 0.15;
+   //  these are fudge parameters, tuned to give average of 150 microns r-phi and 500 microns Z resolution in the outer Tpc layers with the Tpc setup used here and 80 ns SAMPA peaking time
+  Tpc_SmearRPhi = 0.25;
+  Tpc_SmearZ = 0.15;
 }
 
 double Svtx(PHG4Reco* g4Reco, double radius,
@@ -391,7 +391,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
   radius = inner_cage_radius;
 
-  double cage_length = 211.0;  // From TPC group, gives eta = 1.1 at 78 cm
+  double cage_length = 211.0;  // From Tpc group, gives eta = 1.1 at 78 cm
   double n_rad_length_cage = 1.13e-02;
   double cage_thickness = 28.6 * n_rad_length_cage;  // Kapton X_0 = 28.6 cm  // mocks up Kapton + carbon fiber structure
 
@@ -413,7 +413,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
   string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4Reco.cc
 
-  // Layer of inert TPC gas from 20-30 cm
+  // Layer of inert Tpc gas from 20-30 cm
   if (inner_readout_radius - radius > 0)
   {
     cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", n_maps_layer + n_intt_layer + 1);
@@ -430,12 +430,12 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
   double outer_radius = 78.;
 
-  // Active layers of the TPC from 30-40 cm (inner layers)
+  // Active layers of the Tpc from 30-40 cm (inner layers)
 
   for (int ilayer = n_maps_layer + n_intt_layer; ilayer < (n_maps_layer + n_intt_layer + n_tpc_layer_inner); ++ilayer)
   {
     if (verbosity)
-      cout << "Create TPC gas layer " << ilayer << " with inner radius " << radius << " cm "
+      cout << "Create Tpc gas layer " << ilayer << " with inner radius " << radius << " cm "
            << " thickness " << tpc_layer_thick_inner - 0.01 << " length " << cage_length << endl;
 
     cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
@@ -451,12 +451,12 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     radius += tpc_layer_thick_inner;
   }
 
-  // Active layers of the TPC from 40-60 cm (mid layers)
+  // Active layers of the Tpc from 40-60 cm (mid layers)
 
   for (int ilayer = n_maps_layer + n_intt_layer + n_tpc_layer_inner; ilayer < (n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid); ++ilayer)
   {
     if (verbosity)
-      cout << "Create TPC gas layer " << ilayer << " with inner radius " << radius << " cm "
+      cout << "Create Tpc gas layer " << ilayer << " with inner radius " << radius << " cm "
            << " thickness " << tpc_layer_thick_mid - 0.01 << " length " << cage_length << endl;
 
     cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
@@ -472,12 +472,12 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     radius += tpc_layer_thick_mid;
   }
 
-  // Active layers of the TPC from 60-80 cm (outer layers)
+  // Active layers of the Tpc from 60-80 cm (outer layers)
 
   for (int ilayer = n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid; ilayer < (n_maps_layer + n_intt_layer + n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer); ++ilayer)
   {
     if (verbosity)
-      cout << "Create TPC gas layer " << ilayer << " with inner radius " << radius << " cm "
+      cout << "Create Tpc gas layer " << ilayer << " with inner radius " << radius << " cm "
            << " thickness " << tpc_layer_thick_outer - 0.01 << " length " << cage_length << endl;
 
     cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
@@ -532,20 +532,20 @@ void Svtx_Cells(int verbosity = 0)
 
   if (verbosity)
   {
-    cout << "  TPC Drift Velocity: " << TPCDriftVelocity << " cm/nsec" << endl;
-    cout << "  TPC Transverse Diffusion: " << TPC_Trans_Diffusion << " cm/SQRT(cm)" << endl;
-    cout << "  TPC Longitudinal Diffusion: " << TPC_Long_Diffusion << " cm/SQRT(cm)" << endl;
-    cout << "  TPC dE/dx: " << TPC_dEdx << " keV/cm" << endl;
-    cout << "  TPC N Primary: " << TPC_NPri << " electrons/cm" << endl;
-    cout << "  TPC N Total: " << TPC_NTot << " electrons/cm" << endl;
-    cout << "  TPC Electrons Per keV: " << TPC_ElectronsPerKeV << " electrons/keV" << endl;
-    cout << "  TPC ADC Clock: " << TPCADCClock << " nsec" << endl;
-    cout << "  TPC ADC Rate: " << 1000.0 / TPCADCClock << " MHZ" << endl;
-    cout << "  TPC Shaping Lead: " << TPCShapingRMSLead << " nsec" << endl;
-    cout << "  TPC Shaping Tail: " << TPCShapingRMSTail << " nsec" << endl;
-    cout << "  TPC z cell " << tpc_cell_z << " cm" << endl;
-    cout << "  TPC Smear R-Phi " << TPC_SmearRPhi << " cm" << endl;
-    cout << "  TPC Smear Z " << TPC_SmearZ << " cm" << endl;
+    cout << "  Tpc Drift Velocity: " << TpcDriftVelocity << " cm/nsec" << endl;
+    cout << "  Tpc Transverse Diffusion: " << Tpc_Trans_Diffusion << " cm/SQRT(cm)" << endl;
+    cout << "  Tpc Longitudinal Diffusion: " << Tpc_Long_Diffusion << " cm/SQRT(cm)" << endl;
+    cout << "  Tpc dE/dx: " << Tpc_dEdx << " keV/cm" << endl;
+    cout << "  Tpc N Primary: " << Tpc_NPri << " electrons/cm" << endl;
+    cout << "  Tpc N Total: " << Tpc_NTot << " electrons/cm" << endl;
+    cout << "  Tpc Electrons Per keV: " << Tpc_ElectronsPerKeV << " electrons/keV" << endl;
+    cout << "  Tpc ADC Clock: " << TpcADCClock << " nsec" << endl;
+    cout << "  Tpc ADC Rate: " << 1000.0 / TpcADCClock << " MHZ" << endl;
+    cout << "  Tpc Shaping Lead: " << TpcShapingRMSLead << " nsec" << endl;
+    cout << "  Tpc Shaping Tail: " << TpcShapingRMSTail << " nsec" << endl;
+    cout << "  Tpc z cell " << tpc_cell_z << " cm" << endl;
+    cout << "  Tpc Smear R-Phi " << Tpc_SmearRPhi << " cm" << endl;
+    cout << "  Tpc Smear Z " << Tpc_SmearZ << " cm" << endl;
   }
 
   if (n_maps_layer > 0)
@@ -570,54 +570,54 @@ void Svtx_Cells(int verbosity = 0)
     se->registerSubsystem(reco);
   }
 
-  // Main switch for TPC distortion
+  // Main switch for Tpc distortion
   const bool do_tpc_distortion = true;
-  PHG4TPCSpaceChargeDistortion* tpc_distortion = NULL;
+  PHG4TpcSpaceChargeDistortion* tpc_distortion = NULL;
   if (do_tpc_distortion)
   {
     if (inner_cage_radius != 20. && inner_cage_radius != 30.)
     {
-      cout << "Svtx_Cells - Fatal Error - TPC distortion required that "
+      cout << "Svtx_Cells - Fatal Error - Tpc distortion required that "
               "inner_cage_radius is either 20 or 30 cm."
            << endl;
       exit(3);
     }
 
-    string TPC_distortion_file =
+    string Tpc_distortion_file =
         string(getenv("CALIBRATIONROOT")) +
         Form("/Tracking/TPC/SpaceChargeDistortion/TPCCAGE_20_78_211_2.root");
     tpc_distortion =
-        new PHG4TPCSpaceChargeDistortion(TPC_distortion_file);
+        new PHG4TpcSpaceChargeDistortion(Tpc_distortion_file);
     //tpc_distortion -> setAccuracy(0); // option to over write default  factors
     //tpc_distortion -> setPrecision(0.001); // option to over write default  factors      // default is 0.001
   }
 
-  PHG4CylinderCellTPCReco* svtx_cells = new PHG4CylinderCellTPCReco(n_maps_layer + n_intt_layer);
+  PHG4CylinderCellTpcReco* svtx_cells = new PHG4CylinderCellTpcReco(n_maps_layer + n_intt_layer);
   svtx_cells->Detector("SVTX");
   svtx_cells->setDistortion(tpc_distortion);
   //svtx_cells->setZigzags(true);  // set zigzag pads option on if true, use rectangular pads if false  (not required, defaults to true in code).
-  svtx_cells->setDiffusionT(TPC_Trans_Diffusion);
-  svtx_cells->setDiffusionL(TPC_Long_Diffusion);
-  svtx_cells->setSigmaT(TPC_SigmaT);  
-  svtx_cells->setShapingRMSLead(TPCShapingRMSLead * TPCDriftVelocity);
-  svtx_cells->setShapingRMSTail(TPCShapingRMSTail * TPCDriftVelocity);
+  svtx_cells->setDiffusionT(Tpc_Trans_Diffusion);
+  svtx_cells->setDiffusionL(Tpc_Long_Diffusion);
+  svtx_cells->setSigmaT(Tpc_SigmaT);  
+  svtx_cells->setShapingRMSLead(TpcShapingRMSLead * TpcDriftVelocity);
+  svtx_cells->setShapingRMSTail(TpcShapingRMSTail * TpcDriftVelocity);
   // Expected cluster resolutions:
   //     r-phi: diffusion + GEM smearing = 750 microns, assume resolution is 20% of that => 150 microns
-  //    Tune TPC_SmearRPhi and TPC_SmearZ to get 150 microns in the outer layers
-  svtx_cells->setSmearRPhi(TPC_SmearRPhi);  // additional random displacement of cloud positions wrt hits
-  svtx_cells->setSmearZ(TPC_SmearZ);        // additional random displacement of cloud positions wrt hits
-  svtx_cells->set_drift_velocity(TPCDriftVelocity);
+  //    Tune Tpc_SmearRPhi and Tpc_SmearZ to get 150 microns in the outer layers
+  svtx_cells->setSmearRPhi(Tpc_SmearRPhi);  // additional random displacement of cloud positions wrt hits
+  svtx_cells->setSmearZ(Tpc_SmearZ);        // additional random displacement of cloud positions wrt hits
+  svtx_cells->set_drift_velocity(TpcDriftVelocity);
   svtx_cells->setHalfLength(105.5);
-  svtx_cells->setElectronsPerKeV(TPC_ElectronsPerKeV);
+  svtx_cells->setElectronsPerKeV(Tpc_ElectronsPerKeV);
   svtx_cells->Verbosity(0);
 
   // The maps cell size is set when the detector is constructed because it is needed by the geometry object
   // The INTT ladder cell size is set in the detector construction code
 
-  // set cylinder cell TPC cell sizes
+  // set cylinder cell Tpc cell sizes
   //======================
 
-  double tpc_timing_window = 105.5 / TPCDriftVelocity;  // half length in cm / Vd in cm/ns => ns
+  double tpc_timing_window = 105.5 / TpcDriftVelocity;  // half length in cm / Vd in cm/ns => ns
 
   // inner layers
   double radius_layer = inner_readout_radius ;
@@ -628,7 +628,7 @@ void Svtx_Cells(int verbosity = 0)
     svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
     svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
     if (verbosity)
-      cout << "TPC cells inner: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
+      cout << "Tpc cells inner: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
     radius_layer += tpc_layer_thick_inner;
   }
 
@@ -640,7 +640,7 @@ void Svtx_Cells(int verbosity = 0)
     svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
     svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
     if (verbosity)
-      cout << "TPC cells mid: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
+      cout << "Tpc cells mid: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
     radius_layer += tpc_layer_thick_mid;
   }
 
@@ -651,7 +651,7 @@ void Svtx_Cells(int verbosity = 0)
     svtx_cells->cellsize(i, tpc_cell_rphi, tpc_cell_z);
     svtx_cells->set_timing_window(i, -tpc_timing_window, +tpc_timing_window);
     if (verbosity)
-      cout << "TPC cells outer: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
+      cout << "Tpc cells outer: layer " << i << " center radius " << radius_layer << " tpc_cell_rphi " << tpc_cell_rphi << " tpc_cell_z " << tpc_cell_z << endl;
 
     radius_layer += tpc_layer_thick_outer;
   }
@@ -724,13 +724,13 @@ void Svtx_Reco(int verbosity = 0)
 //    digiintt->Verbosity(1);
   }
 
-  // TPC layers use the Svtx digitizer
-  digi->SetTPCMinLayer(n_maps_layer + n_intt_layer);
+  // Tpc layers use the Svtx digitizer
+  digi->SetTpcMinLayer(n_maps_layer + n_intt_layer);
   double ENC = 670.0;  // standard
   digi->SetENC(ENC);  
   double ADC_threshold = 4.0*ENC; 
   digi->SetADCThreshold(ADC_threshold);  // 4 * ENC seems OK
-    cout << " TPC digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold 
+    cout << " Tpc digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold 
        << " maps+INTT layers set to " << n_maps_layer + n_intt_layer << endl;
  
   se->registerSubsystem(digi);
@@ -799,11 +799,11 @@ void Svtx_Reco(int verbosity = 0)
 
   se->registerSubsystem(clusterizer);
 
-  PHG4TPCClusterizer* tpcclusterizer = new PHG4TPCClusterizer();
+  PHG4TpcClusterizer* tpcclusterizer = new PHG4TpcClusterizer();
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->setRangeLayers(n_maps_layer + n_intt_layer, Max_si_layer);
   tpcclusterizer->setEnergyCut(15 /*adc*/);
-  tpcclusterizer->setFitWindowSigmas(0.0150, 0.0160);  // should be changed when TPC cluster resolution changes
+  tpcclusterizer->setFitWindowSigmas(0.0150, 0.0160);  // should be changed when Tpc cluster resolution changes
   tpcclusterizer->setFitWindowMax(5 /*rphibins*/, 5 /*zbins*/);
   se->registerSubsystem(tpcclusterizer);
 

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec.C
@@ -36,7 +36,7 @@ bool tpc_layers_40  = false;
 // Adds second evaluator to process refitted tracks and outputs separate ntuples
 bool use_primary_vertex = false;
 
-const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
+const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
 
 // default setup for the INTT - please don't change this. The configuration can be redone later in the macro if desired
 int n_intt_layer = 8;  
@@ -296,7 +296,7 @@ double Svtx(PHG4Reco* g4Reco, double radius,
       
       // D. McGlinchey 6Aug2018 - type no longer is used, included here because I was too lazy to remove it from the code
       int stave_type[3] = {0, 0, 0};
-      int staves_in_layer[3] = {12, 16, 20};       // Number of staves per layer in sPHENIX MVTX
+      int staves_in_layer[3] = {12, 16, 20};       // Number of staves per layer in sPHENIX Mvtx
       double phi_tilt[3] = {0.300, 0.305, 0.300}; // radians - numbers from Walt 6 Aug 2018
       
       for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
@@ -923,7 +923,7 @@ void Svtx_Eval(std::string outputfile, int verbosity = 0)
   if (use_primary_vertex)
   {
     // make a second evaluator that records tracks fitted with primary vertex included
-    // good for analysis of prompt tracks, particularly if MVTX is not present
+    // good for analysis of prompt tracks, particularly if Mvtx is not present
     SvtxEvaluator* evalp;
     evalp = new SvtxEvaluator("SVTXEVALUATOR", string(outputfile.c_str()) + "_primary_eval.root", "PrimaryTrackMap", n_maps_layer, n_intt_layer, n_gas_layer);
     evalp->do_cluster_eval(true);

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -9,8 +9,8 @@
 #include <g4hough/PHG4TrackKalmanFitter.h>
 #include <g4hough/PHG4TruthPatRec.h>
 #include <g4main/PHG4Reco.h>
-#include <g4mvtx/PHG4MVTXDefs.h>
-#include <g4mvtx/PHG4MVTXSubsystem.h>
+#include <g4mvtx/PHG4MvtxDefs.h>
+#include <g4mvtx/PHG4MvtxSubsystem.h>
 #include <g4tpc/PHG4TPCSpaceChargeDistortion.h>
 R__LOAD_LIBRARY(libg4hough.so)
 R__LOAD_LIBRARY(libg4eval.so)
@@ -28,7 +28,7 @@ bool tpc_layers_40  = false;
 // Adds second evaluator to process refitted tracks and outputs separate ntuples
 bool use_primary_vertex = false;
 
-const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
+const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
 
 // default setup for the INTT - please don't change this. The configuration can be redone later in the nacro if desired
 int n_intt_layer = 0;
@@ -232,18 +232,18 @@ double Svtx(PHG4Reco* g4Reco, double radius,
     //======================================================
 
     // Y. Corrales Morales 4Feb2019
-    // New MVTX configuration to give 2.0 mm clearance from sPHENIX beam-pipe (Walt 3 Jan 2018)
+    // New Mvtx configuration to give 2.0 mm clearance from sPHENIX beam-pipe (Walt 3 Jan 2018)
     //TODO: Add function to estimate stave tilt angle from values given by Walt (Rmin, Rmid, Rmax and sensor width)
-    //TODO: Add default values in PHG4MVTXSubsystem or PHG4MVTXDetector
+    //TODO: Add default values in PHG4MvtxSubsystem or PHG4MvtxDetector
     double maps_layer_radius[3] = {25.69, 33.735, 41.475};  // mm - numbers from Walt 3 Jan 2019 (Rmid)
     double phi_tilt[3] = {0.295, 0.303, 0.298};             // radians - numbers calculated from values given by Walt 3 Jan 2019
 
     // D. McGlinchey 6Aug2018 - type no longer is used, included here because I was too lazy to remove it from the code
     // Y. Corrales Morales - removed, no longer used in the code
     // int stave_type[3] = {0, 0, 0};
-    int staves_in_layer[3] = {12, 16, 20};  // Number of staves per layer in sPHENIX MVTX
+    int staves_in_layer[3] = {12, 16, 20};  // Number of staves per layer in sPHENIX Mvtx
 
-    PHG4MVTXSubsystem* mvtx = new PHG4MVTXSubsystem("MVTX");
+    PHG4MvtxSubsystem* mvtx = new PHG4MvtxSubsystem("MVTX");
     mvtx->Verbosity(verbosity);
 
     for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
@@ -259,11 +259,11 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
       radius = maps_layer_radius[ilayer];
     }
-    mvtx->set_string_param(PHG4MVTXDefs::GLOBAL ,"stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v02.gdml"));
+    mvtx->set_string_param(PHG4MvtxDefs::GLOBAL ,"stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v02.gdml"));
     // The cell size is used only during pixilization of sensor hits, but it is convemient to set it now because the geometry object needs it
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_x", 0.0030);          // pitch in cm
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_z", 0.0030);          // length in cm
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_thickness", 0.0018);  // thickness in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", 0.0030);          // pitch in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", 0.0030);          // length in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_thickness", 0.0018);  // thickness in cm
     mvtx->SetActive(1);
     mvtx->OverlapCheck(maps_overlapcheck);
     g4Reco->registerSubsystem(mvtx);

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -20,11 +20,11 @@
 #include <g4mvtx/PHG4MvtxSubsystem.h>
 #include <g4mvtx/PHG4MvtxHitReco.h>
 
-#include <g4tpc/PHG4TPCDigitizer.h>
-#include <g4tpc/PHG4TPCElectronDrift.h>
-#include <g4tpc/PHG4TPCPadPlane.h>
-#include <g4tpc/PHG4TPCPadPlaneReadout.h>
-#include <g4tpc/PHG4TPCSubsystem.h>
+#include <g4tpc/PHG4TpcDigitizer.h>
+#include <g4tpc/PHG4TpcElectronDrift.h>
+#include <g4tpc/PHG4TpcPadPlane.h>
+#include <g4tpc/PHG4TpcPadPlaneReadout.h>
+#include <g4tpc/PHG4TpcSubsystem.h>
 
 #include <intt/InttClusterizer.h>
 #include <mvtx/MvtxClusterizer.h>
@@ -247,11 +247,11 @@ double Tracking(PHG4Reco* g4Reco, double radius,
   }
 
 
-  // The TPC - always present!
+  // The Tpc - always present!
   //================================
   gSystem->Load("libg4tpc.so");
 
-  PHG4TPCSubsystem* tpc = new PHG4TPCSubsystem("TPC");
+  PHG4TpcSubsystem* tpc = new PHG4TpcSubsystem("TPC");
   tpc->SetActive();
   tpc->SuperDetector("TPC");
   tpc->set_double_param("steplimits", 1);
@@ -327,16 +327,16 @@ void Tracking_Cells(int verbosity = 0)
   }
 
   //=========================
-  // setup TPC readout for filling cells
-  // g4tpc/PHG4TPCElectronDrift uses
-  // g4tpc/PHG4TPCPadPlaneReadout
+  // setup Tpc readout for filling cells
+  // g4tpc/PHG4TpcElectronDrift uses
+  // g4tpc/PHG4TpcPadPlaneReadout
   //=========================
 
-  PHG4TPCPadPlane *padplane = new PHG4TPCPadPlaneReadout();
+  PHG4TpcPadPlane *padplane = new PHG4TpcPadPlaneReadout();
 
-  PHG4TPCElectronDrift *edrift = new PHG4TPCElectronDrift();
+  PHG4TpcElectronDrift *edrift = new PHG4TpcElectronDrift();
   edrift->Detector("TPC");
-  // fudge factors to get drphi 150 microns (in mid and outer TPC) and dz 500 microns cluster resolution
+  // fudge factors to get drphi 150 microns (in mid and outer Tpc) and dz 500 microns cluster resolution
   // They represent effects not due to ideal gas properties and ideal readout plane behavior
   // defaults are 0.12 and 0.15, they can be changed here to get a different resolution
   edrift->set_double_param("added_smear_trans",0.12);
@@ -344,9 +344,9 @@ void Tracking_Cells(int verbosity = 0)
   edrift->registerPadPlane(padplane);
   se->registerSubsystem(edrift);
 
-  // The pad plane readout default is set in PHG4TPCPadPlaneReadout
+  // The pad plane readout default is set in PHG4TpcPadPlaneReadout
   // We may want to change the number of inner layers, and can do that here
-  padplane->set_int_param("tpc_minlayer_inner", n_maps_layer + n_intt_layer);  // sPHENIX layer number of first TPC readout layer
+  padplane->set_int_param("tpc_minlayer_inner", n_maps_layer + n_intt_layer);  // sPHENIX layer number of first Tpc readout layer
   padplane->set_int_param("ntpc_layers_inner", n_tpc_layer_inner);
   padplane->set_int_param("ntpc_phibins_inner", tpc_layer_rphi_count_inner);
 
@@ -465,16 +465,16 @@ void Tracking_Reco(int verbosity = 0)
       se->registerSubsystem(digiintt);
     }
 
-  // TPC
+  // Tpc
   //====
-  PHG4TPCDigitizer* digitpc = new PHG4TPCDigitizer();
-  digitpc->SetTPCMinLayer(n_maps_layer + n_intt_layer);
+  PHG4TpcDigitizer* digitpc = new PHG4TpcDigitizer();
+  digitpc->SetTpcMinLayer(n_maps_layer + n_intt_layer);
   double ENC = 670.0;  // standard
   digitpc->SetENC(ENC);
   double ADC_threshold = 4.0 * ENC;
   digitpc->SetADCThreshold(ADC_threshold);  // 4 * ENC seems OK
 
-  cout << " TPC digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
+  cout << " Tpc digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
        << " maps+Intt layers set to " << n_maps_layer + n_intt_layer << endl;
 
   se->registerSubsystem(digitpc);
@@ -502,7 +502,7 @@ void Tracking_Reco(int verbosity = 0)
   }
   se->registerSubsystem(inttclusterizer);
 
-  // For the TPC
+  // For the Tpc
   //==========
   TpcClusterizer* tpcclusterizer = new TpcClusterizer();
   tpcclusterizer->Verbosity(0);

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -7,18 +7,18 @@
 #include <g4eval/TrkrEvaluator.h>
 #include <g4eval/SvtxEvaluator.h>
 
-#include <g4intt/PHG4INTTDefs.h>
-#include <g4intt/PHG4INTTDigitizer.h>
-#include <g4intt/PHG4INTTSubsystem.h>
-#include <g4intt/PHG4INTTHitReco.h>
-#include <g4intt/PHG4INTTDefs.h>
+#include <g4intt/PHG4InttDefs.h>
+#include <g4intt/PHG4InttDigitizer.h>
+#include <g4intt/PHG4InttSubsystem.h>
+#include <g4intt/PHG4InttHitReco.h>
+#include <g4intt/PHG4InttDefs.h>
 
 #include <g4main/PHG4Reco.h>
 
-#include <g4mvtx/PHG4MVTXDefs.h>
-#include <g4mvtx/PHG4MVTXDigitizer.h>
-#include <g4mvtx/PHG4MVTXSubsystem.h>
-#include <g4mvtx/PHG4MVTXHitReco.h>
+#include <g4mvtx/PHG4MvtxDefs.h>
+#include <g4mvtx/PHG4MvtxDigitizer.h>
+#include <g4mvtx/PHG4MvtxSubsystem.h>
+#include <g4mvtx/PHG4MvtxHitReco.h>
 
 #include <g4tpc/PHG4TPCDigitizer.h>
 #include <g4tpc/PHG4TPCElectronDrift.h>
@@ -59,68 +59,68 @@ R__LOAD_LIBRARY(libtrack_reco.so)
 #define INTTLADDER4_PP
 
 // Dead map options for INTT
-enum enu_INTTDeadMapType
+enum enu_InttDeadMapType
 {
-  kINTTNoDeadMap = 0,        // All channel in INTT is alive
-  kINTT4PercentDeadMap = 4,  // 4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
-  kINTT8PercentDeadMap = 8   // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
+  kInttNoDeadMap = 0,        // All channel in Intt is alive
+  kIntt4PercentDeadMap = 4,  // 4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
+  kIntt8PercentDeadMap = 8   // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
 };
 
-// Choose INTT deadmap here
-enu_INTTDeadMapType INTTDeadMapOption = kINTTNoDeadMap;
+// Choose Intt deadmap here
+enu_InttDeadMapType InttDeadMapOption = kInttNoDeadMap;
 
 // if true, refit tracks with primary vertex included in track fit  - good for analysis of prompt tracks only
 // Adds second node to node tree, keeps original track node undisturbed
 // Adds second evaluator to process refitted tracks and outputs separate ntuples
 bool use_primary_vertex = false;
 
-const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes MVTX completely, n < 3 gives the first n layers
+const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
 
-// Configure the INTT layers
+// Configure the Intt layers
 // offsetphi is in deg, every other layer is offset by one half of the phi spacing between ladders
 #ifdef INTTLADDER8
 int n_intt_layer = 8;
 // default layer configuration
-int laddertype[8] = {PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI};                                    // default
+int laddertype[8] = {PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI};                                    // default
 int nladder[8] = {17, 17, 15, 15, 18, 18, 21, 21};                                       // default
 double sensor_radius[8] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361, 12.676, 13.179};  // radius of center of sensor for layer default
 double offsetphi[8] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5], 0.0, 0.5 * 360.0 / nladder[7]};
 #endif
 #ifdef INTTLADDER6
 int n_intt_layer = 6;
-int laddertype[6] = {PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI};
+int laddertype[6] = {PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI};
 int nladder[6] = {17, 17, 15, 15, 18, 18};
 double sensor_radius[6] = {6.876, 7.462, 8.987, 9.545, 10.835, 11.361};  // radius of center of sensor for layer default
 double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3], 0.0, 0.5 * 360.0 / nladder[5]};
 #endif
 #ifdef INTTLADDER4_ZP
 int n_intt_layer = 4;
-int laddertype[4] = {PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_Z,
-                     PHG4INTTDefs::SEGMENTATION_PHI,
-                     PHG4INTTDefs::SEGMENTATION_PHI};
+int laddertype[4] = {PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_Z,
+                     PHG4InttDefs::SEGMENTATION_PHI,
+                     PHG4InttDefs::SEGMENTATION_PHI};
 int nladder[4] = {17, 17, 18, 18};
 double sensor_radius[6] = {6.876, 7.462, 10.835, 11.361};  // radius of center of sensor for layer default
 double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3]};
 #endif
 #ifdef INTTLADDER4_PP
 int n_intt_layer = 4;
-int laddertype[4] = {PHG4INTTDefs::SEGMENTATION_PHI,
-		       PHG4INTTDefs::SEGMENTATION_PHI,
-		       PHG4INTTDefs::SEGMENTATION_PHI,
-		       PHG4INTTDefs::SEGMENTATION_PHI};
+int laddertype[4] = {PHG4InttDefs::SEGMENTATION_PHI,
+		       PHG4InttDefs::SEGMENTATION_PHI,
+		       PHG4InttDefs::SEGMENTATION_PHI,
+		       PHG4InttDefs::SEGMENTATION_PHI};
 int nladder[4] = {15,  15, 18, 18};
 double sensor_radius[6] = { 8.987, 9.545, 10.835, 11.361};  // radius of center of sensor for layer default
 double offsetphi[6] = {0.0, 0.5 * 360.0 / nladder[1] , 0.0, 0.5 * 360.0 / nladder[3]};
@@ -161,18 +161,18 @@ double Tracking(PHG4Reco* g4Reco, double radius,
     //======================================================
 
     // Y. Corrales Morales 4Feb2019
-    // New MVTX configuration to give 2.0 mm clearance from sPHENIX beam-pipe (Walt 3 Jan 2018)
+    // New Mvtx configuration to give 2.0 mm clearance from sPHENIX beam-pipe (Walt 3 Jan 2018)
     //TODO: Add function to estimate stave tilt angle from values given by Walt (Rmin, Rmid, Rmax and sensor width)
-    //TODO: Add default values in PHG4MVTXSubsystem or PHG4MVTXDetector
+    //TODO: Add default values in PHG4MvtxSubsystem or PHG4MvtxDetector
     double maps_layer_radius[3] = {25.69, 33.735, 41.475};  // mm - numbers from Walt 3 Jan 2019 (Rmid)
     double phi_tilt[3] = {0.295, 0.303, 0.298};             // radians - numbers calculated from values given by Walt 3 Jan 2019
 
     // D. McGlinchey 6Aug2018 - type no longer is used, included here because I was too lazy to remove it from the code
     // Y. Corrales Morales - removed, no longer used in the code
     // int stave_type[3] = {0, 0, 0};
-    int staves_in_layer[3] = {12, 16, 20};  // Number of staves per layer in sPHENIX MVTX
+    int staves_in_layer[3] = {12, 16, 20};  // Number of staves per layer in sPHENIX Mvtx
 
-    PHG4MVTXSubsystem* mvtx = new PHG4MVTXSubsystem("MVTX");
+    PHG4MvtxSubsystem* mvtx = new PHG4MvtxSubsystem("MVTX");
     mvtx->Verbosity(verbosity);
 
     for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
@@ -188,11 +188,11 @@ double Tracking(PHG4Reco* g4Reco, double radius,
 
       radius = maps_layer_radius[ilayer];
     }
-    mvtx->set_string_param(PHG4MVTXDefs::GLOBAL ,"stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v02.gdml"));
+    mvtx->set_string_param(PHG4MvtxDefs::GLOBAL ,"stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v02.gdml"));
     // The cell size is used only during pixilization of sensor hits, but it is convemient to set it now because the geometry object needs it
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_x", 0.0030);          // pitch in cm
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_z", 0.0030);          // length in cm
-    mvtx->set_double_param(PHG4MVTXDefs::ALPIDE_SEGMENTATION, "pixel_thickness", 0.0018);  // thickness in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_x", 0.0030);          // pitch in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_z", 0.0030);          // length in cm
+    mvtx->set_double_param(PHG4MvtxDefs::ALPIDE_SEGMENTATION, "pixel_thickness", 0.0018);  // thickness in cm
     mvtx->SetActive(1);
     mvtx->OverlapCheck(maps_overlapcheck);
     g4Reco->registerSubsystem(mvtx);
@@ -210,7 +210,7 @@ double Tracking(PHG4Reco* g4Reco, double radius,
     // We make one instance of PHG4INTTSubsystem for all four layers of tracker
     // dimensions are in mm, angles are in radians
 
-    // PHG4INTTSubsystem creates the detetor layer using PHG4INTTDetector
+    // PHG4InttSubsystem creates the detetor layer using PHG4InttDetector
     // and instantiates the appropriate PHG4SteppingAction
     const double intt_radius_max = 140.;  // including stagger radius (mm)
 
@@ -218,12 +218,12 @@ double Tracking(PHG4Reco* g4Reco, double radius,
     std::vector<std::pair<int, int>> vpair;  // (sphxlayer, inttlayer)
     for (int i = 0; i < n_intt_layer; i++)
     {
-      // We want the sPHENIX layer numbers for the INTT to be from n_maps_layer to n_maps_layer+n_intt_layer - 1
+      // We want the sPHENIX layer numbers for the Intt to be from n_maps_layer to n_maps_layer+n_intt_layer - 1
       vpair.push_back(std::make_pair(n_maps_layer + i, i));  // sphxlayer=n_maps_layer+i corresponding to inttlayer=i
       if (verbosity) cout << "Create strip tracker layer " << vpair[i].second << " as  sphenix layer  " << vpair[i].first << endl;
     }
 
-    PHG4INTTSubsystem* sitrack = new PHG4INTTSubsystem("INTT", vpair);
+    PHG4InttSubsystem* sitrack = new PHG4InttSubsystem("INTT", vpair);
     sitrack->Verbosity(verbosity);
     sitrack->SetActive(1);
     sitrack->OverlapCheck(intt_overlapcheck);
@@ -231,10 +231,10 @@ double Tracking(PHG4Reco* g4Reco, double radius,
 
     // Set the laddertype and ladder spacing configuration
 
-    cout << "INTT has " << n_intt_layer << " layers with layer setup:" << endl;
+    cout << "Intt has " << n_intt_layer << " layers with layer setup:" << endl;
     for(int i=0;i<n_intt_layer;i++)
       {
-	cout << " INTT layer " << i << " laddertype " << laddertype[i] << " nladders " << nladder[i]
+	cout << " Intt layer " << i << " laddertype " << laddertype[i] << " nladders " << nladder[i]
 	     << " sensor radius " << sensor_radius[i] << " offsetphi " << offsetphi[i] << endl;
 	sitrack->set_int_param(i, "laddertype", laddertype[i]);
 	sitrack->set_int_param(i, "nladder", nladder[i]);
@@ -297,13 +297,13 @@ void Tracking_Cells(int verbosity = 0)
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  // MVTX hit reco
+  // Mvtx hit reco
   //===========
 
   if (n_maps_layer > 0)
   {
     // new storage containers
-    PHG4MVTXHitReco* maps_hits = new PHG4MVTXHitReco("MVTX");
+    PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
     maps_hits->Verbosity(verbosity);
     for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
     {
@@ -313,12 +313,12 @@ void Tracking_Cells(int verbosity = 0)
     se->registerSubsystem(maps_hits);
   }
 
-  // INTT hit reco
+  // Intt hit reco
   //===========
   if (n_intt_layer > 0)
   {
     // new storage containers
-    PHG4INTTHitReco* reco = new PHG4INTTHitReco("INTT");
+    PHG4InttHitReco* reco = new PHG4InttHitReco("INTT");
     // The timing windows are hard-coded in the INTT ladder model, they can be overridden here
     //reco->set_double_param("tmax",80.0);
     //reco->set_double_param("tmin",-20.0);
@@ -373,9 +373,9 @@ void Tracking_Reco(int verbosity = 0)
   // Digitize the hit energy into ADC
   //------------------------------------------
 
-  // MVTX
+  // Mvtx
   //======
-  PHG4MVTXDigitizer* digimvtx = new PHG4MVTXDigitizer();
+  PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();
   digimvtx->Verbosity(0);
   // energy deposit in 25 microns = 9.6 KeV = 1000 electrons collected after recombination
   //digimvtx->set_adc_scale(0.95e-6);  // default set in code is 0.95e-06, which is 99 electrons
@@ -385,46 +385,46 @@ void Tracking_Reco(int verbosity = 0)
     {
 
 #ifdef SVTXDEADMAP
-      if (INTTDeadMapOption != kINTTNoDeadMap)
+      if (InttDeadMapOption != kInttNoDeadMap)
 	{
 	  // Load pre-defined deadmaps
-	  PHG4SvtxDeadMapLoader* deadMapINTT = new PHG4SvtxDeadMapLoader("INTT");
+	  PHG4SvtxDeadMapLoader* deadMapIntt = new PHG4SvtxDeadMapLoader("INTT");
 	  for (int i = 0; i < n_intt_layer; i++)
 	    {
-	      const int database_strip_type = (laddertype[i] == PHG4INTTDefs::SEGMENTATION_Z) ? 0 : 1;
+	      const int database_strip_type = (laddertype[i] == PHG4InttDefs::SEGMENTATION_Z) ? 0 : 1;
 	      string DeadMapConfigName = Form("LadderType%d_RndSeed%d/", database_strip_type, i);
 
 
-	      if (INTTDeadMapOption == kINTT4PercentDeadMap)
+	      if (InttDeadMapOption == kIntt4PercentDeadMap)
 		{
 
 		  string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_4Percent/"); //4% of dead/masked area (2% sensor + 2% chip) as a typical FVTX Run14 production run.
 		  DeadMapPath +=  DeadMapConfigName;
-		  deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
+		  deadMapIntt->deadMapPath(n_maps_layer + i, DeadMapPath);
 
 		}
-	      else if (INTTDeadMapOption == kINTT8PercentDeadMap)
+	      else if (InttDeadMapOption == kIntt8PercentDeadMap)
 		{
 
 		  string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap_8Percent/"); // 8% dead/masked area (6% sensor + 2% chip) as threshold of operational
 		  DeadMapPath +=  DeadMapConfigName;
-		  deadMapINTT->deadMapPath(n_maps_layer + i, DeadMapPath);
+		  deadMapIntt->deadMapPath(n_maps_layer + i, DeadMapPath);
 
 		}
 	      else
 		{
-		  cout <<"Tracking_Reco - fatal error - invalid INTTDeadMapOption = "<<INTTDeadMapOption<<endl;
+		  cout <<"Tracking_Reco - fatal error - invalid InttDeadMapOption = "<<InttDeadMapOption<<endl;
 		  exit(1);
 		}
 	    }
-	  //      deadMapINTT -> Verbosity(1);
-	  se->registerSubsystem(deadMapINTT);
+	  //      deadMapIntt -> Verbosity(1);
+	  se->registerSubsystem(deadMapIntt);
 	}
 #endif // SVTXDEADMAP
 
-      // INTT
+      // Intt
       //=====
-      // these should be used for the INTT
+      // these should be used for the Intt
       /*
 	How threshold are calculated based on default FPHX settings
 	Four part information goes to the threshold calculation:
@@ -443,7 +443,7 @@ void Tracking_Reco(int verbosity = 0)
 	| 9                     | Threshold DAC 5 | 112           | 448                 | 35000                             | 28000     | 8.18E-01        |
 	| 10                    | Threshold DAC 6 | 144           | 576                 | 45000                             | 36000     | 1.05E+00        |
 	| 11                    | Threshold DAC 7 | 176           | 704                 | 55000                             | 44000     | 1.29E+00        |
-	DAC0-7 threshold as fraction to MIP voltage are set to PHG4INTTDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.
+	DAC0-7 threshold as fraction to MIP voltage are set to PHG4InttDigitizer::set_adc_scale as 3-bit ADC threshold as fractions to MIP energy deposition.
       */
       std::vector<double> userrange;  // 3-bit ADC threshold relative to the mip_e at each layer.
       userrange.push_back(0.0584625322997416);
@@ -456,7 +456,7 @@ void Tracking_Reco(int verbosity = 0)
       userrange.push_back(1.28617571059432);
 
       // new containers
-      PHG4INTTDigitizer* digiintt = new PHG4INTTDigitizer();
+      PHG4InttDigitizer* digiintt = new PHG4InttDigitizer();
       digiintt->Verbosity(verbosity);
       for (int i = 0; i < n_intt_layer; i++)
 	{
@@ -475,7 +475,7 @@ void Tracking_Reco(int verbosity = 0)
   digitpc->SetADCThreshold(ADC_threshold);  // 4 * ENC seems OK
 
   cout << " TPC digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
-       << " maps+INTT layers set to " << n_maps_layer + n_intt_layer << endl;
+       << " maps+Intt layers set to " << n_maps_layer + n_intt_layer << endl;
 
   se->registerSubsystem(digitpc);
 
@@ -483,21 +483,21 @@ void Tracking_Reco(int verbosity = 0)
   // Cluster Hits
   //-------------
 
-  // For the MVTX layers
+  // For the Mvtx layers
   //================
   MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
 
-  // For the INTT layers
+  // For the Intt layers
   //===============
   InttClusterizer* inttclusterizer = new InttClusterizer("InttClusterizer", n_maps_layer, n_maps_layer + n_intt_layer - 1);
   inttclusterizer->Verbosity(verbosity);
-  // no Z clustering for INTT type 1 layers (we DO want Z clustering for type 0 layers)
+  // no Z clustering for Intt type 1 layers (we DO want Z clustering for type 0 layers)
   // turning off phi clustering for type 0 layers is not necessary, there is only one strip per sensor in phi
   for (int i = n_maps_layer; i < n_maps_layer + n_intt_layer; i++)
   {
-    if (laddertype[i - n_maps_layer] == PHG4INTTDefs::SEGMENTATION_PHI)
+    if (laddertype[i - n_maps_layer] == PHG4InttDefs::SEGMENTATION_PHI)
       inttclusterizer->set_z_clustering(i, false);
   }
   se->registerSubsystem(inttclusterizer);
@@ -530,7 +530,7 @@ void Tracking_Reco(int verbosity = 0)
 
       for(int i = 0;i<n_intt_layer;i++)
 	{
-	  if(laddertype[i] == PHG4INTTDefs::SEGMENTATION_Z)
+	  if(laddertype[i] == PHG4InttDefs::SEGMENTATION_Z)
 	    {
 	      // strip length is along phi
 	      track_prop->set_max_search_win_theta_intt(i, 0.010);
@@ -617,7 +617,7 @@ void Tracking_Reco(int verbosity = 0)
   if (use_primary_vertex)
   {
     // make a second evaluator that records tracks fitted with primary vertex included
-    // good for analysis of prompt tracks, particularly if MVTX is not present
+    // good for analysis of prompt tracks, particularly if Mvtx is not present
     SvtxEvaluator* evalp;
     evalp = new SvtxEvaluator("SVTXEVALUATOR", string(outputfile.c_str()) + "_primary_eval.root", "PrimaryTrackMap", n_maps_layer, n_intt_layer, n_gas_layer);    evalp->do_cluster_eval(true);
     evalp->do_g4hit_eval(true);


### PR DESCRIPTION
This PR updates the macros for the decapitalized uniformly named Intt, Mvtx and Tpc in the coresoftware.