### PR TITLE
Inputmgr verbosity

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -100,7 +100,7 @@ int Fun4All_G4_EICDetector(
 
   // HepMC2 files
   //  Input::HEPMC = true;
-  Input::HEPMC_VERBOSITY = 1;
+  Input::VERBOSITY = 1;
   INPUTHEPMC::filename = inputFile;
 
   //-----------------

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -75,11 +75,11 @@ int Fun4All_G4_fsPHENIX(
   INPUTSIMPLE::AddParticle("pi-", 5);
   //  INPUTSIMPLE::AddParticle("e-",0);
   //  INPUTSIMPLE::AddParticle("pi-",10);
-INPUTSIMPLE::set_eta_range(-1,3);
-INPUTSIMPLE::set_phi_range(-M_PI,M_PI);
-INPUTSIMPLE::set_pt_range(0.5,50.);
-INPUTSIMPLE::set_vtx_mean(0.,0.,0.);
-INPUTSIMPLE::set_vtx_width(0.,0.,5.);
+  INPUTSIMPLE::set_eta_range(-1, 3);
+  INPUTSIMPLE::set_phi_range(-M_PI, M_PI);
+  INPUTSIMPLE::set_pt_range(0.5, 50.);
+  INPUTSIMPLE::set_vtx_mean(0., 0., 0.);
+  INPUTSIMPLE::set_vtx_width(0., 0., 5.);
 
   //  Input::PYTHIA6 = true;
 

--- a/macros/g4simulations/Fun4All_G4_fsPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_fsPHENIX.C
@@ -91,7 +91,7 @@ INPUTSIMPLE::set_vtx_width(0.,0.,5.);
   //INPUTGUN::set_vtx(0,0,0);
 
   //  Input::HEPMC = true;
-  Input::HEPMC_VERBOSITY = 0;
+  Input::VERBOSITY = 0;
   INPUTHEPMC::filename = inputFile;
 
   //-----------------

--- a/macros/g4simulations/G4_Input.C
+++ b/macros/g4simulations/G4_Input.C
@@ -36,6 +36,7 @@ namespace Input
   bool PYTHIA6 = false;
   bool PYTHIA8 = false;
   bool SARTRE = false;
+  int VERBOSITY = 0;
 }  // namespace Input
 
 namespace INPUTHEPMC
@@ -159,7 +160,7 @@ void InputManagers()
   if (Input::HEPMC)
   {
     Fun4AllInputManager *in = new Fun4AllHepMCInputManager("HEPMCin");
-    in->Verbosity(Input::HEPMC_VERBOSITY);
+    in->Verbosity(Input::VERBOSITY);
     se->registerInputManager(in);
     se->fileopen(in->Name(), INPUTHEPMC::filename);
   }
@@ -167,13 +168,13 @@ void InputManagers()
   {
     Fun4AllInputManager *hitsin = new Fun4AllDstInputManager("DSTin");
     hitsin->fileopen(INPUTREADHITS::filename);
-    hitsin->Verbosity(1);
+    hitsin->Verbosity(Input::VERBOSITY);
     se->registerInputManager(hitsin);
   }
   else
   {
     Fun4AllInputManager *in = new Fun4AllDummyInputManager("JADE");
-    in->Verbosity(1);
+    in->Verbosity(Input::VERBOSITY);
     se->registerInputManager(in);
   }
 }

--- a/macros/g4simulations/GlobalVariables.C
+++ b/macros/g4simulations/GlobalVariables.C
@@ -11,7 +11,6 @@ static double no_overlapp = 0.0001;  // added to radii to avoid overlapping volu
 namespace Input
 {
   bool HEPMC = false;
-  int HEPMC_VERBOSITY = 0;
   bool EMBED = false;
   bool READEIC = false;
 }


### PR DESCRIPTION
This PR turns off the forgotten verbosity=1 setting for some input managers. It now uses INPUT::VERBOSITY for all of them