### PR TITLE
Add example sartre config file so the macro runs

### DIFF
--- a/macros/g4simulations/sartre.cfg
+++ b/macros/g4simulations/sartre.cfg
@@ -1,0 +1,113 @@
+//==============================================================================
+//  sartreRuncard.txt
+//
+//  Copyright (C) 2010-2013 Tobias Toll and Thomas Ullrich 
+//
+//  This file is part of Sartre version: 1.1
+//
+//  This program is free software: you can redistribute it and/or modify 
+//  it under the terms of the GNU General Public License as published by 
+//  the Free Software Foundation.   
+//  This program is distributed in the hope that it will be useful, 
+//  but without any warranty; without even the implied warranty of 
+//  merchantability or fitness for a particular purpose. See the 
+//  GNU General Public License for more details. 
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  Author: Thomas Ullrich 
+//  Last update: 
+//  $Date: 2015-05-29 13:37:30 -0400 (Fri, 29 May 2015) $
+//  $Author: tobilibob@gmail.com $
+//==============================================================================
+// 
+//  Example Runcard for Sartre Event Generator. 
+// 
+//  Comments start with a # or // 
+// 
+//  Name and value are separated by a "=":  name = value 
+//  (alternatively ":" can be used as well) 
+//==============================================================================  
+# 
+#  Define beams 
+# 
+eBeamEnergy =  100
+hBeamEnergy =  100  
+A           =  197
+
+# 
+# UPC settings, to run in UPC mode set UPC=true and UPCA into the photon emitting species:
+#
+UPC=true
+UPCA=1
+
+# 
+#  Number of events and printout frequency 
+# 
+numberOfEvents =  100000
+timesToShow    =  20
+ 
+# 
+#  Set verbosity 
+# 
+verbose       =  false 
+verboseLevel  =  0
+ 
+# 
+#  Rootfile  
+# 
+rootfile =  example.root 
+ 
+# 
+#  Model parameters 
+# 
+#  vectorMesonID: 22, 113, 333, 443
+#  dipoleModel: bSat or bNonSat
+#
+vectorMesonId =  443
+#dipoleModel =  bSat 
+dipoleModel =  bNonSat 
+ 
+# 
+# User variable used for vector meson decays 
+# PDG: pi+ = 211, K+ = 321, e- = 11, mu- = 13  
+#
+userInt = 11
+
+# 
+#  Kinematic range min > max means no limits (given by table range) 
+# 
+Q2min =  1000000
+Q2max =  0
+Wmin  =  1000000
+Wmax  =  0
+ 
+# 
+#  Corrections 
+# 
+correctForRealAmplitude =  true
+correctSkewedness       =  true
+# maxLambdaUsedInCorrections = 0.65
+ 
+# 
+#  Misc 
+# 
+enableNuclearBreakup = false
+maxNuclearExcitationEnergy = 0.5
+ 
+# 
+#  Random generator seed (if not given current time is used) 
+# 
+#seed =  2011987 
+
+# 
+#  User parameters 
+# 
+# userDouble = 0.
+# userString = "Hello World!"
+# userInt = 0
+
+#
+#  Expert flags
+#
+# applyPhotonFlux = true


### PR DESCRIPTION
This PR adds the sartre.cfg which I seem to have forgotten to add/commit. It is needed to run the sartre event generator in our standard macros