### PR TITLE
Upstream/tracking low occupancy qa clusters

### DIFF
--- a/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
+++ b/macros/QA/tracking/QA_Draw_Tracking_nClus_Layer.C
@@ -2,7 +2,7 @@
 
 /*!
  * \file QA_Draw_Tracking_nClus_Layer.C
- * \brief 
+ * \brief
  * \author Hugo Pereira Da Costa <hugo.pereira-da-costa@cea.fr>
  * \version $Revision:   $
  * \date $Date: $
@@ -20,14 +20,57 @@
 //some common style files
 #include "../../sPHENIXStyle/sPhenixStyle.C"
 #include "QA_Draw_Utility.C"
-using namespace std;
+
+namespace  {
+
+  // Normalization
+  double Nevent_new = 1;
+  double Nevent_ref = 1;
+
+  void GetNormalization( TFile* qa_file_new, TFile* qa_file_ref, const TString& prefix, const TString& tag )
+  {
+    if (qa_file_new)
+    {
+      TH1 *h_norm = (TH1 *) qa_file_new->GetObjectChecked( prefix + TString("Normalization"), "TH1");
+      assert(h_norm);
+      Nevent_new = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin( tag ));
+    }
+
+    if (qa_file_ref)
+    {
+      TH1 *h_norm = (TH1 *) qa_file_ref->GetObjectChecked( prefix + TString("Normalization"), "TH1");
+      assert(h_norm);
+      Nevent_ref = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin( tag ));
+    }
+  }
+
+  void Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& prefix, const TString& tag )
+  {
+
+    auto h_new = static_cast<TH1*>( qa_file_new->GetObjectChecked( prefix + tag, "TH1" ) );
+    assert(h_new);
+    h_new->Sumw2();
+    h_new->Scale(1./Nevent_new);
+
+    TH1 *h_ref = nullptr;
+    if (qa_file_ref)
+    {
+      h_ref = static_cast<TH1*>( qa_file_ref->GetObjectChecked( prefix + tag, "TH1") );
+      assert(h_ref);
+      h_ref->Sumw2();
+      h_ref->Scale(1.0/Nevent_ref);
+    }
+
+    DrawReference(h_new, h_ref);
+    HorizontalLine( gPad, 1 )->Draw();
+  }
+
+}
 
 void QA_Draw_Tracking_nClus_Layer(
     const char *hist_name_prefix = "QAG4SimulationTracking",
-    const char *qa_file_name_new =
-        "data/G4sPHENIX.root_qa.root",
-    const char *qa_file_name_ref =
-        "data/G4sPHENIX.root_qa.root")
+    const char *qa_file_name_new = "data/G4sPHENIX.root_qa.root",
+    const char *qa_file_name_ref = "data/G4sPHENIX.root_qa.root")
 {
   SetsPhenixStyle();
 
@@ -43,50 +86,18 @@ void QA_Draw_Tracking_nClus_Layer(
     assert(qa_file_ref->IsOpen());
   }
 
-  // obtain normalization
-  double Nevent_new = 1;
-  double Nevent_ref = 1;
-
-  if (qa_file_new)
-  {
-    TH1 *h_norm = (TH1 *) qa_file_new->GetObjectChecked(
-        prefix + TString("Normalization"), "TH1");
-    assert(h_norm);
-
-    Nevent_new = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
-  }
-  if (qa_file_ref)
-  {
-    TH1 *h_norm = (TH1 *) qa_file_ref->GetObjectChecked(
-        prefix + TString("Normalization"), "TH1");
-    assert(h_norm);
-
-    Nevent_ref = h_norm->GetBinContent(h_norm->GetXaxis()->FindBin("Reco Track"));
-  }
-
-  auto h_new = static_cast<TH1*>( qa_file_new->GetObjectChecked( prefix + TString("nClus_layer"), "TH1" ) );
-  assert(h_new);
-
-  //  h_new->Rebin(1, 2);
-  h_new->Sumw2();
-  h_new->Scale(1./Nevent_new);
-
-  TH1 *h_ref = nullptr;
-  if (qa_file_ref)
-  {
-    h_ref = static_cast<TH1*>( qa_file_ref->GetObjectChecked(
-        prefix + TString("nClus_layer"), "TH1") );
-    assert(h_ref);
-
-    h_ref->Sumw2();
-    h_ref->Scale(1.0/Nevent_ref);
-  }
-
   auto c1 = new TCanvas(TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
     TString("QA_Draw_Tracking_nClus_Layer") + TString("_") + hist_name_prefix,
     1800, 1000);
 
-  DrawReference(h_new, h_ref);
+  c1->Divide( 2, 1 );
+  c1->cd(1);
+  GetNormalization( qa_file_new, qa_file_ref, prefix, "Truth Track" );
+  Draw( qa_file_new, qa_file_ref, prefix, "nClus_layerGen" );
+
+  c1->cd(2);
+  GetNormalization( qa_file_new, qa_file_ref, prefix, "Reco Track" );
+  Draw( qa_file_new, qa_file_ref, prefix, "nClus_layer" );
 
   SaveCanvas(c1, TString(qa_file_name_new) + TString("_") + TString(c1->GetName()), true);
 }

--- a/macros/QA/tracking/QA_Draw_Utility.C
+++ b/macros/QA/tracking/QA_Draw_Utility.C
@@ -65,11 +65,34 @@ TLine* VerticalLine( TVirtualPad* p, Double_t x )
   
   if( p->GetLogy() )
   {
-    yMin = TMath::Power( 10, yMin );
-    yMax = TMath::Power( 10, yMax );
+    yMin = std::pow( 10, yMin );
+    yMax = std::pow( 10, yMax );
   }
   
   TLine *line = new TLine( x, yMin, x, yMax );
+  line->SetLineStyle( 2 );
+  line->SetLineWidth( 1 );
+  line->SetLineColor( 1 );
+  return line;
+  
+}
+
+//! Draw a horizontal line in a pad at given x coordinate
+TLine* HorizontalLine( TVirtualPad* p, Double_t y )
+{
+  
+  p->Update();
+  
+  Double_t xMin = p->GetUxmin();
+  Double_t xMax = p->GetUxmax();
+  
+  if( p->GetLogx() )
+  {
+    xMin = std::pow( 10, xMin );
+    xMax = std::pow( 10, xMax );
+  }
+  
+  TLine *line = new TLine( xMin, y, xMax, y );
   line->SetLineStyle( 2 );
   line->SetLineWidth( 1 );
   line->SetLineColor( 1 );
@@ -463,7 +486,7 @@ TH1 *GetBinominalRatio(TH1 *h_pass, TH1 *h_n_trial, bool process_zero_bins = fal
                                  (p + 1 / (2 * n_trial)) / (1 + 1 / n_trial));
           h_ratio->SetBinError(x, y,
                                z,  //
-                               TMath::Sqrt(
+                               std::sqrt(
                                    1. / n_trial * p * (1 - p) + 1. / (4 * n_trial * n_trial)) /
                                    (1 + 1 / n_trial));
         }

--- a/macros/QA/tracking/QA_Draw_Utility.C
+++ b/macros/QA/tracking/QA_Draw_Utility.C
@@ -57,47 +57,47 @@ void DivideCanvas(TVirtualPad* p, int npads)
 //! Draw a vertical line in a pad at given x coordinate
 TLine* VerticalLine( TVirtualPad* p, Double_t x )
 {
-  
+
   p->Update();
-  
+
   Double_t yMin = p->GetUymin();
   Double_t yMax = p->GetUymax();
-  
+
   if( p->GetLogy() )
   {
     yMin = std::pow( 10, yMin );
     yMax = std::pow( 10, yMax );
   }
-  
+
   TLine *line = new TLine( x, yMin, x, yMax );
   line->SetLineStyle( 2 );
   line->SetLineWidth( 1 );
   line->SetLineColor( 1 );
   return line;
-  
+
 }
 
 //! Draw a horizontal line in a pad at given x coordinate
 TLine* HorizontalLine( TVirtualPad* p, Double_t y )
 {
-  
+
   p->Update();
-  
+
   Double_t xMin = p->GetUxmin();
   Double_t xMax = p->GetUxmax();
-  
+
   if( p->GetLogx() )
   {
     xMin = std::pow( 10, xMin );
     xMax = std::pow( 10, xMax );
   }
-  
+
   TLine *line = new TLine( xMin, y, xMax, y );
   line->SetLineStyle( 2 );
   line->SetLineWidth( 1 );
   line->SetLineColor( 1 );
   return line;
-  
+
 }
 
 //! Service function to SaveCanvas()


### PR DESCRIPTION
This PR draw plots for the nclusters/layer/truth track histogram introduced in https://github.com/sPHENIX-Collaboration/coresoftware/pull/808
Produced plot looks like: 
![G4sPHENIX root_qa root_QA_Draw_Tracking_nClus_Layer_QAG4SimulationTracking](https://user-images.githubusercontent.com/22907496/81348150-cd1f1e80-907a-11ea-9419-df65794facc7.png)
(left is truth tacks, right is reco tracks)