### PR TITLE
Tracking low occupancy qa mvtx

### DIFF
--- a/macros/QA/tracking/QA_Draw_ALL.sh
+++ b/macros/QA/tracking/QA_Draw_ALL.sh
@@ -1,4 +1,4 @@
-#! /bin/tcsh -f 
+#! /bin/tcsh -f
 
 echo "Usage: $0 new_QA_file [ reference_QA_file ]";
 
@@ -14,12 +14,14 @@ set reference_QA_file = 'NULL';
 
 
 if ($# >= 2) then
-	set reference_QA_file = "$q$2$q";
+  set reference_QA_file = "$q$2$q";
 endif
 
 echo "$0 - New QA file: $new_QA_file";
 echo "$0 - Reference QA file: $reference_QA_file";
 
+# mvtx stuff
+root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationUpsilon${q},$new_QA_file, $reference_QA_file)"
 
 # last all jet stuff
 root -b -q "QA_Draw_Tracking_TruthMatchingOverview.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"

--- a/macros/QA/tracking/QA_Draw_ALL.sh
+++ b/macros/QA/tracking/QA_Draw_ALL.sh
@@ -21,7 +21,7 @@ echo "$0 - New QA file: $new_QA_file";
 echo "$0 - Reference QA file: $reference_QA_file";
 
 # mvtx stuff
-root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationUpsilon${q},$new_QA_file, $reference_QA_file)"
+root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationMvtx${q},$new_QA_file, $reference_QA_file)"
 
 # last all jet stuff
 root -b -q "QA_Draw_Tracking_TruthMatchingOverview.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -64,6 +64,7 @@ namespace
       auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
       hnew->Scale( 1./hnew->GetEntries() );
       hnew->SetMinimum(0);
+      hnew->SetTitle(TString("MVTX ") + hnew->GetTitle()); // note detector name in title
 
       // reference
       auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -1,0 +1,121 @@
+/*!
+ * \file QA_Draw_MVtx.C
+ * \brief
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TLine.h>
+#include <TString.h>
+
+//some common style files
+#include "../../sPHENIXStyle/sPhenixStyle.C"
+#include "QA_Draw_Utility.C"
+
+// assume MVTX layers are 0, 1 and 2
+static constexpr int first_layer_mvtx = 0;
+static constexpr int nlayers_mvtx = 3;
+
+namespace
+{
+
+  TLine* VerticalLine( TVirtualPad* pad, Double_t x )
+  {
+
+    pad->Update();
+
+    Double_t yMin = pad->GetUymin();
+    Double_t yMax = pad->GetUymax();
+
+    if( pad->GetLogy() )
+    {
+      yMin = TMath::Power( 10, yMin );
+      yMax = TMath::Power( 10, yMax );
+    }
+
+    TLine *line = new TLine( x, yMin, x, yMax );
+    line->SetLineStyle( 2 );
+    line->SetLineWidth( 1 );
+    line->SetLineColor( 1 );
+    return line;
+
+  }
+
+  TCanvas* Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& hist_name_prefix, const TString& tag )
+  {
+
+    const TString prefix = TString("h_") + hist_name_prefix + TString("_");
+
+    auto cv = new TCanvas(
+      TString("QA_Draw_Mvtx_") + tag + TString("_") + hist_name_prefix,
+      TString("QA_Draw_Mvtx_") + tag + TString("_") + hist_name_prefix,
+      1800, 1000);
+
+    cv->Divide( nlayers_mvtx, 1 );
+    for( int ilayer = 0; ilayer < nlayers_mvtx; ++ilayer )
+    {
+
+      const int layer = ilayer + first_layer_mvtx;
+
+      // get histograms
+      auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
+      hnew->Scale( 1./hnew->GetEntries() );
+
+      // reference
+      auto href = qa_file_ref ? static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;
+      if( href ) href->Scale( 1./href->GetEntries() );
+
+      // draw
+      cv->cd( ilayer+1 );
+      DrawReference(hnew, href, false);
+
+      auto line = VerticalLine( gPad, 0 );
+      line->Draw(); 
+    }
+
+    return cv;
+
+  }
+
+}
+
+void QA_Draw_Mvtx(
+    const char *hist_name_prefix = "QAG4SimulationMvtx",
+    const char *qa_file_name_new =  "data/G4sPHENIX.root_qa.root",
+    const char *qa_file_name_ref =  "data/G4sPHENIX.root_qa.root"
+    )
+{
+
+  SetsPhenixStyle();
+
+  auto qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile* qa_file_ref = nullptr;
+  if (qa_file_name_ref)
+  {
+    qa_file_ref = new TFile(qa_file_name_ref);
+    assert(qa_file_ref->IsOpen());
+  }
+
+  // assume MVTX layers are 0, 1 and 2
+  static constexpr int first_layer_mvtx = 0;
+  static constexpr int nlayers_mvtx = 3;
+
+  std::vector<TCanvas*> cvlist;
+
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "rphi_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "phi_pulls" ) );
+
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "dz" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_pulls" ) );
+
+  for( const auto& cv:cvlist )
+  { SaveCanvas(cv, TString(qa_file_name_new) + TString("_") + TString(cv->GetName()), true); }
+
+}

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -63,17 +63,22 @@ namespace
       // get histograms
       auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
       hnew->Scale( 1./hnew->GetEntries() );
+      hnew->SetMinimum(0);
 
       // reference
-      auto href = qa_file_ref ? static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;
-      if( href ) href->Scale( 1./href->GetEntries() );
+      auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;
+      if( href )
+      {
+        href->Scale( 1./href->GetEntries() );
+        href->SetMinimum(0);
+      }
 
       // draw
       cv->cd( ilayer+1 );
-      DrawReference(hnew, href, false);
+      DrawReference(hnew, href);
 
       auto line = VerticalLine( gPad, 0 );
-      line->Draw(); 
+      line->Draw();
     }
 
     return cv;

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,6 +2,7 @@
 #include <qa_modules/QAG4SimulationUpsilon.h>
 #include <qa_modules/QAG4SimulationTracking.h>
 #include <qa_modules/QAHistManagerDef.h>
+#include <qa_modules/QAG4SimulationMvtx.h>
 #include <phool/PHRandomSeed.h>
 #include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllServer.h>
@@ -644,6 +645,8 @@ int Fun4All_G4_sPHENIX(
         qa->addEmbeddingID(3);
         se->registerSubsystem(qa);
       }
+
+      se->registerSubsystem( new QAG4SimulationMvtx );
     }
   }
 


### PR DESCRIPTION
This PR adds some plotting macros for the new MVTX clusters QA histograms
Residuals, errors and pulls are plotted in separate canvases. 
Vertical line at zero is added. 
For now there is no attempt at fitting the distrubitions, nor information plotted about histograms mean and RMS.
Those could easily be added in the future. 

(Remark: my editor is setup to automatically replace tab characters by space characters, and remove empty spaces/tabs at end-of-line. This creates unrelated changes in the resulting diff. I can disable this and resubmit the pull request, if needed) 