### PR TITLE
Tpc fudge factor tuning

### DIFF
--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -275,7 +275,7 @@ void Tracking_Cells(int verbosity = 0)
   edrift->Verbosity(0);
   // fudge factors to get drphi 150 microns (in mid and outer Tpc) and dz 500 microns cluster resolution
   // They represent effects not due to ideal gas properties and ideal readout plane behavior
-  // defaults are 0.12 and 0.15, they can be changed here to get a different resolution
+  // defaults are 0.085 and 0.105, they can be changed here to get a different resolution
   edrift->set_double_param("added_smear_trans",0.085);
   edrift->set_double_param("added_smear_long",0.105);
   edrift->registerPadPlane(padplane);

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -276,8 +276,8 @@ void Tracking_Cells(int verbosity = 0)
   // fudge factors to get drphi 150 microns (in mid and outer Tpc) and dz 500 microns cluster resolution
   // They represent effects not due to ideal gas properties and ideal readout plane behavior
   // defaults are 0.085 and 0.105, they can be changed here to get a different resolution
-  edrift->set_double_param("added_smear_trans",0.085);
-  edrift->set_double_param("added_smear_long",0.105);
+  //edrift->set_double_param("added_smear_trans",0.085);
+  //edrift->set_double_param("added_smear_long",0.105);
   edrift->registerPadPlane(padplane);
   se->registerSubsystem(edrift);
 

--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -4,7 +4,6 @@
 
 #include <fun4all/Fun4AllServer.h>
 
-#include <g4eval/TrkrEvaluator.h>
 #include <g4eval/SvtxEvaluator.h>
 
 #include <g4intt/PHG4InttDefs.h>
@@ -269,14 +268,16 @@ void Tracking_Cells(int verbosity = 0)
   //=========================
 
   PHG4TpcPadPlane *padplane = new PHG4TpcPadPlaneReadout();
+  padplane->Verbosity(0);
 
   PHG4TpcElectronDrift *edrift = new PHG4TpcElectronDrift();
   edrift->Detector("TPC");
+  edrift->Verbosity(0);
   // fudge factors to get drphi 150 microns (in mid and outer Tpc) and dz 500 microns cluster resolution
   // They represent effects not due to ideal gas properties and ideal readout plane behavior
   // defaults are 0.12 and 0.15, they can be changed here to get a different resolution
-  edrift->set_double_param("added_smear_trans",0.12);
-  edrift->set_double_param("added_smear_long",0.15);
+  edrift->set_double_param("added_smear_trans",0.085);
+  edrift->set_double_param("added_smear_long",0.105);
   edrift->registerPadPlane(padplane);
   se->registerSubsystem(edrift);
 
@@ -409,7 +410,7 @@ void Tracking_Clus(int verbosity = 0)
   digitpc->SetENC(ENC);
   double ADC_threshold = 4.0 * ENC;
   digitpc->SetADCThreshold(ADC_threshold);  // 4 * ENC seems OK
-
+  digitpc->Verbosity(0);
   cout << " Tpc digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
        << " maps+Intt layers set to " << n_maps_layer + n_intt_layer << endl;
 


### PR DESCRIPTION
The TPC cluster resolution fudge factors that increase the resolution to 150 microns in r-phi and ~500 microns in Z have been re-tuned to compensate for Jin's introduction of variable GEM gain in coresoftware PR#705. The fudge factors are now (r-phi) 0.085 and (Z) 0.105 mm.  The performance with the new fudge factors is seen in the two figures. The efficiency is unchanged by the variable GEM gain modification.
[clusres_fudge_085_105.pdf](https://github.com/sPHENIX-Collaboration/macros/files/4391308/clusres_fudge_085_105.pdf)
[ups1s_fudge_085_105.pdf](https://github.com/sPHENIX-Collaboration/macros/files/4391310/ups1s_fudge_085_105.pdf)
