### PR TITLE
Tpc cluster qa - merging high occupancy branch

### DIFF
--- a/macros/QA/tracking/QA_Draw_ALL.sh
+++ b/macros/QA/tracking/QA_Draw_ALL.sh
@@ -26,6 +26,9 @@ root -b -q "QA_Draw_Intt.C(${q}QAG4SimulationIntt${q},$new_QA_file, $reference_Q
 # mvtx stuff
 root -b -q "QA_Draw_Mvtx.C(${q}QAG4SimulationMvtx${q},$new_QA_file, $reference_QA_file)"
 
+# tpc stuff
+root -b -q "QA_Draw_Tpc.C(${q}QAG4SimulationTpc${q},$new_QA_file, $reference_QA_file)"
+
 # last all jet stuff
 root -b -q "QA_Draw_Tracking_TruthMatchingOverview.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"
 root -b -q "QA_Draw_Tracking_pTRatio.C(${q}QAG4SimulationTracking${q}, $new_QA_file, $reference_QA_file)"

--- a/macros/QA/tracking/QA_Draw_Tpc.C
+++ b/macros/QA/tracking/QA_Draw_Tpc.C
@@ -1,0 +1,144 @@
+/*!
+ * \file QA_Draw_Tpc.C
+ * \brief
+ * \author Tony Frawley <afrawley@fsu.edu>
+ * \version $Revision:   $
+ * \date $Date: $
+ */
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TLine.h>
+#include <TString.h>
+
+//some common style files
+#include "../../sPHENIXStyle/sPhenixStyle.C"
+#include "QA_Draw_Utility.C"
+
+static constexpr int nregions_tpc = 3;
+
+namespace
+{
+
+  TCanvas* Draw( TFile* qa_file_new, TFile* qa_file_ref, const TString& hist_name_prefix, const TString& tag )
+  {
+    
+    const TString prefix = TString("h_") + hist_name_prefix + TString("_");
+    
+    auto cv = new TCanvas(
+			  TString("QA_Draw_Tpc_") + tag + TString("_") + hist_name_prefix,
+			  TString("QA_Draw_Tpc_") + tag + TString("_") + hist_name_prefix,
+      1800, 1000);
+
+    cv->Divide( nregions_tpc, 1 );
+    for( int region = 0; region < nregions_tpc; ++region )
+    {
+
+      // get histograms
+      auto hnew = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), region ), "TH1" ) );
+      hnew->Scale( 1./hnew->GetEntries() );
+      hnew->SetMinimum(0);
+
+      // reference
+      auto href = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_%i", prefix.Data(), tag.Data(), region ), "TH1" ) ) : nullptr;
+      if( href )
+      {
+        href->Scale( 1./href->GetEntries() );
+        href->SetMinimum(0);
+      }
+
+      // draw
+      cv->cd( region+1 );
+      DrawReference(hnew, href);
+
+      auto line = VerticalLine( gPad, 0 );
+      line->Draw();
+    }
+
+    return cv;
+
+  }
+
+  TCanvas* Draw_eff( TFile* qa_file_new, TFile* qa_file_ref, const TString& hist_name_prefix, const TString& tag )
+  {
+    
+    const TString prefix = TString("h_") + hist_name_prefix + TString("_");
+    
+    auto cv = new TCanvas(
+			  TString("QA_Draw_Tpc_") + tag + TString("_") + hist_name_prefix,
+			  TString("QA_Draw_Tpc_") + tag + TString("_") + hist_name_prefix,
+			  1800, 1000);
+
+    // get histograms
+    auto hnew0 = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_0", prefix.Data(), tag.Data()), "TH1" ) );
+    auto hnew1 = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_1", prefix.Data(), tag.Data()), "TH1" ) );
+    
+    hnew1->Divide(hnew0);
+    hnew1->SetMinimum(0);
+    
+    // reference
+    auto href0 = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_0", prefix.Data(), tag.Data()), "TH1" ) ) : nullptr;
+    auto href1 = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_1", prefix.Data(), tag.Data()), "TH1" ) ) : nullptr;
+    if( href0 )
+      {
+	href1->Divide(href0);
+        href1->SetMinimum(0);
+      }
+    
+    // draw
+    DrawReference(hnew1, href1);
+    //DrawReference(hnew1, hnew0);
+    
+    auto line = HorizontalLine( gPad, 1 );
+    line->Draw();
+    
+    
+    return cv;
+    
+  }
+  
+}
+
+void QA_Draw_Tpc(
+		 const char *hist_name_prefix = "QAG4SimulationTpc",
+		 const char *qa_file_name_new =  "data/100evts_G4sPHENIX.root_qa.root",
+		 const char *qa_file_name_ref =  "data/200evts_G4sPHENIX.root_qa.root"
+		 )
+{
+
+  SetsPhenixStyle();
+
+  auto qa_file_new = new TFile(qa_file_name_new);
+  assert(qa_file_new->IsOpen());
+
+  TFile* qa_file_ref = nullptr;
+  if (qa_file_name_ref)
+  {
+    qa_file_ref = new TFile(qa_file_name_ref);
+    assert(qa_file_ref->IsOpen());
+  }
+  
+  std::vector<TCanvas*> cvlist;
+
+  // cluster efficiency
+  cvlist.push_back( Draw_eff( qa_file_new, qa_file_ref, hist_name_prefix, "efficiency" ) );
+
+  // phi residuals, errors and pulls
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "drphi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "rphi_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "phi_pulls" ) );
+
+  // z residuals, errors and pulls
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "dz" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_error" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "z_pulls" ) );
+
+  // cluster sizes
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_phi" ) );
+  cvlist.push_back( Draw( qa_file_new, qa_file_ref, hist_name_prefix, "clus_size_z" ) );
+
+  for( const auto& cv:cvlist )
+  { SaveCanvas(cv, TString(qa_file_name_new) + TString("_") + TString(cv->GetName()), true); }
+
+}

