### PR TITLE
My macros

### DIFF
--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -269,6 +269,11 @@ void CEMC_Clusters(int verbosity = 0) {
     cemc_clusterbuilder->Detector("CEMC");
     cemc_clusterbuilder->Verbosity(verbosity);
 
+    ClusterBuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    ClusterBuilder->LoadProfile(femc_prof.c_str());
+
     se->registerSubsystem(cemc_clusterbuilder);
   } else {
     cout << "CEMC_Clusters - unknown clusterizer setting!! " << endl;

--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -262,17 +262,17 @@ void CEMC_Clusters(int verbosity = 0) {
     cemc_clusterbuilder->Detector("CEMC");
     cemc_clusterbuilder->Verbosity(verbosity);
 
+    cemc_clusterbuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    cemc_clusterbuilder->LoadProfile(femc_prof.c_str());
+
     se->registerSubsystem(cemc_clusterbuilder);
   } else if (Cemc_clusterizer == kCemcGraphClusterizer) {
     RawClusterBuilderGraph *cemc_clusterbuilder =
         new RawClusterBuilderGraph("EmcRawClusterBuilderGraph");
     cemc_clusterbuilder->Detector("CEMC");
     cemc_clusterbuilder->Verbosity(verbosity);
-
-    cemc_clusterbuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
-    std::string femc_prof = getenv("CALIBRATIONROOT");
-    femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
-    cemc_clusterbuilder->LoadProfile(femc_prof.c_str());
 
     se->registerSubsystem(cemc_clusterbuilder);
   } else {

--- a/macros/g4simulations/G4_CEmc_EIC.C
+++ b/macros/g4simulations/G4_CEmc_EIC.C
@@ -269,10 +269,10 @@ void CEMC_Clusters(int verbosity = 0) {
     cemc_clusterbuilder->Detector("CEMC");
     cemc_clusterbuilder->Verbosity(verbosity);
 
-    ClusterBuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    cemc_clusterbuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
     std::string femc_prof = getenv("CALIBRATIONROOT");
     femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
-    ClusterBuilder->LoadProfile(femc_prof.c_str());
+    cemc_clusterbuilder->LoadProfile(femc_prof.c_str());
 
     se->registerSubsystem(cemc_clusterbuilder);
   } else {

--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -411,6 +411,10 @@ void CEMC_Clusters(int verbosity = 0)
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplate");
     ClusterBuilder->Detector("CEMC");
     ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.030); // This threshold should be the same as in CEMCprof_Thresh**.root file below
+    std::string femc_prof = getenv("CALIBRATIONROOT");
+    femc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    ClusterBuilder->LoadProfile(femc_prof.c_str());
     se->registerSubsystem(ClusterBuilder);
   }
   else if (Cemc_clusterizer == kCemcGraphClusterizer)

--- a/macros/g4simulations/G4_FEMC.C
+++ b/macros/g4simulations/G4_FEMC.C
@@ -5,7 +5,7 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 #include <caloreco/RawClusterBuilderFwd.h>
-#include <caloreco/RawClusterBuilderTemplateFEMC.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 #include <g4detectors/PHG4ForwardCalCellReco.h>
 #include <g4detectors/PHG4ForwardEcalSubsystem.h>
@@ -210,7 +210,7 @@ void FEMC_Clusters(int verbosity = 0) {
 
   if ( Femc_clusterizer == kFemcTemplateClusterizer )
     {
-      RawClusterBuilderTemplateFEMC *ClusterBuilder = new RawClusterBuilderTemplateFEMC("EmcRawClusterBuilderTemplateFEMC");
+      RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplateFEMC");
       ClusterBuilder->Detector("FEMC");
       ClusterBuilder->Verbosity(verbosity);
       ClusterBuilder->set_threshold_energy(0.020); // This threshold should be the same as in FEMCprof_Thresh**.root file below

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -5,7 +5,7 @@
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>
 #include <caloreco/RawClusterBuilderFwd.h>
-#include <caloreco/RawClusterBuilderTemplateFEMC.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 #include <g4detectors/PHG4ForwardCalCellReco.h>
 #include <g4detectors/PHG4ForwardEcalSubsystem.h>
@@ -211,7 +211,7 @@ void FEMC_Clusters(int verbosity = 0) {
 
   if ( Femc_clusterizer == kFemcTemplateClusterizer )
     {
-      RawClusterBuilderTemplateFEMC *ClusterBuilder = new RawClusterBuilderTemplateFEMC("EmcRawClusterBuilderTemplateFEMC");
+      RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EmcRawClusterBuilderTemplateFEMC");
       ClusterBuilder->Detector("FEMC");
       ClusterBuilder->Verbosity(verbosity);
       ClusterBuilder->set_threshold_energy(0.020); // This threshold should be the same as in FEMCprof_Thresh**.root file below

--- a/macros/g4simulations/G4_HcalIn_EIC.C
+++ b/macros/g4simulations/G4_HcalIn_EIC.C
@@ -181,6 +181,7 @@ void HCALInner_Clusters(int verbosity = 0) {
     {
       RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
       ClusterBuilder->Detector("HCALIN");
+      ClusterBuilder->SetCylindricalGeometry();
       ClusterBuilder->Verbosity(verbosity);
       se->registerSubsystem( ClusterBuilder );
 

--- a/macros/g4simulations/G4_HcalIn_ref.C
+++ b/macros/g4simulations/G4_HcalIn_ref.C
@@ -244,6 +244,7 @@ void HCALInner_Clusters(int verbosity = 0) {
   {
     RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALIN");
+    ClusterBuilder->SetCylindricalGeometry();
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );
 

--- a/macros/g4simulations/G4_HcalOut_ref.C
+++ b/macros/g4simulations/G4_HcalOut_ref.C
@@ -168,6 +168,7 @@ void HCALOuter_Clusters(int verbosity = 0) {
   {
     RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("HcalOutRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALOUT");
+    ClusterBuilder->SetCylindricalGeometry();
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem( ClusterBuilder );
   }


### PR DESCRIPTION
After Template clusterizer re-organization, recently merged, some minor modifications in macros are needed: 

G4_FEMC.C and G4_FEMC_EIC.C: replace RawClusterBuilderTemplateFEMC with RawClusterBuilderTemplate (the former became obsolete)

G4_CEmc_Spacal.C and G4_CEmc_EIC.C: include loading shower profile hists for "prob" evaluation (switch from hard-coded shower profile to input profile hists)

G4_HcalIn_EIC.C, G4_HcalIn_ref.C and G4_HcalOut_ref.C: Include ClusterBuilder->SetCylindricalGeometry(); which is necessary if BEmcRec<CalorName> is not defined for this calorimeter
