### PR TITLE
Sync tracking high occupancy QA

### DIFF
--- a/macros/QA/tracking/QA_Draw_ALL.sh
+++ b/macros/QA/tracking/QA_Draw_ALL.sh
@@ -29,7 +29,8 @@ root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationMvtx${q},$new_QA_file, $reference_Q
 # last all jet stuff
 root -b -q "QA_Draw_Tracking_TruthMatchingOverview.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
 root -b -q "QA_Draw_Tracking_pTRatio.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
-root -b -q "QA_Draw_Tracking_TruthMatching_NumOfHits.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
+root -b -q "QA_Draw_Tracking_TruthMatching_NumOfClusters.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
+root -b -q "QA_Draw_Tracking_nClus_Layer.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
 
 # root -b -q "QA_Draw_Tracking_UpsilonOverview.C(${q}QAG4SimulationUpsilon${q},$new_QA_file, $reference_QA_file)"
 

--- a/macros/QA/tracking/QA_Draw_Tracking_TruthMatching_NumOfClusters.C
+++ b/macros/QA/tracking/QA_Draw_Tracking_TruthMatching_NumOfClusters.C
@@ -1,7 +1,7 @@
 // $Id: $
 
 /*!
- * \file QA_Draw_Tracking_TruthMatching_NumOfHits.C
+ * \file QA_Draw_Tracking_TruthMatching_NumOfClusters.C
  * \brief 
  * \author Jin Huang <jhuang@bnl.gov>
  * \version $Revision:   $
@@ -22,7 +22,7 @@
 #include "QA_Draw_Utility.C"
 using namespace std;
 
-void QA_Draw_Tracking_TruthMatching_NumOfHits(
+void QA_Draw_Tracking_TruthMatching_NumOfClusters(
     const char *hist_name_prefix = "QAG4SimulationTracking",
     const char *qa_file_name_new =
         "data/G4sPHENIX.root_qa.root",
@@ -71,8 +71,9 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
 
   //MVTX, INTT, TPC
   vector<TString> detectors{"MVTX", "INTT", "TPC"};
-  vector<int> eff_nhit_cuts{2, 2, 36};
-  vector<double> nhit_spectrum_pt_cuts{2, 2, 2};
+  vector<int> eff_ncluster_cuts{2, 1, 36};
+  vector<double> ncluster_spectrum_pt_cuts{2, 2, 2};
+
   vector<TH2 *> h_pass_detectors(3, nullptr);
   static const int nrebin = 5;
 
@@ -104,8 +105,8 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
     h_norm_ref->Rebin(nrebin);
   }
 
-  TCanvas *c1 = new TCanvas(TString("QA_Draw_Tracking_TruthMatching_NumOfHits") + TString("_") + hist_name_prefix,
-                            TString("QA_Draw_Tracking_TruthMatching_NumOfHits") + TString("_") + hist_name_prefix,
+  TCanvas *c1 = new TCanvas(TString("QA_Draw_Tracking_TruthMatching_NumOfClusters") + TString("_") + hist_name_prefix,
+                            TString("QA_Draw_Tracking_TruthMatching_NumOfClusters") + TString("_") + hist_name_prefix,
                             1800, 1000);
   c1->Divide(3, 2);
   TPad *p;
@@ -122,22 +123,22 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
       c1->Update();
       p->SetLogy();
 
-      const int bin_start = h_pass_detector->GetXaxis()->FindBin(nhit_spectrum_pt_cuts[i]);
+      const int bin_start = h_pass_detector->GetXaxis()->FindBin(ncluster_spectrum_pt_cuts[i]);
 
-      TH1 *h_pass_detector_nhit = h_pass_detector->ProjectionY(
-          TString(h_pass_detector->GetName()) + "_nHit_new",
+      TH1 *h_pass_detector_ncluster = h_pass_detector->ProjectionY(
+          TString(h_pass_detector->GetName()) + "_nCluster_new",
           bin_start);
-      TH1 *h_pass_detector_nhit_ref = nullptr;
+      TH1 *h_pass_detector_ncluster_ref = nullptr;
       if (h_pass_detector_ref)
       {
-        h_pass_detector_nhit_ref = h_pass_detector_ref->ProjectionY(
-            TString(h_pass_detector_ref->GetName()) + "_nHit_ref",
+        h_pass_detector_ncluster_ref = h_pass_detector_ref->ProjectionY(
+            TString(h_pass_detector_ref->GetName()) + "_nCluster_ref",
             bin_start);
       }
 
-      h_pass_detector_nhit->SetTitle(TString(hist_name_prefix) + ": " + detector + Form(" n_{Hit} | p_{T} #geq %.1fGeV/c", nhit_spectrum_pt_cuts[i]));
-      h_pass_detector_nhit->SetYTitle("# of reconstructed track");
-      DrawReference(h_pass_detector_nhit, h_pass_detector_nhit_ref, false);
+      h_pass_detector_ncluster->SetTitle(TString(hist_name_prefix) + ": " + detector + Form(" n_{Cluster} | p_{T} #geq %.1fGeV/c", ncluster_spectrum_pt_cuts[i]));
+      h_pass_detector_ncluster->SetYTitle("# of reconstructed track");
+      DrawReference(h_pass_detector_ncluster, h_pass_detector_ncluster_ref, false);
     }
 
     {
@@ -146,7 +147,7 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
       p->SetLogx();
       p->SetGridy();
 
-      const int bin_start = h_pass_detector->GetYaxis()->FindBin(eff_nhit_cuts[i]);
+      const int bin_start = h_pass_detector->GetYaxis()->FindBin(eff_ncluster_cuts[i]);
       TH1 *h_pass = h_pass_detector->ProjectionX(
           TString(h_pass_detector->GetName()) + "_nReco_new",
           bin_start);
@@ -155,7 +156,7 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
       h_pass->Rebin(nrebin);
 
       TH1 *h_ratio = GetBinominalRatio(h_pass, h_norm);
-      h_ratio->GetYaxis()->SetTitle("Reco efficiency | " + detector + Form(" n_{Hit} #geq %d", eff_nhit_cuts[i]));
+      h_ratio->GetYaxis()->SetTitle("Reco efficiency | " + detector + Form(" n_{Cluster} #geq %d", eff_ncluster_cuts[i]));
       h_ratio->GetYaxis()->SetRangeUser(-0, 1.);
       //
       TH1 *h_ratio_ref = NULL;
@@ -171,7 +172,7 @@ void QA_Draw_Tracking_TruthMatching_NumOfHits(
         h_ratio_ref = GetBinominalRatio(h_pass, h_norm);
       }
       //
-      h_ratio->SetTitle("Tracking efficiency | " + detector + Form(" n_{Hit} #geq %d", eff_nhit_cuts[i]));
+      h_ratio->SetTitle("Tracking efficiency | " + detector + Form(" n_{Cluster} #geq %d", eff_ncluster_cuts[i]));
       DrawReference(h_ratio, h_ratio_ref, false);
     }
   }

--- a/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
+++ b/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
@@ -2,7 +2,7 @@
 
 /*!
  * \file QA_Draw_Tracking_nClus_Layer.C
- * \brief 
+ * \brief
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  * \version $Revision:   $
  * \date $Date: $
@@ -20,14 +20,57 @@
 //some common style files
 #include "../../sPHENIXStyle/sPhenixStyle.C"
 #include "QA_Draw_Utility.C"
-using namespace std;
+
+namespace  {
+
+  // Normalization
+  double Nevent_new = 1;
+  double Nevent_ref = 1;
+
+  void GetNormalization( TFile* qa_file_new, TFile* qa_file_ref, const TString& prefix, const TString& tag )
+  {
+    if (qa_file_new)
+    {
+      TH1 *h_norm = (TH1 *) qa_file_new->GetObjectChecked( prefix + TString("Normalization"), "TH1");
+      assert(h_norm);
+      Nevent_new = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin( tag ));
+    }
+
+    if (qa_file_ref)
+    {
+      TH1 *h_norm = (TH1 *) qa_file_ref->GetObjectChecked( prefix + TString("Normalization"), "TH1");
+      assert(h_norm);
+      Nevent_ref = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin( tag ));
+    }
+  }
+
+  void Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& prefix, const TString& tag )
+  {
+
+    auto h_new = static_cast<TH1*>( qa_file_new->GetObjectChecked( prefix + tag, "TH1" ) );
+    assert(h_new);
+    h_new->Sumw2();
+    h_new->Scale(1./Nevent_new);
+
+    TH1 *h_ref = nullptr;
+    if (qa_file_ref)
+    {
+      h_ref = static_cast<TH1*>( qa_file_ref->GetObjectChecked( prefix + tag, "TH1") );
+      assert(h_ref);
+      h_ref->Sumw2();
+      h_ref->Scale(1.0/Nevent_ref);
+    }
+
+    DrawReference(h_new, h_ref);
+    HorizontalLine( gPad, 1 )->Draw();
+  }
+
+}
 
 void QA_Draw_Tracking_nClus_Layer(
     const char *hist_name_prefix = "QAG4SimulationTracking",
-    const char *qa_file_name_new =
-        "data/G4sPHENIX.root_qa.root",
-    const char *qa_file_name_ref =
-        "data/G4sPHENIX.root_qa.root")
+    const char *qa_file_name_new = "data/G4sPHENIX.root_qa.root",
+    const char *qa_file_name_ref = "data/G4sPHENIX.root_qa.root")
 {
   SetsPhenixStyle();
 
@@ -43,50 +86,18 @@ void QA_Draw_Tracking_nClus_Layer(
     assert(qa_file_ref->IsOpen());
   }
 
-  // obtain normalization
-  double Nevent_new = 1;
-  double Nevent_ref = 1;
-
-  if (qa_file_new)
-  {
-    TH1 *h_norm = (TH1 *) qa_file_new->GetObjectChecked(
-        prefix + TString("Normalization"), "TH1");
-    assert(h_norm);
-
-    Nevent_new = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
-  }
-  if (qa_file_ref)
-  {
-    TH1 *h_norm = (TH1 *) qa_file_ref->GetObjectChecked(
-        prefix + TString("Normalization"), "TH1");
-    assert(h_norm);
-
-    Nevent_ref = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
-  }
-
-  auto h_new = static_cast<TH1*>( qa_file_new->GetObjectChecked( prefix + TString("nClus_layer"), "TH1" ) );
-  assert(h_new);
-
-  //  h_new->Rebin(1, 2);
-  h_new->Sumw2();
-  h_new->Scale(1./Nevent_new);
-
-  TH1 *h_ref = nullptr;
-  if (qa_file_ref)
-  {
-    h_ref = static_cast<TH1*>( qa_file_ref->GetObjectChecked(
-        prefix + TString("nClus_layer"), "TH1") );
-    assert(h_ref);
-
-    h_ref->Sumw2();
-    h_ref->Scale(1.0/Nevent_ref);
-  }
-
   auto c1 = new TCanvas(TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
     TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
     1800, 1000);
 
-  DrawReference(h_new, h_ref);
+  c1->Divide( 2, 1 );
+  c1->cd(1);
+  GetNormalization( qa_file_new, qa_file_ref, prefix, "Truth Track" );
+  Draw( qa_file_new, qa_file_ref, prefix, "nClus_layerGen" );
+
+  c1->cd(2);
+  GetNormalization( qa_file_new, qa_file_ref, prefix, "Reco Track" );
+  Draw( qa_file_new, qa_file_ref, prefix, "nClus_layer" );
 
   SaveCanvas(c1, TString(qa_file_name_new) + TString("_") + TString(c1->GetName()), true);
 }

--- a/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
+++ b/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
@@ -1,0 +1,92 @@
+// $Id: $
+
+/*!
+ * \file QA_Draw_Tracking_nClus_Layer.C
+ * \brief 
+ * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <TFile.h>
+#include <TH2.h>
+#include <TLine.h>
+#include <TString.h>
+#include <TTree.h>
+#include <TVirtualFitter.h>
+#include <cassert>
+#include <cmath>
+
+//some common style files
+#include "../../sPHENIXStyle/sPhenixStyle.C"
+#include "QA_Draw_Utility.C"
+using namespace std;
+
+void QA_Draw_Tracking_nClus_Layer(
+    const char *hist_name_prefix = "QAG4SimulationTracking",
+    const char *qa_file_name_new =
+        "data/G4sPHENIX.root_qa.root",
+    const char *qa_file_name_ref =
+        "data/G4sPHENIX.root_qa.root")
+{
+  SetsPhenixStyle();
+
+  TString prefix = TString("h_") + hist_name_prefix + TString("_");
+
+  TFile *qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile *qa_file_ref = nullptr;
+  if (qa_file_name_ref)
+  {
+    qa_file_ref = new TFile(qa_file_name_ref);
+    assert(qa_file_ref->IsOpen());
+  }
+
+  // obtain normalization
+  double Nevent_new = 1;
+  double Nevent_ref = 1;
+
+  if (qa_file_new)
+  {
+    TH1 *h_norm = (TH1 *) qa_file_new->GetObjectChecked(
+        prefix + TString("Normalization"), "TH1");
+    assert(h_norm);
+
+    Nevent_new = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
+  }
+  if (qa_file_ref)
+  {
+    TH1 *h_norm = (TH1 *) qa_file_ref->GetObjectChecked(
+        prefix + TString("Normalization"), "TH1");
+    assert(h_norm);
+
+    Nevent_ref = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
+  }
+
+  auto h_new = static_cast<TH1*>( qa_file_new->GetObjectChecked( prefix + TString("nClus_layer"), "TH1" ) );
+  assert(h_new);
+
+  //  h_new->Rebin(1, 2);
+  h_new->Sumw2();
+  h_new->Scale(1./Nevent_new);
+
+  TH1 *h_ref = nullptr;
+  if (qa_file_ref)
+  {
+    h_ref = static_cast<TH1*>( qa_file_ref->GetObjectChecked(
+        prefix + TString("nClus_layer"), "TH1") );
+    assert(h_ref);
+
+    h_ref->Sumw2();
+    h_ref->Scale(1.0/Nevent_ref);
+  }
+
+  auto c1 = new TCanvas(TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
+    TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
+    1800, 1000);
+
+  DrawReference(h_new, h_ref);
+
+  SaveCanvas(c1, TString(qa_file_name_new) + TString("_") + TString(c1->GetName()), true);
+}

--- a/macros/QA/tracking/QA_Draw_Utility.C
+++ b/macros/QA/tracking/QA_Draw_Utility.C
@@ -57,24 +57,47 @@ void DivideCanvas(TVirtualPad* p, int npads)
 //! Draw a vertical line in a pad at given x coordinate
 TLine* VerticalLine( TVirtualPad* p, Double_t x )
 {
-  
+
   p->Update();
-  
+
   Double_t yMin = p->GetUymin();
   Double_t yMax = p->GetUymax();
-  
+
   if( p->GetLogy() )
   {
-    yMin = TMath::Power( 10, yMin );
-    yMax = TMath::Power( 10, yMax );
+    yMin = std::pow( 10, yMin );
+    yMax = std::pow( 10, yMax );
   }
-  
+
   TLine *line = new TLine( x, yMin, x, yMax );
   line->SetLineStyle( 2 );
   line->SetLineWidth( 1 );
   line->SetLineColor( 1 );
   return line;
-  
+
+}
+
+//! Draw a horizontal line in a pad at given x coordinate
+TLine* HorizontalLine( TVirtualPad* p, Double_t y )
+{
+
+  p->Update();
+
+  Double_t xMin = p->GetUxmin();
+  Double_t xMax = p->GetUxmax();
+
+  if( p->GetLogx() )
+  {
+    xMin = std::pow( 10, xMin );
+    xMax = std::pow( 10, xMax );
+  }
+
+  TLine *line = new TLine( xMin, y, xMax, y );
+  line->SetLineStyle( 2 );
+  line->SetLineWidth( 1 );
+  line->SetLineColor( 1 );
+  return line;
+
 }
 
 //! Service function to SaveCanvas()
@@ -463,7 +486,7 @@ TH1 *GetBinominalRatio(TH1 *h_pass, TH1 *h_n_trial, bool process_zero_bins = fal
                                  (p + 1 / (2 * n_trial)) / (1 + 1 / n_trial));
           h_ratio->SetBinError(x, y,
                                z,  //
-                               TMath::Sqrt(
+                               std::sqrt(
                                    1. / n_trial * p * (1 - p) + 1. / (4 * n_trial * n_trial)) /
                                    (1 + 1 / n_trial));
         }

--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -95,7 +95,9 @@ int Fun4All_G4_EICDetector(
   // sPHENIX barrel
   bool do_bbc = true;
 
+  // whether to simulate the Be section of the beam pipe
   bool do_pipe = true;
+  // EIC beam pipe extension beyond the Be-section can be turned on with use_forward_pipes = true in G4_Pipe_EIC.C
 
   bool do_tracking = true;
   bool do_tracking_cell = do_tracking && true;

--- a/macros/g4simulations/G4Setup_EICDetector.C
+++ b/macros/g4simulations/G4Setup_EICDetector.C
@@ -1,7 +1,7 @@
 #pragma once
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
 #include "GlobalVariables.C"
-#include "G4_Pipe.C"
+#include "G4_Pipe_EIC.C"
 #include "G4_Tracking_EIC.C"
 #include "G4_PSTOF.C"
 #include "G4_CEmc_EIC.C"
@@ -52,7 +52,7 @@ void G4Init(bool do_svtx = true,
 
   if (do_pipe)
     {
-      gROOT->LoadMacro("G4_Pipe.C");
+      gROOT->LoadMacro("G4_Pipe_EIC.C");
       PipeInit();
     }
 

--- a/macros/g4simulations/G4_DSTReader_EICDetector.C
+++ b/macros/g4simulations/G4_DSTReader_EICDetector.C
@@ -62,15 +62,22 @@ G4DSTreader_EICDetector( const char * outputFile = "G4sPHENIXCells.root",//
       if (do_svtx)
         {
           ana->AddNode("SVTX");
+          ana->AddNode("MVTX");
+
           ana->AddNode("EGEM_0");
           ana->AddNode("EGEM_1");
           ana->AddNode("EGEM_2");
           ana->AddNode("EGEM_3");
-          ana->AddNode("FGEM_0");
-          ana->AddNode("FGEM_1");
+
           ana->AddNode("FGEM_2");
           ana->AddNode("FGEM_3");
           ana->AddNode("FGEM_4");
+
+          ana->AddNode("FST_0");
+          ana->AddNode("FST_1");
+          ana->AddNode("FST_2");
+          ana->AddNode("FST_3");
+          ana->AddNode("FST_4");
         }
 
       if (do_cemc)

--- a/macros/g4simulations/G4_EEMC.C
+++ b/macros/g4simulations/G4_EEMC.C
@@ -51,7 +51,7 @@ EEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   /* Use non-projective geometry */
   if(!use_projective_geometry)
     {
-      mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v005.txt";
+      mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
       eemc->SetTowerMappingFile( mapping_eemc.str() );
     }
 
