### PR TITLE
Mar-2020 EIC beam pipe and detector addition/adjustment

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -95,7 +95,9 @@ int Fun4All_G4_EICDetector(
   // sPHENIX barrel
   bool do_bbc = true;
 
+  // whether to simulate the Be section of the beam pipe
   bool do_pipe = true;
+  // EIC beam pipe extension beyond the Be-section can be turned on with use_forward_pipes = true in G4_Pipe_EIC.C
 
   bool do_tracking = true;
   bool do_tracking_cell = do_tracking && true;

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -1,7 +1,7 @@
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include "GlobalVariables.C"
-#include "G4_Pipe.C"
+#include "G4_Pipe_EIC.C"
 #include "G4_Tracking_EIC.C"
 #include "G4_PSTOF.C"
 #include "G4_CEmc_EIC.C"
@@ -52,7 +52,7 @@ void G4Init(bool do_svtx = true,
 
   if (do_pipe)
     {
-      gROOT->LoadMacro("G4_Pipe.C");
+      gROOT->LoadMacro("G4_Pipe_EIC.C");
       PipeInit();
     }
 

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -62,15 +62,22 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
       if (do_svtx)
         {
           ana->AddNode("SVTX");
+          ana->AddNode("MVTX");
+
           ana->AddNode("EGEM_0");
           ana->AddNode("EGEM_1");
           ana->AddNode("EGEM_2");
           ana->AddNode("EGEM_3");
-          ana->AddNode("FGEM_0");
-          ana->AddNode("FGEM_1");
+
           ana->AddNode("FGEM_2");
           ana->AddNode("FGEM_3");
           ana->AddNode("FGEM_4");
+
+          ana->AddNode("FST_0");
+          ana->AddNode("FST_1");
+          ana->AddNode("FST_2");
+          ana->AddNode("FST_3");
+          ana->AddNode("FST_4");
         }
 
       if (do_cemc)

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -51,7 +51,7 @@ EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   /* Use non-projective geometry */
   if(!use_projective_geometry)
     {
-      mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v005.txt";
+      mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
       eemc->SetTowerMappingFile( mapping_eemc.str() );
     }
 
@@ -83,7 +83,7 @@ void EEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_eemc;
   mapping_eemc << getenv("CALIBRATIONROOT") <<
-    "/CrystalCalorimeter/mapping/towerMap_EEMC_v005.txt";
+    "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -65,8 +65,11 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   
   femc->SetEICDetector(); 
+
   // fsPHENIX ECAL
-  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+//  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v006.txt";
 
   cout << mapping_femc.str() << endl;
   femc->SetTowerMappingFile( mapping_femc.str() );
@@ -87,9 +90,12 @@ void FEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_femc;
 
-  // fsPHENIX ECAL
-  mapping_femc << getenv("CALIBRATIONROOT") <<
-   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+//  // fsPHENIX ECAL
+//  mapping_femc << getenv("CALIBRATIONROOT") <<
+//   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v006.txt";
+
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -107,41 +113,41 @@ void FEMC_Towers(int verbosity = 0) {
   //se->registerSubsystem( TowerDigitizer1 );
 
   // PbSc towers
-  //RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
-  //TowerDigitizer2->Detector("FEMC");
-  //TowerDigitizer2->TowerType(2); 
-  //TowerDigitizer2->Verbosity(verbosity);
-  //TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  //se->registerSubsystem( TowerDigitizer2 );
+  RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  TowerDigitizer2->Detector("FEMC");
+  TowerDigitizer2->TowerType(2);
+  TowerDigitizer2->Verbosity(verbosity);
+  TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem( TowerDigitizer2 );
 
-  // E864 towers (three types for three sizes)
-  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
-  TowerDigitizer3->Detector("FEMC");
-  TowerDigitizer3->TowerType(3); 
-  TowerDigitizer3->Verbosity(verbosity);
-  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer3 );
-
-  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
-  TowerDigitizer4->Detector("FEMC");
-  TowerDigitizer4->TowerType(4); 
-  TowerDigitizer4->Verbosity(verbosity);
-  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer4 );
-
-  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
-  TowerDigitizer5->Detector("FEMC");
-  TowerDigitizer5->TowerType(5); 
-  TowerDigitizer5->Verbosity(verbosity);
-  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer5 );
-
-  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
-  TowerDigitizer6->Detector("FEMC");
-  TowerDigitizer6->TowerType(6); 
-  TowerDigitizer6->Verbosity(verbosity);
-  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer6 );
+//  // E864 towers (three types for three sizes)
+//  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
+//  TowerDigitizer3->Detector("FEMC");
+//  TowerDigitizer3->TowerType(3);
+//  TowerDigitizer3->Verbosity(verbosity);
+//  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer3 );
+//
+//  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
+//  TowerDigitizer4->Detector("FEMC");
+//  TowerDigitizer4->TowerType(4);
+//  TowerDigitizer4->Verbosity(verbosity);
+//  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer4 );
+//
+//  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
+//  TowerDigitizer5->Detector("FEMC");
+//  TowerDigitizer5->TowerType(5);
+//  TowerDigitizer5->Verbosity(verbosity);
+//  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer5 );
+//
+//  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
+//  TowerDigitizer6->Detector("FEMC");
+//  TowerDigitizer6->TowerType(6);
+//  TowerDigitizer6->Verbosity(verbosity);
+//  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer6 );
 
   // PbW crystals
   //RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
