### PR TITLE
Fixed FEMC Separation Bug

### DIFF
--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -9,7 +9,7 @@
 #include "G4_Magnet.C"
 #include "G4_HcalOut_ref.C"
 #include "G4_PlugDoor_EIC.C"
-#include "G4_FEMC.C"
+#include "G4_FEMC_EIC.C"
 #include "G4_FHCAL.C"
 #include "G4_EEMC.C"
 #include "G4_DIRC.C"

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -64,13 +64,15 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   ostringstream mapping_femc;
 
   
+  femc->SetEICDetector(); 
+  // fsPHENIX ECAL
   mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
 
   cout << mapping_femc.str() << endl;
-
   femc->SetTowerMappingFile( mapping_femc.str() );
   femc->OverlapCheck(overlapcheck);
-
+  femc->SetActive();
+  femc->SuperDetector("FEMC");
   if (absorberactive)  femc->SetAbsorberActive();
 
   g4Reco->registerSubsystem( femc );


### PR DESCRIPTION
Jin pointed out a bug with running the EIC framework in root5 after the FEMC fsPHENIX/EIC separation. 

Tested with both root5 and root6 on rcas - bug of not working with root5 appears to be fixed.