@@ -83,7 +83,7 @@ void EEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_eemc;
   mapping_eemc << getenv("CALIBRATIONROOT") <<
-    "/CrystalCalorimeter/mapping/towerMap_EEMC_v005.txt";
+    "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
 
   RawTowerBuilderByHitIndex* tower_EEMC = new RawTowerBuilderByHitIndex("TowerBuilder_EEMC");
   tower_EEMC->Detector("EEMC");

--- a/macros/g4simulations/G4_FEMC_EIC.C
+++ b/macros/g4simulations/G4_FEMC_EIC.C
@@ -64,9 +64,12 @@ FEMCSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
   ostringstream mapping_femc;
 
   
-  femc->SetEICDetector(); 
+//  femc->SetEICDetector();
+
   // fsPHENIX ECAL
-  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+//  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
 
   cout << mapping_femc.str() << endl;
   femc->SetTowerMappingFile( mapping_femc.str() );
@@ -87,9 +90,12 @@ void FEMC_Towers(int verbosity = 0) {
 
   ostringstream mapping_femc;
 
-  // fsPHENIX ECAL
-  mapping_femc << getenv("CALIBRATIONROOT") <<
-   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+//  // fsPHENIX ECAL
+//  mapping_femc << getenv("CALIBRATIONROOT") <<
+//   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+
 
   RawTowerBuilderByHitIndex* tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -107,41 +113,41 @@ void FEMC_Towers(int verbosity = 0) {
   //se->registerSubsystem( TowerDigitizer1 );
 
   // PbSc towers
-  //RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
-  //TowerDigitizer2->Detector("FEMC");
-  //TowerDigitizer2->TowerType(2); 
-  //TowerDigitizer2->Verbosity(verbosity);
-  //TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  //se->registerSubsystem( TowerDigitizer2 );
+  RawTowerDigitizer *TowerDigitizer2 = new RawTowerDigitizer("FEMCRawTowerDigitizer2");
+  TowerDigitizer2->Detector("FEMC");
+  TowerDigitizer2->TowerType(2);
+  TowerDigitizer2->Verbosity(verbosity);
+  TowerDigitizer2->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+  se->registerSubsystem( TowerDigitizer2 );
 
-  // E864 towers (three types for three sizes)
-  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
-  TowerDigitizer3->Detector("FEMC");
-  TowerDigitizer3->TowerType(3); 
-  TowerDigitizer3->Verbosity(verbosity);
-  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer3 );
-
-  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
-  TowerDigitizer4->Detector("FEMC");
-  TowerDigitizer4->TowerType(4); 
-  TowerDigitizer4->Verbosity(verbosity);
-  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer4 );
-
-  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
-  TowerDigitizer5->Detector("FEMC");
-  TowerDigitizer5->TowerType(5); 
-  TowerDigitizer5->Verbosity(verbosity);
-  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer5 );
-
-  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
-  TowerDigitizer6->Detector("FEMC");
-  TowerDigitizer6->TowerType(6); 
-  TowerDigitizer6->Verbosity(verbosity);
-  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem( TowerDigitizer6 );
+//  // E864 towers (three types for three sizes)
+//  RawTowerDigitizer *TowerDigitizer3 = new RawTowerDigitizer("FEMCRawTowerDigitizer3");
+//  TowerDigitizer3->Detector("FEMC");
+//  TowerDigitizer3->TowerType(3);
+//  TowerDigitizer3->Verbosity(verbosity);
+//  TowerDigitizer3->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer3 );
+//
+//  RawTowerDigitizer *TowerDigitizer4 = new RawTowerDigitizer("FEMCRawTowerDigitizer4");
+//  TowerDigitizer4->Detector("FEMC");
+//  TowerDigitizer4->TowerType(4);
+//  TowerDigitizer4->Verbosity(verbosity);
+//  TowerDigitizer4->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer4 );
+//
+//  RawTowerDigitizer *TowerDigitizer5 = new RawTowerDigitizer("FEMCRawTowerDigitizer5");
+//  TowerDigitizer5->Detector("FEMC");
+//  TowerDigitizer5->TowerType(5);
+//  TowerDigitizer5->Verbosity(verbosity);
+//  TowerDigitizer5->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer5 );
+//
+//  RawTowerDigitizer *TowerDigitizer6 = new RawTowerDigitizer("FEMCRawTowerDigitizer6");
+//  TowerDigitizer6->Detector("FEMC");
+//  TowerDigitizer6->TowerType(6);
+//  TowerDigitizer6->Verbosity(verbosity);
+//  TowerDigitizer6->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+//  se->registerSubsystem( TowerDigitizer6 );
 
   // PbW crystals
   //RawTowerCalibration *TowerCalibration1 = new RawTowerCalibration("FEMCRawTowerCalibration1");