@@ -154,51 +160,51 @@ void FEMC_Towers(int verbosity = 0) {
   //se->registerSubsystem( TowerCalibration1 );
 
   // PbSc towers
-  //RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
-  //TowerCalibration2->Detector("FEMC");
-  //TowerCalibration2->TowerType(2);
-  //TowerCalibration2->Verbosity(verbosity);
-  //TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  //TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
-  //TowerCalibration2->set_pedstal_ADC(0);
-  //se->registerSubsystem( TowerCalibration2 );
+  RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  TowerCalibration2->Detector("FEMC");
+  TowerCalibration2->TowerType(2);
+  TowerCalibration2->Verbosity(verbosity);
+  TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
+  TowerCalibration2->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration2 );
 
-  // E864 towers (three types for three sizes)
-  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
-  TowerCalibration3->Detector("FEMC");
-  TowerCalibration3->TowerType(3);
-  TowerCalibration3->Verbosity(verbosity);
-  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030 
-  TowerCalibration3->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration3 );
-
-  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
-  TowerCalibration4->Detector("FEMC");
-  TowerCalibration4->TowerType(4);
-  TowerCalibration4->Verbosity(verbosity);
-  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration4->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration4 );
-
-  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
-  TowerCalibration5->Detector("FEMC");
-  TowerCalibration5->TowerType(5);
-  TowerCalibration5->Verbosity(verbosity);
-  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration5->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration5 );
-
-  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
-  TowerCalibration6->Detector("FEMC");
-  TowerCalibration6->TowerType(6);
-  TowerCalibration6->Verbosity(verbosity);
-  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration6->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration6->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration6 );
+//  // E864 towers (three types for three sizes)
+//  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
+//  TowerCalibration3->Detector("FEMC");
+//  TowerCalibration3->TowerType(3);
+//  TowerCalibration3->Verbosity(verbosity);
+//  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration3->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration3 );
+//
+//  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
+//  TowerCalibration4->Detector("FEMC");
+//  TowerCalibration4->TowerType(4);
+//  TowerCalibration4->Verbosity(verbosity);
+//  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration4->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration4 );
+//
+//  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
+//  TowerCalibration5->Detector("FEMC");
+//  TowerCalibration5->TowerType(5);
+//  TowerCalibration5->Verbosity(verbosity);
+//  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration5->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration5 );
+//
+//  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
+//  TowerCalibration6->Detector("FEMC");
+//  TowerCalibration6->TowerType(6);
+//  TowerCalibration6->Verbosity(verbosity);
+//  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration6->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration6->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration6 );
 
 }
 

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -51,7 +51,7 @@ FHCALSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   /* path to central copy of calibrations repositry */
   mapping_hhcal << getenv("CALIBRATIONROOT") ;
-  mapping_hhcal << "/ForwardHcal/mapping/towerMap_FHCAL_v004.txt";
+  mapping_hhcal << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
   cout << mapping_hhcal.str() << endl;
   //mapping_hhcal << "towerMap_FHCAL_latest.txt";
 
@@ -73,7 +73,7 @@ void FHCAL_Towers(int verbosity = 0) {
 
   ostringstream mapping_fhcal;
   mapping_fhcal << getenv("CALIBRATIONROOT") <<
-  	"/ForwardHcal/mapping/towerMap_FHCAL_v004.txt";
+  	"/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
   //mapping_fhcal << "towerMap_FHCAL_latest.txt";
 
   RawTowerBuilderByHitIndex* tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");

--- a/macros/g4simulations/G4_GEM_EIC.C
+++ b/macros/g4simulations/G4_GEM_EIC.C
@@ -35,8 +35,8 @@ void EGEMSetup(PHG4Reco *g4Reco)
   float thickness = 3.;
   make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
   make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
-  make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.9);
-  make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -4.00);
+  make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+  make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
 }
 
 void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
