### PR TITLE
added cluster size histograms

### DIFF
--- a/macros/QA/tracking/QA_Draw_Intt.C
+++ b/macros/QA/tracking/QA_Draw_Intt.C
@@ -86,13 +86,20 @@ void QA_Draw_Intt(
 
   std::vector<TCanvas*> cvlist;
 
+  // phi residuals, errors and pulls
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "rphi_error" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "phi_pulls" ) );
 
+  // z residuals, errors and pulls
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "dz" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_error" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_pulls" ) );
+
+  // cluster sizes
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_phi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_z" ) );
 
   for( const auto& cv:cvlist )
   { SaveCanvas(cv, TString(qa_file_name_new) + TString("_") + TString(cv->GetName()), true); }

--- a/macros/QA/tracking/QA_Draw_Mvtx.C
+++ b/macros/QA/tracking/QA_Draw_Mvtx.C
@@ -86,13 +86,20 @@ void QA_Draw_Mvtx(
   
   std::vector<TCanvas*> cvlist;
 
+  // phi residuals, errors and pulls
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "rphi_error" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "phi_pulls" ) );
 
+  // z residuals, errors and pulls
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "dz" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_error" ) );
   cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_pulls" ) );
+
+  // cluster sizes
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_phi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_z" ) );
 
   for( const auto& cv:cvlist )
   { SaveCanvas(cv, TString(qa_file_name_new) + TString("_") + TString(cv->GetName()), true); }


### PR DESCRIPTION
This PR adds plotting for the cluster size histograms for MVTX and INTT , as added in https://github.com/sPHENIX-Collaboration/coresoftware/pull/820
Typical plots look like: 
![G4sPHENIX root_qa root_QA_Draw_Mvtx_clus_size_QAG4SimulationMvtx](https://user-images.githubusercontent.com/22907496/82237334-b25a6e80-98f2-11ea-8e7b-9b30c906d75f.png)
![G4sPHENIX root_qa root_QA_Draw_Mvtx_clus_size_phi_QAG4SimulationMvtx](https://user-images.githubusercontent.com/22907496/82237347-b8e8e600-98f2-11ea-8a94-a753f014bc86.png)
![G4sPHENIX root_qa root_QA_Draw_Mvtx_clus_size_z_QAG4SimulationMvtx](https://user-images.githubusercontent.com/22907496/82237357-bc7c6d00-98f2-11ea-908e-60609c6da254.png)
