### PR TITLE
load lib for sartre

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -36,6 +36,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4testbench.so)
 R__LOAD_LIBRARY(libPHPythia6.so)
 R__LOAD_LIBRARY(libPHPythia8.so)
+R__LOAD_LIBRARY(libPHSartre.so)
 #endif
 
 using namespace std;


### PR DESCRIPTION
This PR enables Sartre to run. It adds Sartre.cfg (copied from the sartre installation) and add the loading of the sartre library