### PR TITLE
Qt initvis

### DIFF
--- a/macros/g4jleic/DisplayOn.C
+++ b/macros/g4jleic/DisplayOn.C
@@ -4,6 +4,19 @@
 #include <g4main/PHG4Reco.h>
 #endif
 
+// This starts the QT based G4 gui which takes control
+// when x'ed out it will return a pointer to PHG4Reco so
+// the gui can be startrd again
+PHG4Reco *QTGui()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  g4->StartGui();
+  return g4;
+}
+
 // stupid macro to turn on the geant4 display
 // we ask Fun4All for a pointer to PHG4Reco
 // using the ApplyCommand will start up the

--- a/macros/g4jleic/init_gui_vis.mac
+++ b/macros/g4jleic/init_gui_vis.mac
@@ -13,5 +13,8 @@
 # Initialize kernel
 /run/initialize
 #
-# Visualization setting
-/control/execute vis.mac
+# create empty scene
+#
+/vis/scene/create
+# open graphics (opengl QT)
+/vis/open OGL

--- a/macros/g4simulations/DisplayOn.C
+++ b/macros/g4simulations/DisplayOn.C
@@ -4,6 +4,19 @@
 #include <g4main/PHG4Reco.h>
 #endif
 
+// This starts the QT based G4 gui which takes control
+// when x'ed out it will return a pointer to PHG4Reco so
+// the gui can be startrd again
+PHG4Reco *QTGui()
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+  PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco("PHG4RECO");
+  g4->InitRun(se->topNode());
+  g4->ApplyDisplayAction();
+  g4->StartGui();
+  return g4;
+}
+
 // stupid macro to turn on the geant4 display
 // we ask Fun4All for a pointer to PHG4Reco
 // using the ApplyCommand will start up the

--- a/macros/g4simulations/init_gui_vis.mac
+++ b/macros/g4simulations/init_gui_vis.mac
@@ -13,5 +13,8 @@
 # Initialize kernel
 /run/initialize
 #
-# Visualization setting
-/control/execute vis.mac
+# create empty scene
+#
+/vis/scene/create
+# open graphics (opengl QT)
+/vis/open OGL


### PR DESCRIPTION
When using the qt based gui another opengl graphics driver needs to be used. PHG4Reco::StartGui() executes init_gui_vis.mac by default which so far called vis.mac which is used by the regular display. Now init_gui_vis.mac is standalone and calls the OGL graphics driver but nothing else. Our vis.mac has a bunch of additional calls (saving trajectories, filtering of tracks, cutting the detector), this needs to be either added or called in a separate macro (which is the preferred choice)
The DisplayOn.C has a new function QTGui() which starts the qt gui and returns a pointer to PHG4Reco (after the gui is x'ed out) so it can be restarted by g4->QTGui()