### PR TITLE
Modified EEMC and CEMC_EIC Geometry for consistency

### DIFF
--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -83,7 +83,7 @@ void EEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_eemc;
   mapping_eemc << getenv("CALIBRATIONROOT") <<
-    "/CrystalCalorimeter/mapping/towerMap_EEMC_v004.txt";
+    "/CrystalCalorimeter/mapping/towerMap_EEMC_v005.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");


### PR DESCRIPTION
Modified EEMC macro as discussed on slides 9-10 here:

https://indico.bnl.gov/event/7399/contributions/34257/attachments/26399/39954/sphenix_012820.pdf

The only difference is that I changed the line with v004->v005, instead of the other way.

In addition, for the CEMC, to keep a fixed eta acceptance for each layer requires a layer-dependent shift. This has been implemented here.