@@ -59,14 +59,15 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   // We also need two outer barrel layers which might need some adjustments by the space limitation
   // and needs integration with the central vertex detector.
   //
-  // Note:  last station need to be removed to avoid confliction with the gas RICH. GEM chamber at z=2.7m is used instead
+  // Note1:  last station need to be removed to avoid confliction with the gas RICH. GEM chamber at z=2.7m is used instead
+  // Note2:  increase inner radius for beam pipe flange clearance
 
-  make_LANL_FST_station("FST_0", g4Reco, 17, 3.2, 19);
-  make_LANL_FST_station("FST_1", g4Reco, 62, 3.2, 19);
+  make_LANL_FST_station("FST_0", g4Reco, 17, 3.2, 18);
+  make_LANL_FST_station("FST_1", g4Reco, 62, 3.2, 18);
 
   ///////////////////////////////////////////////////////////////////////////
 
-  make_LANL_FST_station("FST_2", g4Reco, 120, 4.5, 35);
+  make_LANL_FST_station("FST_2", g4Reco, 120, 10, 35);
 
   ///////////////////////////////////////////////////////////////////////////
 
@@ -95,7 +96,7 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
 
   ///////////////////////////////////////////////////////////////////////////
 
-  make_LANL_FST_station("FST_3", g4Reco, 140, 5, 39);
+  make_LANL_FST_station("FST_3", g4Reco, 140, 12, 41);
 
   ///////////////////////////////////////////////////////////////////////////
 
@@ -130,12 +131,12 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
 
   ///////////////////////////////////////////////////////////////////////////
 
-  make_LANL_FST_station("FST_4", g4Reco, 160, 6, 41);
+  make_LANL_FST_station("FST_4", g4Reco, 160, 12, 41);
 
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_4";
-  etamax = 4;
+  etamax = 3.5;
   etamin = min_eta;
   zpos = 271.0;
   gem = new PHG4SectorSubsystem(name.c_str());
@@ -183,7 +184,7 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
 
   ///////////////////////////////////////////////////////////////////////////
 
-  make_LANL_FST_station("FST_5", g4Reco, 280, 10, 41);
+  make_LANL_FST_station("FST_5", g4Reco, 280, 17, 41);
 
   ///////////////////////////////////////////////////////////////////////////
 }

--- a/macros/g4simulations/G4_GEM_EIC.C
+++ b/macros/g4simulations/G4_GEM_EIC.C
@@ -1,28 +1,30 @@
 #pragma once
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
-#include "GlobalVariables.C"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
+#include <TMath.h>
 #include <g4detectors/PHG4SectorSubsystem.h>
 #include <g4main/PHG4Reco.h>
-int make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-                 double etamax,  const int N_Sector = 8);
+#include <string>
+#include "GlobalVariables.C"
+
+using namespace std;
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8);
 void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax);
 R__LOAD_LIBRARY(libg4detectors.so)
 #endif
 
-void
-EGEM_Init()
+void EGEM_Init()
 {
-
 }
 
-void
-FGEM_Init()
+void FGEM_Init()
 {
-
 }
 
-void
-EGEMSetup(PHG4Reco* g4Reco)
+void EGEMSetup(PHG4Reco *g4Reco)
 {
   /* Careful with dimensions! If GEM station volumes overlap, e.g. with TPC volume, they will be
    * drawn in event display but will NOT register any hits.
@@ -30,17 +32,16 @@ EGEMSetup(PHG4Reco* g4Reco)
    * Geometric constraints:
    * TPC length = 211 cm --> from z = -105.5 to z = +105.5
    */
-  float thickness=3.;
-  make_GEM_station("EGEM_0", g4Reco,  -20.5 + thickness, -0.94, -1.95);
-  make_GEM_station("EGEM_1", g4Reco,  -69.5 + thickness, -2.07, -3.21);
+  float thickness = 3.;
+  make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
+  make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
   make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.9);
   make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -4.00);
 }
 