@@ -154,51 +160,51 @@ void FEMC_Towers(int verbosity = 0) {
   //se->registerSubsystem( TowerCalibration1 );
 
   // PbSc towers
-  //RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
-  //TowerCalibration2->Detector("FEMC");
-  //TowerCalibration2->TowerType(2);
-  //TowerCalibration2->Verbosity(verbosity);
-  //TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  //TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
-  //TowerCalibration2->set_pedstal_ADC(0);
-  //se->registerSubsystem( TowerCalibration2 );
+  RawTowerCalibration *TowerCalibration2 = new RawTowerCalibration("FEMCRawTowerCalibration2");
+  TowerCalibration2->Detector("FEMC");
+  TowerCalibration2->TowerType(2);
+  TowerCalibration2->Verbosity(verbosity);
+  TowerCalibration2->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+  TowerCalibration2->set_calib_const_GeV_ADC(1.0/0.249);  // sampling fraction = 0.249 for e-
+  TowerCalibration2->set_pedstal_ADC(0);
+  se->registerSubsystem( TowerCalibration2 );
 
-  // E864 towers (three types for three sizes)
-  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
-  TowerCalibration3->Detector("FEMC");
-  TowerCalibration3->TowerType(3);
-  TowerCalibration3->Verbosity(verbosity);
-  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030 
-  TowerCalibration3->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration3 );
-
-  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
-  TowerCalibration4->Detector("FEMC");
-  TowerCalibration4->TowerType(4);
-  TowerCalibration4->Verbosity(verbosity);
-  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration4->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration4 );
-
-  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
-  TowerCalibration5->Detector("FEMC");
-  TowerCalibration5->TowerType(5);
-  TowerCalibration5->Verbosity(verbosity);
-  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration5->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration5 );
-
-  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
-  TowerCalibration6->Detector("FEMC");
-  TowerCalibration6->TowerType(6);
-  TowerCalibration6->Verbosity(verbosity);
-  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration6->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
-  TowerCalibration6->set_pedstal_ADC(0);
-  se->registerSubsystem( TowerCalibration6 );
+//  // E864 towers (three types for three sizes)
+//  RawTowerCalibration *TowerCalibration3 = new RawTowerCalibration("FEMCRawTowerCalibration3");
+//  TowerCalibration3->Detector("FEMC");
+//  TowerCalibration3->TowerType(3);
+//  TowerCalibration3->Verbosity(verbosity);
+//  TowerCalibration3->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration3->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration3->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration3 );
+//
+//  RawTowerCalibration *TowerCalibration4 = new RawTowerCalibration("FEMCRawTowerCalibration4");
+//  TowerCalibration4->Detector("FEMC");
+//  TowerCalibration4->TowerType(4);
+//  TowerCalibration4->Verbosity(verbosity);
+//  TowerCalibration4->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration4->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration4->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration4 );
+//
+//  RawTowerCalibration *TowerCalibration5 = new RawTowerCalibration("FEMCRawTowerCalibration5");
+//  TowerCalibration5->Detector("FEMC");
+//  TowerCalibration5->TowerType(5);
+//  TowerCalibration5->Verbosity(verbosity);
+//  TowerCalibration5->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration5->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration5->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration5 );
+//
+//  RawTowerCalibration *TowerCalibration6 = new RawTowerCalibration("FEMCRawTowerCalibration6");
+//  TowerCalibration6->Detector("FEMC");
+//  TowerCalibration6->TowerType(6);
+//  TowerCalibration6->Verbosity(verbosity);
+//  TowerCalibration6->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+//  TowerCalibration6->set_calib_const_GeV_ADC(1.0/0.030);  // sampling fraction = 0.030
+//  TowerCalibration6->set_pedstal_ADC(0);
+//  se->registerSubsystem( TowerCalibration6 );
 
 }
 

