### PR TITLE
Add fEMC to sPHENIX

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -117,6 +117,12 @@ int Fun4All_G4_sPHENIX(
   bool do_hcalout_cluster = do_hcalout_twr && true;
   bool do_hcalout_eval = do_hcalout_cluster && true;
 
+  // forward EMC
+  bool do_FEMC = true;
+  bool do_FEMC_cell = do_FEMC && true;
+  bool do_FEMC_twr = do_FEMC_cell && true;
+  bool do_FEMC_cluster = do_FEMC_twr && true;
+
   //! forward flux return plug door. Out of acceptance and off by default.
   bool do_plugdoor = false;
 
@@ -149,7 +155,7 @@ int Fun4All_G4_sPHENIX(
   gSystem->Load("libg4intt.so");
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor);
+  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, do_FEMC);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
@@ -338,10 +344,10 @@ int Fun4All_G4_sPHENIX(
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
     G4Setup(absorberactive, magfield, EDecayType::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_FEMC, magfield_rescale);
 #else
     G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_FEMC, magfield_rescale);
 #endif
   }
 

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -118,7 +118,7 @@ int Fun4All_G4_sPHENIX(
   bool do_hcalout_eval = do_hcalout_cluster && true;
 
   // forward EMC
-  bool do_FEMC = true;
+  bool do_FEMC = false;
   bool do_FEMC_cell = do_FEMC && true;
   bool do_FEMC_twr = do_FEMC_cell && true;
   bool do_FEMC_cluster = do_FEMC_twr && true;

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -8,6 +8,7 @@
 #include "G4_Magnet.C"
 #include "G4_HcalOut_ref.C"
 #include "G4_PlugDoor.C"
+#include "G4_FEMC.C"
 
 #include <g4eval/PHG4DstCompressReco.h>
 #include <fun4all/Fun4AllServer.h>
@@ -38,7 +39,8 @@ void G4Init(const bool do_tracking = true,
 	    const bool do_magnet = true,
 	    const bool do_hcalout = true,
 	    const bool do_pipe = true,
-	    const bool do_plugdoor = false
+	    const bool do_plugdoor = false,
+	    const bool do_FEMC = false
 	    )
   {
 
@@ -89,6 +91,12 @@ void G4Init(const bool do_tracking = true,
       gROOT->LoadMacro("G4_PlugDoor.C");
       PlugDoorInit();
     }
+  if (do_FEMC)
+    {
+      gROOT->LoadMacro("G4_FEMC.C");
+      FEMCInit();
+    }
+
 }
 
 
@@ -108,6 +116,7 @@ int G4Setup(const int absorberactive = 0,
       const bool do_pipe = true,
       const bool do_plugdoor = false,
 //	    const bool do_plugdoor = true,
+	    const bool do_FEMC = false, 
 	    const float magfield_rescale = 1.0) {
   
   //---------------
@@ -196,6 +205,9 @@ int G4Setup(const int absorberactive = 0,
   // sPHENIX forward flux return door
   if (do_plugdoor) PlugDoor(g4Reco, absorberactive);
 
+  // forward EMC
+  if(do_FEMC) FEMCSetup(g4Reco, absorberactive);
+
   //----------------------------------------
   // BLACKHOLE
   
@@ -279,6 +291,12 @@ void ShowerCompress(int verbosity = 0) {
   compress->AddTowerContainer("TOWER_SIM_HCALOUT");
   compress->AddTowerContainer("TOWER_RAW_HCALOUT");
   compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+  compress->AddHitContainer("G4HIT_FEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
+  compress->AddCellContainer("G4CELL_FEMC");
+  compress->AddTowerContainer("TOWER_SIM_FEMC");
+  compress->AddTowerContainer("TOWER_RAW_FEMC");
+  compress->AddTowerContainer("TOWER_CALIB_FEMC");
   se->registerSubsystem(compress);
   
   return; 
@@ -304,5 +322,8 @@ void DstCompress(Fun4AllDstOutputManager* out) {
     out->StripNode("G4CELL_CEMC");
     out->StripNode("G4CELL_HCALIN");
     out->StripNode("G4CELL_HCALOUT");
+    out->StripNode("G4HIT_FEMC");
+    out->StripNode("G4HIT_ABSORBER_FEMC");
+    out->StripNode("G4CELL_FEMC");
   }
 }


### PR DESCRIPTION
This set of macro changes enables the forward EMCal (fEMC) for sPHENIX. The fEMC was originally developed for fsPHENIX but is potentially useful in determining the event plane outside the central barrel.  The changes are straightforward, and take advantage of the same macro and geometry used in the fsPHENIX macro.  There are no geometry conflicts between the fEMC and the existing sPHENIX setup (including the plug door, which is not enabled in the sPHENIX macro by default). 

![sPHENIX_with_fEMC](https://user-images.githubusercontent.com/3042746/65785530-32408800-e11a-11e9-8fcf-506d3dcb1e21.png)

I tested these changes by visual inspection (see figure), checking for overlaps between the fEMC detectors and other volumes (the fEMC is added last in the macros) and by running a handful of sHIJING events. Everything seems just fine. 