### PR TITLE
TPC -> Tpc

### DIFF
--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -11,7 +11,7 @@
 #include <g4main/PHG4Reco.h>
 #include <g4mvtx/PHG4MvtxDefs.h>
 #include <g4mvtx/PHG4MvtxSubsystem.h>
-#include <g4tpc/PHG4TPCSpaceChargeDistortion.h>
+#include <g4tpc/PHG4TpcSpaceChargeDistortion.h>
 R__LOAD_LIBRARY(libg4hough.so)
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4mvtx.so)


### PR DESCRIPTION
This PR fixes an oversight in one of the macros where I had forgotten to replace TPC by Tpc in an include filename