--- a/macros/g4simulations/G4_FHCAL.C
+++ b/macros/g4simulations/G4_FHCAL.C
@@ -51,7 +51,7 @@ FHCALSetup(PHG4Reco* g4Reco, const int absorberactive = 0)
 
   /* path to central copy of calibrations repositry */
   mapping_hhcal << getenv("CALIBRATIONROOT") ;
-  mapping_hhcal << "/ForwardHcal/mapping/towerMap_FHCAL_v004.txt";
+  mapping_hhcal << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
   cout << mapping_hhcal.str() << endl;
   //mapping_hhcal << "towerMap_FHCAL_latest.txt";
 
@@ -73,7 +73,7 @@ void FHCAL_Towers(int verbosity = 0) {
 
   ostringstream mapping_fhcal;
   mapping_fhcal << getenv("CALIBRATIONROOT") <<
-  	"/ForwardHcal/mapping/towerMap_FHCAL_v004.txt";
+  	"/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
   //mapping_fhcal << "towerMap_FHCAL_latest.txt";
 
   RawTowerBuilderByHitIndex* tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");

--- a/macros/g4simulations/G4_GEM_EIC.C
+++ b/macros/g4simulations/G4_GEM_EIC.C
@@ -1,28 +1,30 @@
 #pragma once
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
-#include "GlobalVariables.C"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
+#include <TMath.h>
 #include <g4detectors/PHG4SectorSubsystem.h>
 #include <g4main/PHG4Reco.h>
-int make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-                 double etamax,  const int N_Sector = 8);
+#include <string>
+#include "GlobalVariables.C"
+
+using namespace std;
+
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8);
 void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
+int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax);
 R__LOAD_LIBRARY(libg4detectors.so)
 #endif
 
-void
-EGEM_Init()
+void EGEM_Init()
 {
-
 }
 
-void
-FGEM_Init()
+void FGEM_Init()
 {
-
 }
 
