### PR TITLE
remove obsolete TrkrEvaluator.h

### DIFF
--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -4,7 +4,6 @@
 
 #include <fun4all/Fun4AllServer.h>
 
-#include <g4eval/TrkrEvaluator.h>
 #include <g4eval/SvtxEvaluator.h>
 
 #include <g4intt/PHG4InttDefs.h>
@@ -48,7 +47,7 @@ R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libmvtx.so)
 R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
-//R__LOAD_LIBRARY(libg4hough.so)
+
 #endif
 
 #include <vector>


### PR DESCRIPTION
This PR removes the inclusion of the removed g4eval/TrkrEvaluator.h