### PR TITLE
Fix InttHitReco module name

### DIFF
--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -320,7 +320,7 @@ void Tracking_Cells(int verbosity = 0)
   if (n_intt_layer > 0)
   {
     // new storage containers
-    PHG4InttHitReco* reco = new PHG4InttHitReco("INTT");
+    PHG4InttHitReco* reco = new PHG4InttHitReco();
     // The timing windows are hard-coded in the INTT ladder model, they can be overridden here
     //reco->set_double_param("tmax",80.0);
     //reco->set_double_param("tmin",-20.0);


### PR DESCRIPTION
The parameter is supposed to be the module name, not the detector so one can see in printouts which module is running. The detector name is now initialized in the code, it's still hokey and will break if you rename the detector.