-void
-FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-          const double min_eta = 1.245 //
-          )
+void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
+               const double min_eta = 1.245               //
+)
 {
   const double tilt = .1;
 
@@ -50,13 +51,27 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   double zpos;
   PHG4SectorSubsystem *gem;
 
-  make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 2.73, N_Sector);
-  make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 4.00, N_Sector);
+  /// LANL FST From Xuan Li
+  // plane 1, z location: 1200mm, inner radius: 45mm, outer radius: 350mm
+  // plane 2, z location: 1400mm, inner radius: 50mm, outer radius: 390mm
+  // plane 3, z location: 1700mm, inner radius: 60mm, outer radius: 410mm
+  // plane 4, z location: 1900mm, inner radius: 70mm, outer radius: 430mm
+  // We also need two outer barrel layers which might need some adjustments by the space limitation
+  // and needs integration with the central vertex detector.
+  //
+  // Note:  last station need to be removed to avoid confliction with the gas RICH. GEM chamber at z=2.7m is used instead
+
+  make_LANL_FST_station("FST_0", g4Reco, 17, 3.2, 19);
+  make_LANL_FST_station("FST_1", g4Reco, 62, 3.2, 19);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  make_LANL_FST_station("FST_2", g4Reco, 120, 4.5, 35);
 
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_2";
-  etamax = 4;
+  etamax = 2;
   etamin = min_eta;
   zpos = 134.0;
 
@@ -64,13 +79,13 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   gem->get_geometry().set_normal_polar_angle(tilt);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->OverlapCheck(overlapcheck);
@@ -80,57 +95,42 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   ///////////////////////////////////////////////////////////////////////////
 
+  make_LANL_FST_station("FST_3", g4Reco, 140, 5, 39);
+
+  ///////////////////////////////////////////////////////////////////////////
+
   name = "FGEM_3";
-  etamax = 4;
+  etamax = 2;
   etamin = min_eta;
   zpos = 157.0;
-  gem = new PHG4SectorSubsystem(name.c_str());
-
-  gem->SuperDetector(name);
-  gem->get_geometry().set_normal_polar_angle(tilt);
-  gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
-  gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
-  gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
-  gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
-  gem->get_geometry().set_material("G4_METHANE");
-  gem->get_geometry().set_N_Sector(N_Sector);
-  gem->OverlapCheck(overlapcheck);
-  AddLayers_MiniTPCDrift(gem);
-  gem->get_geometry().AddLayers_HBD_GEM();
-  g4Reco->registerSubsystem(gem);
 
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
-  zpos = zpos
-    - (zpos * sin(tilt)
-       + zpos * cos(tilt)
-       * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-    * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax) - tilt)) * sin(tilt);
 
   gem->get_geometry().set_normal_polar_angle(
-                                             (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-                                              + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax)) / 2);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
-                                       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
 
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
   gem->OverlapCheck(overlapcheck);
   g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  make_LANL_FST_station("FST_4", g4Reco, 160, 6, 41);
 
   ///////////////////////////////////////////////////////////////////////////
 
@@ -143,13 +143,13 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem->SuperDetector(name);
   gem->get_geometry().set_normal_polar_angle(tilt);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->OverlapCheck(overlapcheck);
@@ -157,29 +157,24 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
 
