### PR TITLE
Fast tracking parameter update for EIC macro

### DIFF
--- a/macros/g4simulations/Fun4All_G4_EICDetector.C
+++ b/macros/g4simulations/Fun4All_G4_EICDetector.C
@@ -39,7 +39,7 @@ int Fun4All_G4_EICDetector(
   // PHRandomSeed() which reads /dev/urandom to get its seed
   // if the RANDOMSEED flag is set its value is taken as initial seed
   // which will produce identical results so you can debug your code
-  rc->set_IntFlag("RANDOMSEED", 12345);
+  // rc->set_IntFlag("RANDOMSEED", 12345);
 
   //===============
   // Input options
@@ -70,7 +70,7 @@ int Fun4All_G4_EICDetector(
 
   // Simple multi particle generator in eta/phi/pt ranges
   Input::SIMPLE = true;
-  Input::SIMPLE_VERBOSITY = 1;
+  Input::SIMPLE_VERBOSITY = 0;
   INPUTSIMPLE::AddParticle("pi-", 5);
   INPUTSIMPLE::set_eta_range(-3, 3);
   INPUTSIMPLE::set_phi_range(-M_PI, M_PI);
@@ -100,7 +100,7 @@ int Fun4All_G4_EICDetector(
 
   // HepMC2 files
   //  Input::HEPMC = true;
-  Input::VERBOSITY = 1;
+  Input::VERBOSITY = 0;
   INPUTHEPMC::filename = inputFile;
 
   //-----------------

--- a/macros/g4simulations/G4_Tracking_EIC.C
+++ b/macros/g4simulations/G4_Tracking_EIC.C
@@ -58,11 +58,13 @@ void Tracking_Reco()
   //  kalman->Smearing(false);
   if (G4TRACKING::DISPLACED_VERTEX)
   {
-    //use very loose vertex constraint (1cm in sigma) to allow reco of displaced vertex
-    kalman->set_use_vertex_in_fitting(true);
-    kalman->set_vertex_xy_resolution(1);
-    kalman->set_vertex_z_resolution(1);
-    kalman->enable_vertexing(true);
+    // do not use truth vertex in the track fitting,
+    // which would lead to worse momentum resolution for prompt tracks
+    // but this allows displaced track analysis including DCA and vertex finding
+    kalman->set_use_vertex_in_fitting(false);
+    kalman->set_vertex_xy_resolution(0);// do not smear the vertex used in the built-in DCA calculation
+    kalman->set_vertex_z_resolution(0); // do not smear the vertex used in the built-in DCA calculation
+    kalman->enable_vertexing(true);     // enable vertex finding and fitting
   }
   else
   {


### PR DESCRIPTION
Two tuning on the EIC macro: 
1. For the displaced vertex mode, exclude vertex in track fit and use not-smeared truth vertex for DCA calculation reference. Thanks to Håkan Wennlöf of University of Birmingham for verifying this setup.
2. For the main macro, use random seed by default and silence verbosity of input manager and simple event generator.

Here is an example 2D DCA from 20 GeV pions: 
![image](https://user-images.githubusercontent.com/7947083/87080188-3fd08580-c1f5-11ea-8385-65adc9dc4490.png)