-void
-EGEMSetup(PHG4Reco* g4Reco)
+void EGEMSetup(PHG4Reco *g4Reco)
 {
   /* Careful with dimensions! If GEM station volumes overlap, e.g. with TPC volume, they will be
    * drawn in event display but will NOT register any hits.
@@ -30,17 +32,16 @@ EGEMSetup(PHG4Reco* g4Reco)
    * Geometric constraints:
    * TPC length = 211 cm --> from z = -105.5 to z = +105.5
    */
-  float thickness=3.;
-  make_GEM_station("EGEM_0", g4Reco,  -20.5 + thickness, -0.94, -1.95);
-  make_GEM_station("EGEM_1", g4Reco,  -69.5 + thickness, -2.07, -3.21);
-  make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.9);
-  make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -4.00);
+  float thickness = 3.;
+  make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
+  make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
+  make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+  make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
 }
 
-void
-FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
-          const double min_eta = 1.245 //
-          )
+void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
+               const double min_eta = 1.245               //
+)
 {
   const double tilt = .1;
 
@@ -50,13 +51,28 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   double zpos;
   PHG4SectorSubsystem *gem;
 
-  make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 2.73, N_Sector);
-  make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 4.00, N_Sector);
+  /// LANL FST From Xuan Li
+  // plane 1, z location: 1200mm, inner radius: 45mm, outer radius: 350mm
+  // plane 2, z location: 1400mm, inner radius: 50mm, outer radius: 390mm
+  // plane 3, z location: 1700mm, inner radius: 60mm, outer radius: 410mm
+  // plane 4, z location: 1900mm, inner radius: 70mm, outer radius: 430mm
+  // We also need two outer barrel layers which might need some adjustments by the space limitation
+  // and needs integration with the central vertex detector.
+  //
+  // Note1:  last station need to be removed to avoid confliction with the gas RICH. GEM chamber at z=2.7m is used instead
+  // Note2:  increase inner radius for beam pipe flange clearance
+
+  make_LANL_FST_station("FST_0", g4Reco, 17, 3.2, 18);
+  make_LANL_FST_station("FST_1", g4Reco, 62, 3.2, 18);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  make_LANL_FST_station("FST_2", g4Reco, 120, 10, 35);
 
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_2";
-  etamax = 4;
+  etamax = 2;
   etamin = min_eta;
   zpos = 134.0;
 
@@ -64,68 +80,49 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   gem->get_geometry().set_normal_polar_angle(tilt);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->OverlapCheck(overlapcheck);
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
+
+  ///////////////////////////////////////////////////////////////////////////
+
+  make_LANL_FST_station("FST_3", g4Reco, 140, 12, 41);
 
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_3";
-  etamax = 4;
+  etamax = 2;
   etamin = min_eta;
   zpos = 157.0;
-  gem = new PHG4SectorSubsystem(name.c_str());
-
-  gem->SuperDetector(name);
-  gem->get_geometry().set_normal_polar_angle(tilt);
-  gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
-  gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
-  gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
-  gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
-  gem->get_geometry().set_material("G4_METHANE");
-  gem->get_geometry().set_N_Sector(N_Sector);
-  gem->OverlapCheck(overlapcheck);
-  AddLayers_MiniTPCDrift(gem);
-  gem->get_geometry().AddLayers_HBD_GEM();
-  g4Reco->registerSubsystem(gem);
 
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
-  zpos = zpos
-    - (zpos * sin(tilt)
-       + zpos * cos(tilt)
-       * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-    * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax) - tilt)) * sin(tilt);
 
   gem->get_geometry().set_normal_polar_angle(
-                                             (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-                                              + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax)) / 2);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
-                                       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
 
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
@@ -134,8 +131,12 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   ///////////////////////////////////////////////////////////////////////////
 
+  make_LANL_FST_station("FST_4", g4Reco, 160, 12, 41);
+
+  ///////////////////////////////////////////////////////////////////////////
+
   name = "FGEM_4";
-  etamax = 4;
+  etamax = 3.5;
   etamin = min_eta;
   zpos = 271.0;
   gem = new PHG4SectorSubsystem(name.c_str());
@@ -143,13 +144,13 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem->SuperDetector(name);
   gem->get_geometry().set_normal_polar_angle(tilt);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(), 0);
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->OverlapCheck(overlapcheck);
@@ -157,29 +158,24 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
   gem->get_geometry().AddLayers_HBD_GEM();
   g4Reco->registerSubsystem(gem);
 
-  zpos = zpos
-    - (zpos * sin(tilt)
-       + zpos * cos(tilt)
-       * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt))
-    * sin(tilt);
+  zpos = zpos - (zpos * sin(tilt) + zpos * cos(tilt) * tan(PHG4Sector::Sector_Geometry::eta_to_polar_angle(2) - tilt)) * sin(tilt);
 
   gem = new PHG4SectorSubsystem(name + "_LowerEta");
   gem->SuperDetector(name);
 
   gem->get_geometry().set_normal_polar_angle(
-                                             (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta)
-                                              + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
+      (PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta) + PHG4Sector::Sector_Geometry::eta_to_polar_angle(2)) / 2);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
-                                       PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm(),
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(2));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(min_eta));
   gem->get_geometry().set_material("G4_METHANE");
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
 
   AddLayers_MiniTPCDrift(gem);
   gem->get_geometry().AddLayers_HBD_GEM();
@@ -188,11 +184,73 @@ FGEMSetup(PHG4Reco* g4Reco, const int N_Sector = 8, //
 
   ///////////////////////////////////////////////////////////////////////////
 
+  make_LANL_FST_station("FST_5", g4Reco, 280, 17, 41);
+
+  ///////////////////////////////////////////////////////////////////////////
+}
+
+int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax)
+{
+  //  cout
+  //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
+  //      << name << endl;
+
+  // always facing the interaction point
+  double polar_angle = 0;
+  if (zpos < 0)
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
+
+  double min_polar_angle = TMath::ATan2(Rmin, zpos);
+  double max_polar_angle = TMath::ATan2(Rmax, zpos);
+
+  if (max_polar_angle < min_polar_angle)
+  {
+    double t = max_polar_angle;
+    max_polar_angle = min_polar_angle;
+    min_polar_angle = t;
+  }
+
+  PHG4SectorSubsystem *fst;
+  fst = new PHG4SectorSubsystem(name.c_str());
+
+  fst->SuperDetector(name);
+
+  fst->get_geometry().set_normal_polar_angle(polar_angle);
+  fst->get_geometry().set_normal_start(
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+  fst->get_geometry().set_min_polar_angle(min_polar_angle);
+  fst->get_geometry().set_max_polar_angle(max_polar_angle);
+  fst->get_geometry().set_max_polar_edge(
+      PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_min_polar_edge(
+      PHG4Sector::Sector_Geometry::ConeEdge());
+  fst->get_geometry().set_N_Sector(1);
+  fst->get_geometry().set_material("G4_AIR");
+  fst->OverlapCheck(overlapcheck);
+
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+  // build up layers
+  fst->get_geometry().AddLayer("SliconSensor", "G4_Si", 18 * um, true, 100);
+  fst->get_geometry().AddLayer("Metalconnection", "G4_Al", 15 * um, false, 100);
+  fst->get_geometry().AddLayer("SliconSupport", "G4_Al", 285 * um, false, 100);
+  fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 20 * um, false, 100);
+  fst->get_geometry().AddLayer("Cooling", "G4_WATER", 100 * um, false, 100);
+  fst->get_geometry().AddLayer("Support", "G4_GRAPHITE", 50 * um, false, 100);
+  fst->get_geometry().AddLayer("Support_Gap", "G4_AIR", 1 * cm, false, 100);
+  fst->get_geometry().AddLayer("Support2", "G4_GRAPHITE", 50 * um, false, 100);
+
+  g4Reco->registerSubsystem(fst);
+  return 0;
 }
 
 //! Add drift layers to mini TPC
-void
-AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
+void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
 {
   assert(gem);
 
@@ -201,7 +259,7 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
   const double um = 1e-3 * mm;
 
   //  const int N_Layers = 70; // used for mini-drift TPC timing digitalization
-  const int N_Layers = 1; // simplified setup
+  const int N_Layers = 1;  // simplified setup
   const double thickness = 2 * cm;
 
   gem->get_geometry().AddLayer("EntranceWindow", "G4_MYLAR", 25 * um, false,
@@ -209,22 +267,19 @@ AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem)
   gem->get_geometry().AddLayer("Cathode", "G4_GRAPHITE", 10 * um, false, 100);
 
   for (int d = 1; d <= N_Layers; d++)
-    {
-      stringstream s;
-      s << "DriftLayer_";
-      s << d;
+  {
+    stringstream s;
+    s << "DriftLayer_";
+    s << d;
 
-      gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
-                                   true);
-
-    }
+    gem->get_geometry().AddLayer(s.str(), "G4_METHANE", thickness / N_Layers,
+                                 true);
+  }
 }
 
