### PR TITLE
Add missing phpythia6.cfg copied from analysys/EICTRigger

### DIFF
--- a/macros/g4simulations/phpythia6.cfg
+++ b/macros/g4simulations/phpythia6.cfg
@@ -1,0 +1,17 @@
+roots   200
+proj    p
+targ    p
+frame   cms
+msel    0       // turn on all prod. mechanisms manually
+msub    11 1    // these are the semi-hard QCD 2->2 processes
+msub    12 1
+msub    13 1
+msub    28 1
+msub    53 1
+msub    68 1
+mstp    91 1    // gaussian intrinsic kt
+parp    91 1.5  // intrinsic kt value
+mstp    33 1    // use k factor
+parp    31 2.5  // k factor
+ckin    3  2.0  // min parton pt of 2.0
+#mstj   1  2    // independent fragmentation


### PR DESCRIPTION
This PR adds the missing missing phpythia6.cfg copied from analysys/EICTrigger so it at least runs