### PR TITLE
Upstream/tracking low occupancy qa intt

### DIFF
--- a/macros/QA/tracking/QA_Draw_ALL.sh
+++ b/macros/QA/tracking/QA_Draw_ALL.sh
@@ -20,6 +20,9 @@ endif
 echo "$0 - New QA file: $new_QA_file";
 echo "$0 - Reference QA file: $reference_QA_file";
 
+# intt stuff
+root -b -q "QA_Draw_Intt.C(${q}QAG4SimulationIntt${q},$new_QA_file, $reference_QA_file)"
+
 # mvtx stuff
 root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationMvtx${q},$new_QA_file, $reference_QA_file)"
 

--- a/macros/QA/tracking/QA_Draw_Intt.C
+++ b/macros/QA/tracking/QA_Draw_Intt.C
@@ -42,7 +42,6 @@ namespace
       auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
       hnew->Scale( 1./hnew->GetEntries() );
       hnew->SetMinimum(0);
-      hnew->SetTitle(TString("INTT ") + hnew->GetTitle()); // note detector name in title
 
       // reference
       auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;

--- a/macros/QA/tracking/QA_Draw_Intt.C
+++ b/macros/QA/tracking/QA_Draw_Intt.C
@@ -1,0 +1,101 @@
+/*!
+ * \file QA_Draw_Intt.C
+ * \brief
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TLine.h>
+#include <TString.h>
+
+//some common style files
+#include "../../sPHENIXStyle/sPhenixStyle.C"
+#include "QA_Draw_Utility.C"
+
+// assume INTT layers are 3 to 6
+static constexpr int first_layer_intt = 3;
+static constexpr int nlayers_intt = 4;
+
+namespace
+{
+
+  TCanvas* Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& hist_name_prefix, const TString& tag )
+  {
+
+    const TString prefix = TString("h_") + hist_name_prefix + TString("_");
+
+    auto cv = new TCanvas(
+      TString("QA_Draw_Intt_") + tag + TString("_") + hist_name_prefix,
+      TString("QA_Draw_Intt_") + tag + TString("_") + hist_name_prefix,
+      1800, 1000);
+
+    DivideCanvas( cv, nlayers_intt );
+    for( int ilayer = 0; ilayer < nlayers_intt; ++ilayer )
+    {
+
+      const int layer = ilayer + first_layer_intt;
+
+      // get histograms
+      auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
+      hnew->Scale( 1./hnew->GetEntries() );
+      hnew->SetMinimum(0);
+      hnew->SetTitle(TString("INTT ") + hnew->GetTitle()); // note detector name in title
+
+      // reference
+      auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;
+      if( href )
+      {
+        href->Scale( 1./href->GetEntries() );
+        href->SetMinimum(0);
+      }
+
+      // draw
+      cv->cd( ilayer+1 );
+      DrawReference(hnew, href);
+
+      auto line = VerticalLine( gPad, 0 );
+      line->Draw();
+    }
+
+    return cv;
+
+  }
+
+}
+
+void QA_Draw_Intt(
+    const char *hist_name_prefix = "QAG4SimulationIntt",
+    const char *qa_file_name_new =  "data/G4sPHENIX.root_qa.root",
+    const char *qa_file_name_ref =  "data/G4sPHENIX.root_qa.root"
+    )
+{
+
+  SetsPhenixStyle();
+
+  auto qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile* qa_file_ref = nullptr;
+  if (qa_file_name_ref)
+  {
+    qa_file_ref = new TFile(qa_file_name_ref);
+    assert(qa_file_ref->IsOpen());
+  }
+
+  std::vector<TCanvas*> cvlist;
+
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "rphi_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "phi_pulls" ) );
+
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "dz" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_pulls" ) );
+
+  for( const auto& cv:cvlist )
+  { SaveCanvas(cv, TString(qa_file_name_new) + TString("_") + TString(cv->GetName()), true); }
+
+}

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -42,7 +42,6 @@ namespace
       auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) );
       hnew->Scale( 1./hnew->GetEntries() );
       hnew->SetMinimum(0);
-      hnew->SetTitle(TString("MVTX ") + hnew->GetTitle()); // note detector name in title
 
       // reference
       auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), layer ), "TH1" ) ) : nullptr;

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -22,28 +22,6 @@ static constexpr int nlayers_mvtx = 3;
 namespace
 {
 
-  TLine* VerticalLine( TVirtualPad* pad, Double_t x )
-  {
-
-    pad->Update();
-
-    Double_t yMin = pad->GetUymin();
-    Double_t yMax = pad->GetUymax();
-
-    if( pad->GetLogy() )
-    {
-      yMin = TMath::Power( 10, yMin );
-      yMax = TMath::Power( 10, yMax );
-    }
-
-    TLine *line = new TLine( x, yMin, x, yMax );
-    line->SetLineStyle( 2 );
-    line->SetLineWidth( 1 );
-    line->SetLineColor( 1 );
-    return line;
-
-  }
-
   TCanvas* Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& hist_name_prefix, const TString& tag )
   {
 
@@ -106,11 +84,7 @@ void QA_Draw_Mvtx(
     qa_file_ref = new TFile(qa_file_name_ref);
     assert(qa_file_ref->IsOpen());
   }
-
-  // assume MVTX layers are 0, 1 and 2
-  static constexpr int first_layer_mvtx = 0;
-  static constexpr int nlayers_mvtx = 3;
-
+  
   std::vector<TCanvas*> cvlist;
 
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );

--- a/macros/QA/tracking/QA_Draw_Utility.C
+++ b/macros/QA/tracking/QA_Draw_Utility.C
@@ -38,6 +38,45 @@
 
 using namespace std;
 
+//! Divide canvas in a given number of pads, with a number of pads in both directions that match the width/height ratio of the canvas
+void DivideCanvas(TVirtualPad* p, int npads)
+{
+  if( !p ) return;
+  if( !npads ) return;
+  const double ratio = double(p->GetWw())/p->GetWh();
+  Int_t columns = std::max( 1, int(std::sqrt( npads*ratio )) );
+  Int_t rows = std::max( 1, int(npads/columns) );
+  while( rows * columns < npads )
+  {
+    columns++;
+    if( rows * columns < npads ) rows++;
+  }
+  p->Divide( rows, columns );
+}
+
+//! Draw a vertical line in a pad at given x coordinate
+TLine* VerticalLine( TVirtualPad* p, Double_t x )
+{
+  
+  p->Update();
+  
+  Double_t yMin = p->GetUymin();
+  Double_t yMax = p->GetUymax();
+  
+  if( p->GetLogy() )
+  {
+    yMin = TMath::Power( 10, yMin );
+    yMax = TMath::Power( 10, yMax );
+  }
+  
+  TLine *line = new TLine( x, yMin, x, yMax );
+  line->SetLineStyle( 2 );
+  line->SetLineWidth( 1 );
+  line->SetLineColor( 1 );
+  return line;
+  
+}
+
 //! Service function to SaveCanvas()
 void SavePad(TPad *p)
 {

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -2,6 +2,7 @@
 #include <qa_modules/QAG4SimulationUpsilon.h>
 #include <qa_modules/QAG4SimulationTracking.h>
 #include <qa_modules/QAHistManagerDef.h>
+#include <qa_modules/QAG4SimulationIntt.h>
 #include <qa_modules/QAG4SimulationMvtx.h>
 #include <phool/PHRandomSeed.h>
 #include <fun4all/SubsysReco.h>
@@ -646,6 +647,7 @@ int Fun4All_G4_sPHENIX(
         se->registerSubsystem(qa);
       }
 
+      se->registerSubsystem( new QAG4SimulationIntt );
       se->registerSubsystem( new QAG4SimulationMvtx );
     }
   }


### PR DESCRIPTION
This PR adds the INTT QA module to the fun4all macro and the INTT QA histograms plotting macro. 
The macro is also added in the "draw_all" shell script. 
Some utility functions common to both INTT and MVTX have been moved to QA_Draw_Utility