-int
-make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
-                 double etamax,  const int N_Sector = 8)
+int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
+                     double etamax, const int N_Sector = 8)
 {
-
   //  cout
   //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
   //      << name << endl;
@@ -232,17 +287,16 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
   double polar_angle = 0;
 
   if (zpos < 0)
-    {
-      zpos = -zpos;
-      polar_angle = TMath::Pi();
-
-    }
+  {
+    zpos = -zpos;
+    polar_angle = TMath::Pi();
+  }
   if (etamax < etamin)
-    {
-      double t = etamax;
-      etamax = etamin;
-      etamin = t;
-    }
+  {
+    double t = etamax;
+    etamax = etamin;
+    etamin = t;
+  }
 
   PHG4SectorSubsystem *gem;
   gem = new PHG4SectorSubsystem(name.c_str());
@@ -251,15 +305,15 @@ make_GEM_station(string name, PHG4Reco* g4Reco, double zpos, double etamin,
 
   gem->get_geometry().set_normal_polar_angle(polar_angle);
   gem->get_geometry().set_normal_start(
-                                       zpos * PHG4Sector::Sector_Geometry::Unit_cm());
+      zpos * PHG4Sector::Sector_Geometry::Unit_cm());
   gem->get_geometry().set_min_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamax));
   gem->get_geometry().set_max_polar_angle(
-                                          PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
+      PHG4Sector::Sector_Geometry::eta_to_polar_angle(etamin));
   gem->get_geometry().set_max_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_min_polar_edge(
-                                         PHG4Sector::Sector_Geometry::FlatEdge());
+      PHG4Sector::Sector_Geometry::FlatEdge());
   gem->get_geometry().set_N_Sector(N_Sector);
   gem->get_geometry().set_material("G4_METHANE");
   gem->OverlapCheck(overlapcheck);

