### PR TITLE
Enable printing of random seeds for rare problem debugging

### DIFF
--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -1,4 +1,5 @@
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#include <phool/PHRandomSeed.h>
 #include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllInputManager.h>
@@ -175,6 +176,10 @@ int Fun4All_G4_sPHENIX(
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
+
+  //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
+  PHRandomSeed::Verbosity(1);
+
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();
   // By default every random number generator uses


### PR DESCRIPTION
Following the discussion in the last meeting, enable printing of random seeds for rare problem debugging, such as the on-going debug for rare non-initialized variable in the tracking evaluator.

This is a 2nd try of https://github.com/sPHENIX-Collaboration/coresoftware/pull/717 following @pinkenburg 's suggestions