### PR TITLE
Add comment to clarify where the xml file applies

### DIFF
--- a/macros/g4simulations/flowAfterburner.xml
+++ b/macros/g4simulations/flowAfterburner.xml
@@ -5,6 +5,11 @@
   </RANDOM>
   <INPUT>sHijing.dat</INPUT>
   <OUTPUT>flowAfterburner.dat</OUTPUT>
+<!--
+     the following adjusts the values used in the executable
+     if you want to change the values used by the flow afterburner
+     module in our simulations you need to change the macro
+-->
   <CUTS>
     <MINETA>-4.0</MINETA>
     <MAXETA>4.0</MAXETA>


### PR DESCRIPTION
This PR just adds a comment to the flowAfterburner.xml file to clarify that it only applies to the executable, not the flow afterburner module in the simulations