-  zpos = zpos
-    - (zpos * sin(tilt)
-       + zpos * cos(tilt)
-       * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-    * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
 
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
   gem->get_geometry().set_normal_polar_angle(
-                                             (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-                                              + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
-                                       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
 
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
@@ -188,11 +183,72 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   ///////////////////////////////////////////////////////////////////////////
 
+  make_LANL_FST_station("FST_5", g4Reco, 280, 10, 41);
+
+  ///////////////////////////////////////////////////////////////////////////
+}
+
+int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax)
+{
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  // always facing the interaction point
+  double polar_angle = 0;
+  if (zpos < 0)
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
+
+  double min_polar_angle = TMath::ATan2(Rmin, zpos);
+  double max_polar_angle = TMath::ATan2(Rmax, zpos);
+
+  if (max_polar_angle < min_polar_angle)
+  {
+    double t = max_polar_angle;
+    max_polar_angle = min_polar_angle;
+    min_polar_angle = t;
+  }
+
+  PHG4SectorSubsystem *fst;
+  fst = new PHG4SectorSubsystem(name.c_str());
+
+  fst->SuperDetector(name);
+
+  fst->get_geometry().set_normal_polar_angle(polar_angle);
+  fst->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  fst->get_geometry().set_min_polar_angle(min_polar_angle);
+  fst->get_geometry().set_max_polar_angle(max_polar_angle);
+  fst->get_geometry().set_max_polar_edge(
+      PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_min_polar_edge(
+      PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_N_Sector(1);
+  fst->get_geometry().set_material("G4_AIR");
+  fst->OverlapCheck(overlapcheck);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+  // build up layers
+  fst->get_geometry().AddLayer("SliconSensor", "G4_Al", 20 * um, false, 100);
+  fst->get_geometry().AddLayer("SliconSensor", "G4_Si", 50 * um, true, 100);
+  fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 50 * um, false, 100);
+  fst->get_geometry().AddLayer("Cooling", "G4_WATER", 100 * um, false, 100);
+  fst->get_geometry().AddLayer("Support", "G4_GRAPHITE", 50 * um, false, 100);
+  fst->get_geometry().AddLayer("Support_Gap", "G4_AIR", 1 * cm, false, 100);
+  fst->get_geometry().AddLayer("Support2", "G4_GRAPHITE", 50 * um, false, 100);
+
+  g4Reco->registerSubsystem(fst);
+  return 0;
 }
 
 //! Add drift layers to mini TPC
-void
-AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
 {
   assert(gem);
 
@@ -201,7 +257,7 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
   const double um = 1e-3 * mm;
 
   //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
-  const int N_Layers = 1; // simplified setup
+  const int N_Layers = 1;  // simplified setup
   const double thickness = 2 * cm;
 
   gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false,
@@ -209,22 +265,19 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
   gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
 
   for (int d = 1; d <= N_Layers; d++)
-    {
-      stringstream s;
-      s << "DriftLayer_";
-      s << d;
+  {
+    stringstream s;
+    s << "DriftLayer_";
+    s << d;
 
-      gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
-                                   true);
-
-    }
+    gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
+                                 true);
+  }
 }
 
-int
-make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-                 double etamax,  const int N_Sector = 8)
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8)
 {
-
   //  cout
   //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
   //      << name << endl;
@@ -232,17 +285,16 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
   double polar_angle = 0;
 
   if (zpos < 0)
-    {
-      zpos = -zpos;
-      polar_angle = TMath::Pi();
-
-    }
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
   if (etamax < etamin)
-    {
-      double t = etamax;
-      etamax = etamin;
-      etamin = t;
-    }
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
 
   PHG4SectorSubsystem *gem;
   gem = new PHG4SectorSubsystem(name.c_str());
@@ -251,15 +303,15 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
 
   gem->get_geometry().set_normal_polar_angle(polar_angle);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm());
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_material("G4_METHANE");
   gem->OverlapCheck(overlapcheck);

--- a/macros/g4simulations/G4_Pipe_EIC.C
+++ b/macros/g4simulations/G4_Pipe_EIC.C
@@ -13,14 +13,15 @@ void PipeInit()
 }
 
 //! construct beam pipe
