### PR TITLE
use Al by default

### DIFF
--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -22,9 +22,9 @@ R__LOAD_LIBRARY(libg4eval.so)
 #endif
 
 //Inner HCal absorber material selector:
-//false - Default, absorber material is SS310
-//true - Choose if you want Aluminum
-const bool inner_hcal_material_Al = false;
+//false - old version, absorber material is SS310
+//true - default Choose if you want Aluminum
+const bool inner_hcal_material_Al = true;
 
 static int inner_hcal_eic = 0;
 


### PR DESCRIPTION
This PR changes the material chosen in the macro to Al (the code default still uses SS310). This was discussed in the simulation meeting yesterday