--- a/macros/g4simulations/G4_Pipe_EIC.C
+++ b/macros/g4simulations/G4_Pipe_EIC.C
@@ -1,0 +1,100 @@
+#pragma once
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
+#include <TSystem.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4detectors/PHG4GDMLSubsystem.h>
+#include <g4main/PHG4Reco.h>
+#include "GlobalVariables.C"
+R__LOAD_LIBRARY(libg4detectors.so)
+#endif
+
+void PipeInit()
+{
+}
+
+//! construct beam pipe
+//! \param[in] use_forward_pipes whether to include the forward pipe extension beyond the Be section
+double Pipe(PHG4Reco* g4Reco,
+            double radius,
+            const int absorberactive = 0,
+            int verbosity = 0
+            )
+{
+  // process pipe extentions?
+  bool use_forward_pipes = false;
+  const static bool do_pipe_hadron_forward_extension = use_forward_pipes && true;
+  const static bool do_pipe_electron_forward_extension = use_forward_pipes && true;
+
+  // Central pipe dimension
+  // Extracted via mechanical model: Detector chamber 3-20-20
+  // directly implimenting the central Be section in G4 cylinder for max speed simulation in the detector region.
+  // The jointer lip structure of the pipe R = 3.2cm x L=5mm is ignored here
+  static const double be_pipe_radius = 3.1000;
+  static const double be_pipe_thickness = 3.1762 - be_pipe_radius;  // 760 um for sPHENIX
+  static const double be_pipe_length_plus = 66.8;                   // +z beam pipe extend.
+  static const double be_pipe_length_neg = -79.8;                   // -z beam pipe extend.
+
+  static const double be_pipe_length = be_pipe_length_plus - be_pipe_length_neg;  // pipe length
+  static const double be_pipe_center = 0.5 * (be_pipe_length_plus + be_pipe_length_neg);
+
+  if (radius > be_pipe_radius)
+  {
+    cout << "inconsistency: radius: " << radius
+         << " larger than pipe inner radius: " << be_pipe_radius << endl;
+    gSystem->Exit(-1);
+  }
+
+  gSystem->Load("libg4detectors.so");
+  gSystem->Load("libg4testbench.so");
+
+  // mid-rapidity beryillium pipe
+  PHG4CylinderSubsystem* cyl = new PHG4CylinderSubsystem("VAC_BE_PIPE", 0);
+  cyl->set_double_param("radius", 0.0);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Galactic");
+  cyl->set_double_param("thickness", be_pipe_radius);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(overlapcheck);
+  if (absorberactive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  cyl = new PHG4CylinderSubsystem("BE_PIPE", 1);
+  cyl->set_double_param("radius", be_pipe_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", be_pipe_length);
+  cyl->set_double_param("place_z", be_pipe_center);
+  cyl->set_string_param("material", "G4_Be");
+  cyl->set_double_param("thickness", be_pipe_thickness);
+  cyl->SuperDetector("PIPE");
+  cyl->OverlapCheck(overlapcheck);
+  if (absorberactive) cyl->SetActive();
+  g4Reco->registerSubsystem(cyl);
+
+  radius = be_pipe_radius + be_pipe_thickness;
+
+  radius += no_overlapp;
+
+  if (do_pipe_electron_forward_extension)
+  {
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(overlapcheck);
+    g4Reco->registerSubsystem(gdml);
+  }
+
+  if (do_pipe_hadron_forward_extension)
+  {
+    PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
+    gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+    gdml->OverlapCheck(overlapcheck);
+    g4Reco->registerSubsystem(gdml);
+  }
+
+  return radius;
+}

--- a/macros/g4simulations/G4_RICH.C
+++ b/macros/g4simulations/G4_RICH.C
@@ -35,7 +35,9 @@ RICHSetup(PHG4Reco* g4Reco, //
 	  const double min_eta = 1.3, //
 	  const double R_mirror_ref = 190, //cm // Reduced from 195 (2014 LOI) -> 190 to avoid overlap with FGEM4 (it seems to fit fine in the AutoCAD drawing- is the RICH longer in Geant4 than in the AutoCAD drawing?)
 	  const double z_shift = 75, // cm
-	  const double R_shift = 18.5 // cm
+	  const double R_shift = 18.5, // cm
+    const double R_beampipe_front = 8, // clearance for EIC beam pipe flange
+    const double R_beampipe_back = 27 // clearance for EIC beam pipe flange
 	  )
 {
 
@@ -50,6 +52,9 @@ RICHSetup(PHG4Reco* g4Reco, //
 
   rich->get_RICH_geometry().set_z_shift(z_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
   rich->get_RICH_geometry().set_R_shift(R_shift * ePHENIXRICH::RICH_Geometry::Unit_cm());
+
+  rich->get_RICH_geometry().set_R_beam_pipe_front(R_beampipe_front * ePHENIXRICH::RICH_Geometry::Unit_cm());
+  rich->get_RICH_geometry().set_R_beam_pipe_back(R_beampipe_back * ePHENIXRICH::RICH_Geometry::Unit_cm());
 
   /* Register RICH module */
   rich->OverlapCheck( overlapcheck );

--- a/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
+++ b/macros/g4simulations/G4_Svtx_maps_ladders+intt_ladders+tpc_KalmanPatRec_EIC.C
@@ -1,6 +1,6 @@
 #pragma once
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
-#include "GlobalVariables.C"
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
+#include <TMath.h>
 #include <fun4all/Fun4AllServer.h>
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4eval/SvtxEvaluator.h>
@@ -8,15 +8,15 @@
 #include <g4mvtx/PHG4MvtxDefs.h>
 #include <g4mvtx/PHG4MvtxSubsystem.h>
 #include <g4tpc/PHG4TpcSpaceChargeDistortion.h>
+#include "GlobalVariables.C"
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4mvtx.so)
 #endif
 
-
 #include <vector>
 
 // ONLY if backward compatibility with hits files already generated with 8 inner TPC layers is needed, you can set this to "true"
-bool tpc_layers_40  = false;
+bool tpc_layers_40 = false;
 
 // if true, refit tracks with primary vertex included in track fit  - good for analysis of prompt tracks only
 // Adds second node to node tree, keeps original track node undisturbed
@@ -28,13 +28,13 @@ const int n_maps_layer = 3;  // must be 0-3, setting it to zero removes Mvtx com
 // default setup for the INTT - please don't change this. The configuration can be redone later in the nacro if desired
 int n_intt_layer = 0;
 // default layer configuration
-int laddertype[4] = {0, 1, 1, 1};  // default
-int nladder[4] = {34, 30, 36, 42};  // default
+int laddertype[4] = {0, 1, 1, 1};                                // default
+int nladder[4] = {34, 30, 36, 42};                               // default
 double sensor_radius_inner[4] = {6.876, 8.987, 10.835, 12.676};  // inner staggered radius for layer default
 double sensor_radius_outer[4] = {7.462, 9.545, 11.361, 13.179};  // outer staggered radius for layer  default
 
 int n_tpc_layer_inner = 16;
-double tpc_layer_thick_inner = 1.25; // EIC- recover default inner radius of TPC vol.
+double tpc_layer_thick_inner = 1.25;  // EIC- recover default inner radius of TPC vol.
 int tpc_layer_rphi_count_inner = 1152;
 
 int n_tpc_layer_mid = 16;
@@ -42,13 +42,13 @@ double tpc_layer_thick_mid = 1.25;
 int tpc_layer_rphi_count_mid = 1536;
 
 int n_tpc_layer_outer = 16;
-double tpc_layer_thick_outer = 1.125; // outer later reach from 60-78 cm (instead of 80 cm), that leads to radial thickness of 1.125 cm
+double tpc_layer_thick_outer = 1.125;  // outer later reach from 60-78 cm (instead of 80 cm), that leads to radial thickness of 1.125 cm
 int tpc_layer_rphi_count_outer = 2304;
 
 int n_gas_layer = n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer;
 
 double inner_cage_radius = 20.;
-double inner_readout_radius = 30.;
+// double inner_readout_radius = 30.; - deprecated for EIC simulation
 
 // TPC gas parameters
 // These are set for a variety of gas choices...
@@ -204,12 +204,12 @@ void SvtxInit(int verbosity = 0)
   // TPC readout shaping time and ADC clock parameters
   // these set the Z size of the TPC cells
   //=======================================
-  TPCShapingRMSLead = 32.0;  // ns, rising RMS equivalent of shaping amplifier for 80 ns SAMPA
-  TPCShapingRMSTail = 48.0;  // ns, falling RMS equivalent of shaping amplifier for 80 ns SAMPA
+  TPCShapingRMSLead = 32.0;                     // ns, rising RMS equivalent of shaping amplifier for 80 ns SAMPA
+  TPCShapingRMSTail = 48.0;                     // ns, falling RMS equivalent of shaping amplifier for 80 ns SAMPA
   TPCADCClock = 53.0;                           // ns, corresponds to an ADC clock rate of 18.8 MHz
   tpc_cell_z = TPCADCClock * TPCDriftVelocity;  // cm
 
-   //  these are fudge parameters, tuned to give average of 150 microns r-phi and 500 microns Z resolution in the outer TPC layers with the TPC setup used here and 80 ns SAMPA peaking time
+  //  these are fudge parameters, tuned to give average of 150 microns r-phi and 500 microns Z resolution in the outer TPC layers with the TPC setup used here and 80 ns SAMPA peaking time
   TPC_SmearRPhi = 0.25;
   TPC_SmearZ = 0.15;
 }
@@ -223,27 +223,62 @@ double Svtx(PHG4Reco* g4Reco, double radius,
   {
     bool maps_overlapcheck = false;  // set to true if you want to check for overlaps
 
-    // MAPS inner barrel layers
-    //======================================================
-    // YCM (2020-01-08): Using default values from PHG4MvtxSubsystem and PHG4MvtxDefs....
+    // Update EIC MAPS layer structure based on inner two layers of U. Birmingham tracker
 
     PHG4MvtxSubsystem* mvtx = new PHG4MvtxSubsystem("MVTX");
     mvtx->Verbosity(verbosity);
 
-    for (int ilayer = 0; ilayer < n_maps_layer; ilayer++)
-    {
-      double radius_lyr = PHG4MvtxDefs::mvtxdat[ilayer][PHG4MvtxDefs::kRmd];
-      if (verbosity)
-        cout << "Create Maps layer " << ilayer << " with radius " << radius_lyr << " mm." << endl;
-      radius = radius_lyr;
-    }
-    mvtx->set_string_param(PHG4MvtxDefs::GLOBAL ,"stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
+    // H?kan Wennl?f <hwennlof@kth.se> :
+    //    Without time-stamping layer:
+    //    Stave type  Length  Overlap Radius [mm] Tilt  Radiation length  Number of staves
+    //    ALICE inner 270 mm  2 mm  36.4  12.0 deg  0.3 % X0  18
+    //    ALICE inner 270 mm  2 mm  59.8  12.0 deg  0.3 % X0  30
+    //    ALICE outer 840 mm  4 mm  133.8 6.0 deg 0.8 % X0  16
+    //    ALICE outer 840 mm  4 mm  180 6.0 deg 0.8 % X0  21
+
+
+    static const double Degree2Rad = 180. / TMath::Pi();
+    int ilyr = 0;
+    mvtx->set_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
+    mvtx->set_int_param(ilyr, "layer", ilyr);
+    mvtx->set_int_param(ilyr, "N_staves", 18);
+    mvtx->set_double_param(ilyr, "layer_nominal_radius", 36.4); // mm
+    mvtx->set_double_param(ilyr, "phitilt", 12.0 * Degree2Rad + TMath::Pi());
+    mvtx->set_double_param(ilyr, "phi0", 0);
+
+    // Then add a new mid layer that is extrapolation of the inner two.
+    ++ilyr;
+    mvtx->set_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
+    mvtx->set_int_param(ilyr, "layer", ilyr);
+    mvtx->set_int_param(ilyr, "N_staves", 24);
+    mvtx->set_double_param(ilyr, "layer_nominal_radius", 48.1 ); // mm
+    mvtx->set_double_param(ilyr, "phitilt", 12.0 * Degree2Rad + TMath::Pi());
+    mvtx->set_double_param(ilyr, "phi0", 0);
+
+    ++ilyr;
+    mvtx->set_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
+    mvtx->set_int_param(ilyr, "layer", ilyr);
+    mvtx->set_int_param(ilyr, "N_staves", 30);
+    mvtx->set_double_param(ilyr, "layer_nominal_radius", 59.8 ); // mm
+    mvtx->set_double_param(ilyr, "phitilt", 12.0 * Degree2Rad + TMath::Pi());
+    mvtx->set_double_param(ilyr, "phi0", 0);
+
+//    // Then add a new 3rd layer that is extrapolation of the inner two.
+//    ++ilyr;
+//    mvtx->set_int_param(ilyr, "active", 1);  //non-automatic initialization in PHG4DetectorGroupSubsystem
+//    mvtx->set_int_param(ilyr, "layer", ilyr);
+//    mvtx->set_int_param(ilyr, "N_staves", 42);
+//    mvtx->set_double_param(ilyr, "layer_nominal_radius", 83.2 ); // mm
+//    mvtx->set_double_param(ilyr, "phitilt", 12.0 * Degree2Rad + TMath::Pi());
+//    mvtx->set_double_param(ilyr, "phi0", 0);
+
+    mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
     mvtx->SetActive(1);
     mvtx->OverlapCheck(maps_overlapcheck);
     g4Reco->registerSubsystem(mvtx);
-  }
+  }  //   if (n_maps_layer > 0)
 
-  assert (n_intt_layer == 0);
+  assert(n_intt_layer == 0);
 
   //  int verbosity = 1;
 
@@ -251,12 +286,12 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
   // switch ONLY for backward compatibility with 40 layer hits files!
   if (tpc_layers_40)
-    {
-      n_tpc_layer_inner = 8;
-      tpc_layer_thick_inner = 1.25;
-      tpc_layer_rphi_count_inner = 1152;
-      cout << "Using 8 inner_layers for backward comatibility" << endl;
-    }
+  {
+    n_tpc_layer_inner = 8;
+    tpc_layer_thick_inner = 1.25;
+    tpc_layer_rphi_count_inner = 1152;
+    cout << "Using 8 inner_layers for backward comatibility" << endl;
+  }
 
   PHG4CylinderSubsystem* cyl;
 
@@ -279,29 +314,29 @@ double Svtx(PHG4Reco* g4Reco, double radius,
 
   radius += cage_thickness;
 
-  double inner_readout_radius = radius;
-//  if (inner_readout_radius < radius) inner_readout_radius = radius;
-//
+  // double inner_readout_radius = radius; 
+  //  if (inner_readout_radius < radius) inner_readout_radius = radius;
+  //
   string tpcgas = "sPHENIX_TPC_Gas";  //  Ne(90%) CF4(10%) - defined in g4main/PHG4Reco.cc
-//
-//  // Layer of inert TPC gas from 20-30 cm
-//  if (inner_readout_radius - radius > 0)
-//  {
-//    cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", n_maps_layer + n_intt_layer + 1);
-//    cyl->set_double_param("radius", radius);
-//    cyl->set_int_param("lengthviarapidity", 0);
-//    cyl->set_double_param("length", cage_length);
-//    cyl->set_string_param("material", tpcgas.c_str());
-//    cyl->set_double_param("thickness", inner_readout_radius - radius);
-//    cyl->SuperDetector("SVTXSUPPORT");
-//    g4Reco->registerSubsystem(cyl);
-//  }
-//
-//  radius = inner_readout_radius;
+                                      //
+                                      //  // Layer of inert TPC gas from 20-30 cm
+                                      //  if (inner_readout_radius - radius > 0)
+                                      //  {
+                                      //    cyl = new PHG4CylinderSubsystem("SVTXSUPPORT", n_maps_layer + n_intt_layer + 1);
+                                      //    cyl->set_double_param("radius", radius);
+                                      //    cyl->set_int_param("lengthviarapidity", 0);
+                                      //    cyl->set_double_param("length", cage_length);
+                                      //    cyl->set_string_param("material", tpcgas.c_str());
+                                      //    cyl->set_double_param("thickness", inner_readout_radius - radius);
+                                      //    cyl->SuperDetector("SVTXSUPPORT");
+                                      //    g4Reco->registerSubsystem(cyl);
+                                      //  }
+                                      //
+                                      //  radius = inner_readout_radius;
 
   double outer_radius = 78.;
 
-  // Active layers of the TPC from 30-40 cm (inner layers)
+  // Active layers of the TPC (inner layers)
 
   for (int ilayer = n_maps_layer + n_intt_layer; ilayer < (n_maps_layer + n_intt_layer + n_tpc_layer_inner); ++ilayer)
   {
@@ -401,7 +436,6 @@ void Svtx_Cells(int verbosity = 0)
   //-----------
   // SVTX cells
   //-----------
-
 
   return;
 }

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -137,23 +137,23 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                                  //      const float noise
   );
 
-  // GEM0, 70um azimuthal resolution, 1cm radial strips
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
   kalman->add_phg4hits(
-      "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
+      "G4HIT_FST_0",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12.),                    //      const float radres,
-      70e-4,                             //      const float phires,
-      100e-4,                            //      const float lonres,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
-  // GEM1, 70um azimuthal resolution, 1cm radial strips
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
   kalman->add_phg4hits(
-      "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
+      "G4HIT_FST_1",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12.),                    //      const float radres,
-      70e-4,                             //      const float phires,
-      100e-4,                            //      const float lonres,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
@@ -169,6 +169,17 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                            //      const float noise
   );
 
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_2",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM2, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
@@ -179,6 +190,18 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
+
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_3",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM3, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
@@ -189,6 +212,18 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       1,                                 //      const float eff,
       0                                  //      const float noise
   );
+
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_4",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
+
   // GEM4, 70um azimuthal resolution, 1cm radial strips
   kalman->add_phg4hits(
       "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
@@ -200,6 +235,16 @@ void Tracking_Reco(int verbosity = 0, bool displaced_vertex = false)
       0                                  //      const float noise
   );
 
+  // LANL FST:   We could put the hit resolution at 5 micron with the 30 micron pixel pitch.
+  kalman->add_phg4hits(
+      "G4HIT_FST_5",                    //      const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+      5e-4,                    //      const float radres,
+      5e-4,                             //      const float phires,
+      50e-4 / sqrt(12.),                            //      const float lonres,
+      1,                                 //      const float eff,
+      0                                  //      const float noise
+  );
   // Saved track states (projections)
   kalman->add_state_name("FEMC");
   kalman->add_state_name("FHCAL");


### PR DESCRIPTION
Following #240 and sync it to the high occupancy QA.

Also updating the INTT-dependent tracking efficiency to cut on >=1 INTT hit (previously cut on >=2 hit, which is a bit tight)