### PR TITLE
Two fixes for Pull Request #233

### DIFF
--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -69,7 +69,7 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   // fsPHENIX ECAL
 //  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
   // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
-  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v006.txt";
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
 
   cout << mapping_femc.str() << endl;
   femc->SetTowerMappingFile( mapping_femc.str() );
@@ -94,7 +94,7 @@ void FEMC_Towers(int verbosity = 0) {
 //  mapping_femc << getenv("CALIBRATIONROOT") <<
 //   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
   // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
-  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v006.txt";
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
 
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -64,7 +64,7 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   ostringstream mapping_femc;
 
   
-  femc->SetEICDetector(); 
+//  femc->SetEICDetector();
 
   // fsPHENIX ECAL
 //  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";

--- a/macros/g4simulations/G4_GEM_EIC.C
+++ b/macros/g4simulations/G4_GEM_EIC.C
@@ -236,9 +236,10 @@ int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmi
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
   // build up layers
-  fst->get_geometry().AddLayer("SliconSensor", "G4_Al", 20 * um, false, 100);
-  fst->get_geometry().AddLayer("SliconSensor", "G4_Si", 50 * um, true, 100);
-  fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 50 * um, false, 100);
+  fst->get_geometry().AddLayer("SliconSensor", "G4_Si", 18 * um, true, 100);
+  fst->get_geometry().AddLayer("Metalconnection", "G4_Al", 15 * um, false, 100);
+  fst->get_geometry().AddLayer("SliconSupport", "G4_Al", 285 * um, false, 100);
+  fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 20 * um, false, 100);
   fst->get_geometry().AddLayer("Cooling", "G4_WATER", 100 * um, false, 100);
   fst->get_geometry().AddLayer("Support", "G4_GRAPHITE", 50 * um, false, 100);
   fst->get_geometry().AddLayer("Support_Gap", "G4_AIR", 1 * cm, false, 100);


### PR DESCRIPTION
# Fix 1: Update Forward EMCal structure

Fixing a problem left from https://github.com/sPHENIX-Collaboration/calibrations/pull/58 and https://github.com/sPHENIX-Collaboration/macros/pull/233 , where the Forward EMCal model was switched to the re-stacked PHENIX EMCal as implemented in `PHG4EICForwardEcalDetector::ConstructTower()`. However, the sampling structure appears there has too high Pb to Scintillator ratio. 

Therefore, this pull request switch the tower map to fit `PHG4ForwardEcalDetector::ConstructTowerType2()`, which has the proper sampling structure implemented and fits the digitization code. Mapping changes are in https://github.com/sPHENIX-Collaboration/calibrations/pull/59

Thanks to Barak Schmookler for pointing out this problem. 

# Fix 2: update material thickness in the forward silicon tracker 

Thanks to Xuan Li who suggested an update on the material thickness in the forward silicon tracker to properly reflect the multiple scattering effect