--- a/macros/QA/tracking/QA_Draw_Tpc.C
+++ b/macros/QA/tracking/QA_Draw_Tpc.C
@@ -101,7 +101,7 @@ namespace
 
 void QA_Draw_Tpc(
 		 const char *hist_name_prefix = "QAG4SimulationTpc",
-		 const char *qa_file_name_new =  "data/100evts_G4sPHENIX.root_qa.root",
+		 const char *qa_file_name_new =  "data/G4sPHENIX.root_qa.root",
 		 const char *qa_file_name_ref =  "data/200evts_G4sPHENIX.root_qa.root"
 		 )
 {

--- a/macros/QA/tracking/QA_Draw_Tpc.C
+++ b/macros/QA/tracking/QA_Draw_Tpc.C
@@ -73,7 +73,7 @@ namespace
     auto hnew0 = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_0", prefix.Data(), tag.Data()), "TH1" ) );
     auto hnew1 = static_cast<TH1*>( qa_file_new->GetObjectChecked( Form( "%s%s_1", prefix.Data(), tag.Data()), "TH1" ) );
     
-    hnew1->Divide(hnew0);
+    hnew1->Divide(hnew1, hnew0, 1, 1, "B");
     hnew1->SetMinimum(0);
     
     // reference
@@ -81,14 +81,13 @@ namespace
     auto href1 = qa_file_ref ? static_cast<TH1*>( qa_file_ref->GetObjectChecked( Form( "%s%s_1", prefix.Data(), tag.Data()), "TH1" ) ) : nullptr;
     if( href0 )
       {
-	href1->Divide(href0);
-        href1->SetMinimum(0);
+	href1->Divide(href1, href0, 1, 1, "B");
+	href1->SetMinimum(0);
       }
     
     // draw
     DrawReference(hnew1, href1);
-    //DrawReference(hnew1, hnew0);
-    
+        
     auto line = HorizontalLine( gPad, 1 );
     line->Draw();
     

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -4,6 +4,7 @@
 #include <qa_modules/QAHistManagerDef.h>
 #include <qa_modules/QAG4SimulationIntt.h>
 #include <qa_modules/QAG4SimulationMvtx.h>
+#include <qa_modules/QAG4SimulationTpc.h>
 #include <phool/PHRandomSeed.h>
 #include <fun4all/SubsysReco.h>
 #include <fun4all/Fun4AllServer.h>
@@ -649,6 +650,7 @@ int Fun4All_G4_sPHENIX(
 
       se->registerSubsystem( new QAG4SimulationIntt );
       se->registerSubsystem( new QAG4SimulationMvtx );
+      se->registerSubsystem( new QAG4SimulationTpc );
     }
   }
 


### PR DESCRIPTION
Step 2/2: Resubmitting #268 to merge into tracking-high-occupancy-qa branch.

The result is already available from an earlier test in #269 : 
https://web.racf.bnl.gov/jenkins-sphenix/job/sPHENIX/job/test-tracking-high-occupancy-qa/296/QA_20Report/TPC/

The drop of cluster efficiency in the high occupancy events are significant: 
![image](https://user-images.githubusercontent.com/7947083/87973141-10900300-ca96-11ea-975f-95ff4f84d378.png)