-//! \param[in] use_forward_pipes whetehr to include the engineer
+//! \param[in] use_forward_pipes whether to include the forward pipe extension beyond the Be section
 double Pipe(PHG4Reco* g4Reco,
             double radius,
             const int absorberactive = 0,
-            int verbosity = 0,
-            bool use_forward_pipes = true)
+            int verbosity = 0
+            )
 {
   // process pipe extentions?
+  bool use_forward_pipes = false;
   const static bool do_pipe_hadron_forward_extension = use_forward_pipes && true;
   const static bool do_pipe_electron_forward_extension = use_forward_pipes && true;
 

--- a/macros/g4simulations/G4_Pipe_EIC.C
+++ b/macros/g4simulations/G4_Pipe_EIC.C
@@ -1,0 +1,67 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/PHG4Reco.h>
+#include "GlobalVariables.C"
+R__LOAD_LIBRARY(libg4detectors.so)
+#endif
+
+void PipeInit()
+{
+}
+
+double Pipe(PHG4Reco* g4Reco,
+            double radius,
+            const int absorberactive = 0,
+            int verbosity = 0)
+{
+  // extracted via mechanical model: Detector chamber 3-20-20
+  // directly implimenting the central Be section in G4 cylinder for max speed simulation in the detector region.
+  // The jointer lip structure of the pipe R = 3.2cm x L=5mm is ignored here
+  static const double be_pipe_radius = 3.1000;
+  static const double be_pipe_thickness = 3.1762 - be_pipe_radius;  // 760 um based on spec sheet
+  static const double be_pipe_length_plus = 66.8;                   // +z beam pipe extend.
+  static const double be_pipe_length_neg = -79.8;                   // +z beam pipe extend.
+
+  static const double be_pipe_length = be_pipe_length_plus - be_pipe_length_neg;  // pipe length
+  static const double be_pipe_center = 0.5 * (be_pipe_length_plus + be_pipe_length_neg);
+
+  if (radius > be_pipe_radius)
+  {
+    cout << "inconsistency: radius: " << radius
+         << " larger than pipe inner radius: " << be_pipe_radius << endl;
+    gSystem->Exit(-1);
+  }
+
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4testbench.so");
+
+  // mid-rapidity beryillium pipe
+  PHG4CylinderSubsystem* cyl = new PHG4CylinderSubsystem("VAC_BE_PIPE", 0);
+  cyl->set_double_param("radius", 0.0);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Galactic");
+  cyl->set_double_param("thickness", be_pipe_radius);
+  cyl->SuperDetector("PIPE");
+  if (absorberactive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  cyl = new PHG4CylinderSubsystem("BE_PIPE", 1);
+  cyl->set_double_param("radius", be_pipe_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Be");
+  cyl->set_double_param("thickness", be_pipe_thickness);
+  cyl->SuperDetector("PIPE");
+  if (absorberactive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  radius = be_pipe_radius + be_pipe_thickness;
+
+  radius += no_overlapp;
+
+  return radius;
+}

--- a/macros/g4simulations/G4_Pipe_EIC.C
+++ b/macros/g4simulations/G4_Pipe_EIC.C
@@ -21,7 +21,7 @@ double Pipe(PHG4Reco* g4Reco,
   static const double be_pipe_radius = 3.1000;
   static const double be_pipe_thickness = 3.1762 - be_pipe_radius;  // 760 um based on spec sheet
   static const double be_pipe_length_plus = 66.8;                   // +z beam pipe extend.
-  static const double be_pipe_length_neg = -79.8;                   // +z beam pipe extend.
+  static const double be_pipe_length_neg = -79.8;                   // -z beam pipe extend.
 
   static const double be_pipe_length = be_pipe_length_plus - be_pipe_length_neg;  // pipe length
   static const double be_pipe_center = 0.5 * (be_pipe_length_plus + be_pipe_length_neg);

--- a/macros/g4simulations/G4_Pipe_EIC.C
+++ b/macros/g4simulations/G4_Pipe_EIC.C
@@ -1,10 +1,10 @@
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
-#include <g4detectors/PHG4CylinderSubsystem.h>
-#include <g4main/PHG4Reco.h>
-#include <g4detectors/PHG4GDMLSubsystem.h>
-#include "GlobalVariables.C"
 #include <TSystem.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4GDMLSubsystem.h>
+#include <g4main/PHG4Reco.h>
+#include "GlobalVariables.C"
 R__LOAD_LIBRARY(libg4detectors.so)
 #endif
 
@@ -18,12 +18,11 @@ double Pipe(PHG4Reco* g4Reco,
             double radius,
             const int absorberactive = 0,
             int verbosity = 0,
-            bool use_forward_pipes = true
-)
+            bool use_forward_pipes = true)
 {
   // process pipe extentions?
-  const static bool do_pipe_hadron_forward_extension = true;
-  const static bool do_pipe_electron_forward_extension = true;
+  const static bool do_pipe_hadron_forward_extension = use_forward_pipes && true;
+  const static bool do_pipe_electron_forward_extension = use_forward_pipes && true;
 
   // Central pipe dimension
   // Extracted via mechanical model: Detector chamber 3-20-20
@@ -78,24 +77,23 @@ double Pipe(PHG4Reco* g4Reco,
 
   if (do_pipe_electron_forward_extension)
   {
-  PHG4GDMLSubsystem *gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
-  gdml->set_string_param("GDMPath",string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
-  gdml->set_string_param("TopVolName","ElectronForwardEnvelope");
-  gdml->set_int_param("skip_DST_geometry_export", 1); // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
-  gdml->OverlapCheck(overlapcheck);
-  g4Reco->registerSubsystem(gdml);
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(overlapcheck);
+    g4Reco->registerSubsystem(gdml);
   }
 
   if (do_pipe_hadron_forward_extension)
   {
-  PHG4GDMLSubsystem *gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
-  gdml->set_string_param("GDMPath",string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
-  gdml->set_string_param("TopVolName","HadronForwardEnvelope");
-  gdml->set_int_param("skip_DST_geometry_export", 1); // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
-  gdml->OverlapCheck(overlapcheck);
-  g4Reco->registerSubsystem(gdml);
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(overlapcheck);
+    g4Reco->registerSubsystem(gdml);
   }
-
 
   return radius;
 }

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -35,7 +35,9 @@ RICHSetup(PHG4Reco* g4Reco, //
 	  const double min_eta = 1.3, //
 	  const double R_mirror_ref = 190, //cm // Reduced from 195 (2014 LOI) -> 190 to avoid overlap with FGEM4 (it seems to fit fine in the AutoCAD drawing- is the RICH longer in Geant4 than in the AutoCAD drawing?)
 	  const double z_shift = 75, // cm
-	  const double R_shift = 18.5 // cm
+	  const double R_shift = 18.5, // cm
+    const double R_beampipe_front = 8, // clearance for EIC beam pipe flange
+    const double R_beampipe_back = 27 // clearance for EIC beam pipe flange
 	  )
 {
 
@@ -50,6 +52,9 @@ RICHSetup(PHG4Reco* g4Reco, //
 
   rich->get_RICH_geometry().set_z_shift(z_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
   rich->get_RICH_geometry().set_R_shift(R_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->get_RICH_geometry().set_R_beam_pipe_front(R_beampipe_front * ePHENIXRICH::RICH_Geometry::Unit_cm());
+  rich->get_RICH_geometry().set_R_beam_pipe_back(R_beampipe_back * ePHENIXRICH::RICH_Geometry::Unit_cm());
 
   /* Register RICH module */
   rich->OverlapCheck( overlapcheck );

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -137,23 +137,23 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                                  //      const float noise
   );
 
-  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
   kalman->add_phg4hits(
-      "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
+      "G4HIT_FST_0",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12.),                    //      const float radres,
-      70e-4,                             //      const float phires,
-      100e-4,                            //      const float lonres,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
-  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
   kalman->add_phg4hits(
-      "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
+      "G4HIT_FST_1",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12.),                    //      const float radres,
-      70e-4,                             //      const float phires,
-      100e-4,                            //      const float lonres,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
@@ -169,6 +169,17 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                            //      const float noise
   );
 
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM2, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
@@ -179,6 +190,18 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
+
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM3, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
@@ -189,6 +212,18 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
+
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_4",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM4, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
@@ -200,6 +235,16 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                                  //      const float noise
   );
 
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_5",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
   // Saved track states (projections)
   kalman->add_state_name("FEMC");
   kalman->add_state_name("FHCAL");


### PR DESCRIPTION
# Introduction

In the EIC 1st yellow report workshop, a detailed CAD model for the EIC beam pipe at 25mrad crossing angle was discussed: https://indico.bnl.gov/event/7449/contributions/36037/

This pull request import this beam pipe model to the Geant4 simulation and adjust the sPHENIX-EIC detector layout around the new beam pipe and its extension. This pull request also imports the [LANL FST forward vertex tracker](https://arxiv.org/abs/2002.05880).

## Changes to users

The change should be transparent to analysis code. But one would notice the change in DCA (larger beam pipe), better forward momentum resolution (LANL FST) and reduced high psuedorapidity acceptance (accommodate beam pipe and crossing angle)

Note the Be-section of the beam pipe is always enabled in the simulation. The forward-backward Al extensions can be enabled by choice in `G4_Pipe_EIC.C`

## Event display

Here is DIS event display with this update, e x p @ 18x275 GeV/c, 25mrad crossing, x~0.5, Q^2 ~ 5000 (GeV/c)^2, horizontal cut away:
![EICGeometryTune30](https://user-images.githubusercontent.com/7947083/80051961-814f6f80-84e7-11ea-9b99-9c190b3fb0cc.png)
![EICGeometryTune34](https://user-images.githubusercontent.com/7947083/80051962-81e80600-84e7-11ea-82c3-ab445e37ed11.png)

# Beam Pipe

The beam pipe is based on a STEP model on SharePoint labeled `Detector chamber 3-20-20`: 
![Detector chamber 3-20-20](https://user-images.githubusercontent.com/7947083/80035531-310fe780-84be-11ea-9743-6bfb26a92db9.png)

Then quite a few steps to make it usable in Geant4 simulation: 
1. Remove the central Be-beam pipe and implement it directly in Geant4 as cylinders. This help speed up simulation and use the pipe material in reconstruction/analysis

2. In the Inventor CAD model, remove the vac meter, vac pump port and electron-going flanges, which overburdens the geometry complexity for G4 description. Its material effect is best replaced by a surrogate box (not yet done)
![image](https://user-images.githubusercontent.com/7947083/80035837-b398a700-84be-11ea-8c49-9e674741b96a.png)

Half cut of the result CAD model: 
![image](https://user-images.githubusercontent.com/7947083/80041663-fb253000-84ca-11ea-8c82-a5ed69694dd6.png)

3. For the forward-backward beam pipe extensions, use STEP to GDML conversion to tessellated solid. 

4. The output was manually edited to avoid a few um-level geometry conflictions due to tessellated conversion precision, which leads to small overlaps for touching parts. In the end, there is still one um-level overlap between the beam pipes and electron screen in the hadron-forward extension. This need to be resolved with usolid after integrating with `vecgeom` package. @pinkenburg 

5. Add an enclosing envelop column in GDML roughly follow the z-rotational-symmetric contour of the beam pipe. The envelope serves as two roles: 
  - Group beam pipe in Geant4 simulation, so simulation outside the pipe's virginity is much faster without having to touch the tessellated solid. 
  - Define the vacuum region

TODO is to make the envelop as close to the beam pipe extensions as possible, to allow detector use the real-estate outside the pipe and reduce the nonphysical vacuum  region outside the beam vacuum vessel. 

6. Import to Geant4 simulation with GDML subsystem as two separate extensions and joint the central Be-beam pipe 

![EICGeometryTune29](https://user-images.githubusercontent.com/7947083/80039089-fd848b80-84c4-11ea-94b7-ab50908d2ce2.png)

# Detector adjustments

Top-down view
![image](https://user-images.githubusercontent.com/7947083/80042496-26a91a00-84cd-11ea-9a24-8ec82be16043.png)


## Silicon vertex tracker

The EIC beam pipe is ~50% larger than the RHIC beam pipe. The MVTX geometry is adjusted to accommodate this pipe. The layout is based on the inner tracker from eRD16/18 from Håkan Wennlöf <hwennlof@kth.se>. There are two layers in the most inner vertex layers from the eRD16/18 designs. One additional layer is added in between to produce a tight-packed three-layer vertex track immediate outside the beam pipe for robust pattern recognition. 

![EICGeometryTune3](https://user-images.githubusercontent.com/7947083/80036308-7aad0200-84bf-11ea-92d7-94a034847b27.png)
![EICGeometryTune4](https://user-images.githubusercontent.com/7947083/80036316-7e408900-84bf-11ea-88fc-7f792d0a9fe5.png)
![EICGeometryTune36](https://user-images.githubusercontent.com/7947083/80057559-dcd42a00-84f4-11ea-8077-75a1f4c6b026.png)



## Forward silicon tracker

Forward momentum measurement can be improved with silicon tracker. Taking this chance also importing the LANL Forward Silicon Tracker in 2e80609 and 7fcbca0. The tracker z location was adjusted to work with the Gas RICH. And the inner radius was adjusted to fit the beam pipe. The forward mini-drift GEM chamber was used for the lower eta region. 

![EICGeometryTune7](https://user-images.githubusercontent.com/7947083/80042177-54419380-84cc-11ea-8155-0016baad123d.png)
![EICGeometryTune33](https://user-images.githubusercontent.com/7947083/80051863-3e8d9780-84e7-11ea-8da2-b1f966e3bed8.png)

## Gas RICH

Using a tapered larger beam pipe opening for the gas-mirror vessel: 

![EICGeometryTune19](https://user-images.githubusercontent.com/7947083/80042330-b4383a00-84cc-11ea-9bab-35bca497b77b.png)

## Electron-going EMCal

Use a larger beam opening: 

![EICGeometryTune21](https://user-images.githubusercontent.com/7947083/80042255-881cb900-84cc-11ea-87ae-0c49deb88043.png)
![EICGeometryTune20](https://user-images.githubusercontent.com/7947083/80042257-881cb900-84cc-11ea-8621-8c055b284293.png)

## Hadron-going EMCal and HCal

Also use a larger beam opening: 

![EICGeometryTune28](https://user-images.githubusercontent.com/7947083/80042239-7dfaba80-84cc-11ea-8f65-54539d7e2be0.png)
![EICGeometryTune27](https://user-images.githubusercontent.com/7947083/80042240-7dfaba80-84cc-11ea-8106-ec696674e9fb.png)

Note this revert back the the Pb-Scint sample EMCal from E864 calorimeter for the FEMCal as the Pb-Scint mapping generator macro is accessible from the calibration respository. Nonetheless, user can switch back to E864 calorimeter as the setup and digitization code block is preserved. 

# Associated pull requests

* coresoftware: https://github.com/sPHENIX-Collaboration/coresoftware/pull/790
* calibrations:  https://github.com/sPHENIX-Collaboration/calibrations/pull/58
