### PR TITLE
 Beta version of MVTX service barrel

### DIFF
--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -28,7 +28,7 @@ namespace Enable
   bool MVTX_CLUSTER = false;
   bool MVTX_ABSORBER = false;
   bool MVTX_SERVICE = true;
-  int MVTX_VERBOSITY = 1;
+  int MVTX_VERBOSITY = 0;
 
 }  // namespace Enable
 
@@ -154,7 +154,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 
   if (verbosity > 0)
   {
-    cout << "=========================== G4_MVTXService.C::MVTXService() =============================" << endl;
+    cout << "=========================== MVTX Service Barrel =============================" << endl;
     cout << " MVTX Service Material Description:" << endl;
 
     cout << "  Single stave copper area  = " << G4MVTX::single_stave_service_copper_area << " cm^2" << endl;
@@ -170,7 +170,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     cout << "  Service barrel radius = " << G4MVTX::service_barrel_radius << " cm" << endl;
     cout << "  Service barrel start = " << G4MVTX::service_barrel_start << " cm" << endl;
     cout << "  Service barrel length = " << G4MVTX::service_barrel_length << " cm" << endl;
-    cout << "=========================================================================================" << endl;
+    cout << "===============================================================================" << endl;
   }
 
   radius += no_overlapp;

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -20,8 +20,6 @@
 R__LOAD_LIBRARY(libg4mvtx.so)
 R__LOAD_LIBRARY(libmvtx.so)
 
-const double pi = 3.14159265358979323846;
-
 namespace Enable
 {
   bool MVTX = false;
@@ -30,7 +28,7 @@ namespace Enable
   bool MVTX_CLUSTER = false;
   bool MVTX_ABSORBER = false;
   bool MVTX_SERVICE = true;
-  int MVTX_VERBOSITY = 0;
+  int MVTX_VERBOSITY = 1;
 
 }  // namespace Enable
 
@@ -63,12 +61,12 @@ void MvtxInit()
 
 double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
 {
-	return pi*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
+	return M_PI*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
 }
 
 double calculateOR( double inner_radius, double area ) //Calculate the outer radius of a disk, knowing the inner radius and the area
 {
-	return std::sqrt( area/pi + std::pow( inner_radius, 2 ) );
+	return std::sqrt( area/M_PI + std::pow( inner_radius, 2 ) );
 }
 
 void calculateMaterialBoundaries(int& service_layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius) //Calculate where the transition between each material occurs

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -20,12 +20,15 @@
 R__LOAD_LIBRARY(libg4mvtx.so)
 R__LOAD_LIBRARY(libmvtx.so)
 
+const double pi = 3.14159265358979323846;
+
 namespace Enable
 {
   bool MVTX = false;
   bool MVTX_OVERLAPCHECK = false;
   bool MVTX_CELL = false;
   bool MVTX_CLUSTER = false;
+  bool MVTX_SERVICE = true;
   int MVTX_VERBOSITY = 0;
 
 }  // namespace Enable
@@ -34,12 +37,26 @@ namespace G4MVTX
 {
   int n_maps_layer = 3;        // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
   double radius_offset = 0.7;  // clearance around radius
+
+  double single_stave_service_copper_area  = 0.0677; //Cross-sectional area of copper for 1 stave [cm^2]
+  double single_stave_service_water_area   = 0.0098; //Cross-sectional area of water for 1 stave [cm^2]
+  double single_stave_service_plastic_area = 0.4303; //Cross-sectional area of plastic for 1 stave [cm^2]
+
+  const int n_service_layers = 1; //Number of service cable service_layers to generate
+  double service_layer_start_radius[] = {8.5}; //Inner radius of where the cables begin [cm]
+     int n_staves_service_layer[] = {48}; //Number of staves associated to each service layer
+
+  double service_barrel_radius = 10.75; // [cm] From final design review
+  double service_barrel_start  = 10; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
+  double service_barrel_length = 150; // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTX
 
 void MvtxInit()
 {
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, (PHG4MvtxDefs::mvtxdat[G4MVTX::n_maps_layer - 1][PHG4MvtxDefs::kRmd]) / 10. + G4MVTX::radius_offset);
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 16.);
+  //BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, (PHG4MvtxDefs::mvtxdat[G4MVTX::n_maps_layer - 1][PHG4MvtxDefs::kRmd]) / 10. + G4MVTX::radius_offset);
+  //BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 16.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MVTX::service_barrel_radius);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start));
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -17.);
 }
 
@@ -66,6 +83,7 @@ double Mvtx(PHG4Reco* g4Reco, double radius,
   mvtx->OverlapCheck(maps_overlapcheck);
   g4Reco->registerSubsystem(mvtx);
   radius += G4MVTX::radius_offset;
+  if (MVTX_SERVICE) radius += MVTXService(g4Reco, radius);
   return radius;
 }
 
@@ -101,4 +119,120 @@ void Mvtx_Clustering()
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
 }
+
+double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
+{
+	return pi*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
+}
+
+double calculateOR( double inner_radius, double area ) //Calculate the outer radius of a disk, knowing the inner radius and the area
+{
+	return std::sqrt( area/pi + std::pow( inner_radius, 2 ) );
+}
+
+void calculateMaterialBoundaries(int& service_layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius) //Calculate where the transition between each material occurs
+{
+   outer_copper_radius  = calculateOR( G4MVTX::service_layer_start_radius[service_layer_ID], G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_copper_area );
+   outer_water_radius   = calculateOR( outer_copper_radius, G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_water_area );
+   outer_plastic_radius = calculateOR( outer_water_radius, G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_plastic_area );
+}
+
+double MVTXService(PHG4Reco* g4Reco, double radius)
+{
+// Note, cables are all south  
+// Setup service_layers
+  double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers]; //Objects for material outer radii
+  int subsystem_service_layer = 0
+  std::string copper_name, water_name, plastic_name;
+  PHG4CylinderSubsystem* cyl;
+
+  for (int i = 0; i < G4MVTX::n_service_layers; ++i) //Build a service_layer of copper, then water, then plastic
+  {
+    calculateMaterialBoundaries(i, copper_OR[i], water_OR[i], plastic_OR[i]);
+
+    copper_name  = "MVTX_Service_copper_service_layer_"  + std::to_string(i);
+    water_name   = "MVTX_Service_water_service_layer_"   + std::to_string(i);
+    plastic_name = "MVTX_Service_plastic_service_layer_" + std::to_string(i);
+
+    cyl = new PHG4CylinderSubsystem(copper_name, subsystem_service_layer);
+    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", G4MVTX::service_layer_start_radius[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTX::service_barrel_length);
+    cyl->set_string_param("material", "G4_Cu");
+    cyl->set_double_param("thickness", copper_OR[i] - G4MVTX::service_layer_start_radius[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+    subsystem_service_layer += 1;
+
+    cyl = new PHG4CylinderSubsystem(water_name, subsystem_service_layer);
+    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", copper_OR[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTX::service_barrel_length);
+    cyl->set_string_param("material", "G4_WATER");
+    cyl->set_double_param("thickness", water_OR[i] - copper_OR[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+    subsystem_service_layer += 1;
+
+    cyl = new PHG4CylinderSubsystem(plastic_name, subsystem_service_layer);
+    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", water_OR[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTX::service_barrel_length);
+    cyl->set_string_param("material", "G4_POLYETHYLENE");
+    cyl->set_double_param("thickness", plastic_OR[i] - water_OR[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+    subsystem_service_layer += 1;
+
+  }
+
+  cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_service_layer", subsystem_service_layer);
+  cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+  cyl->set_double_param("radius", service_barrel_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", G4MVTX::service_barrel_length);
+  cyl->set_string_param("material", "PEEK"); //Service barrel is carbon fibre (peek?)
+  cyl->set_double_param("thickness", 0.1); //Service barrel is 1mm thick
+  cyl->SuperDetector("MVTXSERVICE");
+  if (AbsorberActive) cyl->SetActive();
+  cyl->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(cyl);
+
+  radius = G4MVTX::service_barrel_radius;
+
+  if (verbosity > 0)
+  {
+    cout << "=========================== G4_MVTXService.C::MVTXService() =============================" << endl;
+    cout << " MVTX Service Material Description:" << endl;
+
+    cout << "  Single stave copper area  = " << G4MVTX::single_stave_service_copper_area << " cm^2" << endl;
+    cout << "  Single stave water area   = " << G4MVTX::single_stave_service_water_area << " cm^2" << endl;
+    cout << "  Single stave plastic area = " << G4MVTX::single_stave_service_plastic_area << " cm^2" << endl;
+
+    for (int j = 0; j < G4MVTX::n_service_layers; ++j)
+    {
+        cout << "  service_layer " << j << " starts at " << G4MVTX::service_layer_start_radius[j] << " cm" << endl;
+        cout << "  service_layer " << j << " services " << G4MVTX::n_staves_service_layer[j] << " staves" << endl;
+    }
+
+    cout << "  Service barrel radius = " << G4MVTX::service_barrel_radius << " cm" << endl;
+    cout << "  Service barrel start = " << G4MVTX::service_barrel_start << " cm" << endl;
+    cout << "  Service barrel length = " << G4MVTX::service_barrel_length << " cm" << endl;
+    cout << "=========================================================================================" << endl;
+  }
+
+  radius += no_overlapp;
+
+  return radius;
+}
+
 #endif

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -47,7 +47,7 @@ namespace G4MVTX
      int n_staves_service_layer[] = {48}; //Number of staves associated to each service layer
 
   double service_barrel_radius = 10.75; // [cm] From final design review
-  double service_barrel_start  = 10; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
+  double service_barrel_start  = -35; //[cm] Approx.
   double service_barrel_length = 150; // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTX
 
@@ -142,7 +142,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 // Note, cables are all south  
 // Setup service_layers
   double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers]; //Objects for material outer radii
-  int subsystem_service_layer = 0
+  int subsystem_service_layer = 0;
   std::string copper_name, water_name, plastic_name;
   PHG4CylinderSubsystem* cyl;
 
@@ -197,7 +197,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 
   cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_service_layer", subsystem_service_layer);
   cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
-  cyl->set_double_param("radius", service_barrel_radius);
+  cyl->set_double_param("radius", G4MVTX::service_barrel_radius);
   cyl->set_int_param("lengthviarapidity", 0);
   cyl->set_double_param("length", G4MVTX::service_barrel_length);
   cyl->set_string_param("material", "PEEK"); //Service barrel is carbon fibre (peek?)

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -28,6 +28,7 @@ namespace Enable
   bool MVTX_OVERLAPCHECK = false;
   bool MVTX_CELL = false;
   bool MVTX_CLUSTER = false;
+  bool MVTX_ABSORBER = false;
   bool MVTX_SERVICE = true;
   int MVTX_VERBOSITY = 0;
 
@@ -60,66 +61,6 @@ void MvtxInit()
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -17.);
 }
 
-double Mvtx(PHG4Reco* g4Reco, double radius,
-            const int absorberactive = 0)
-{
-  bool maps_overlapcheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
-  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
-
-  PHG4MvtxSubsystem* mvtx = new PHG4MvtxSubsystem("MVTX");
-  mvtx->Verbosity(verbosity);
-
-  for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
-  {
-    double radius_lyr = PHG4MvtxDefs::mvtxdat[ilayer][PHG4MvtxDefs::kRmd];
-    if (verbosity)
-    {
-      cout << "Create Maps layer " << ilayer << " with radius " << radius_lyr << " mm." << endl;
-    }
-    radius = radius_lyr / 10.;
-  }
-  mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
-  mvtx->SetActive();
-  mvtx->OverlapCheck(maps_overlapcheck);
-  g4Reco->registerSubsystem(mvtx);
-  radius += G4MVTX::radius_offset;
-  if (MVTX_SERVICE) radius += MVTXService(g4Reco, radius);
-  return radius;
-}
-
-// Central detector cell reco is disabled as EIC setup use the fast tracking sim for now
-void Mvtx_Cells()
-{
-  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
-  Fun4AllServer* se = Fun4AllServer::instance();
-  // new storage containers
-  PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
-  maps_hits->Verbosity(verbosity);
-  for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
-  {
-    // override the default timing window for this layer - default is +/- 5000 ns
-    maps_hits->set_timing_window(ilayer, -5000, 5000);
-  }
-  se->registerSubsystem(maps_hits);
-  return;
-}
-
-void Mvtx_Clustering()
-{
-  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
-  Fun4AllServer* se = Fun4AllServer::instance();
-  PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();
-  digimvtx->Verbosity(verbosity);
-  // energy deposit in 25 microns = 9.6 KeV = 1000 electrons collected after recombination
-  //digimvtx->set_adc_scale(0.95e-6);  // default set in code is 0.95e-06, which is 99 electrons
-  se->registerSubsystem(digimvtx);
-  // For the Mvtx layers
-  //================
-  MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
-  mvtxclusterizer->Verbosity(verbosity);
-  se->registerSubsystem(mvtxclusterizer);
-}
-
 double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
 {
 	return pi*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
@@ -141,6 +82,10 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 {
 // Note, cables are all south  
 // Setup service_layers
+  bool AbsorberActive = Enable::ABSORBER || Enable::MVTX_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+
   double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers]; //Objects for material outer radii
   int subsystem_service_layer = 0;
   std::string copper_name, water_name, plastic_name;
@@ -234,5 +179,66 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 
   return radius;
 }
+
+double Mvtx(PHG4Reco* g4Reco, double radius,
+            const int absorberactive = 0)
+{
+  bool maps_overlapcheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+
+  PHG4MvtxSubsystem* mvtx = new PHG4MvtxSubsystem("MVTX");
+  mvtx->Verbosity(verbosity);
+
+  for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
+  {
+    double radius_lyr = PHG4MvtxDefs::mvtxdat[ilayer][PHG4MvtxDefs::kRmd];
+    if (verbosity)
+    {
+      cout << "Create Maps layer " << ilayer << " with radius " << radius_lyr << " mm." << endl;
+    }
+    radius = radius_lyr / 10.;
+  }
+  mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
+  mvtx->SetActive();
+  mvtx->OverlapCheck(maps_overlapcheck);
+  g4Reco->registerSubsystem(mvtx);
+  radius += G4MVTX::radius_offset;
+  if (Enable::MVTX_SERVICE) radius += MVTXService(g4Reco, radius);
+  return radius;
+}
+
+// Central detector cell reco is disabled as EIC setup use the fast tracking sim for now
+void Mvtx_Cells()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+  Fun4AllServer* se = Fun4AllServer::instance();
+  // new storage containers
+  PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
+  maps_hits->Verbosity(verbosity);
+  for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
+  {
+    // override the default timing window for this layer - default is +/- 5000 ns
+    maps_hits->set_timing_window(ilayer, -5000, 5000);
+  }
+  se->registerSubsystem(maps_hits);
+  return;
+}
+
+void Mvtx_Clustering()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+  Fun4AllServer* se = Fun4AllServer::instance();
+  PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();
+  digimvtx->Verbosity(verbosity);
+  // energy deposit in 25 microns = 9.6 KeV = 1000 electrons collected after recombination
+  //digimvtx->set_adc_scale(0.95e-6);  // default set in code is 0.95e-06, which is 99 electrons
+  se->registerSubsystem(digimvtx);
+  // For the Mvtx layers
+  //================
+  MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
+  mvtxclusterizer->Verbosity(verbosity);
+  se->registerSubsystem(mvtxclusterizer);
+}
+
 
 #endif

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -366,7 +366,7 @@ int Fun4All_G4_sPHENIX(
             do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservice, magfield_rescale);
 #else
     G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservic, emagfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservice, magfield_rescale);
 #endif
   }
 

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -96,6 +96,7 @@ int Fun4All_G4_sPHENIX(
   bool do_bbc = true;
 
   bool do_pipe = true;
+  bool do_mvtxservice = true;
 
   bool do_tracking = true;
   bool do_tracking_cell = do_tracking && true;
@@ -169,7 +170,7 @@ int Fun4All_G4_sPHENIX(
   gSystem->Load("libg4intt.so");
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, do_femc);
+  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, do_femc, do_mvtxservice);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
@@ -197,12 +198,12 @@ int Fun4All_G4_sPHENIX(
   // By default every random number generator uses
   // PHRandomSeed() which reads /dev/urandom to get its seed
   // if the RANDOMSEED flag is set its value is taken as seed
-  // You ca neither set this to a random value using PHRandomSeed()
+  // You can either set this to a random value using PHRandomSeed()
   // which will make all seeds identical (not sure what the point of
   // this would be:
   //  rc->set_IntFlag("RANDOMSEED",PHRandomSeed());
   // or set it to a fixed value so you can debug your code
-  //  rc->set_IntFlag("RANDOMSEED", 12345);
+  rc->set_IntFlag("RANDOMSEED", 12345);
 
   //-----------------
   // Event generation
@@ -362,10 +363,10 @@ int Fun4All_G4_sPHENIX(
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
     G4Setup(absorberactive, magfield, EDecayType::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservice, magfield_rescale);
 #else
     G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservic, emagfield_rescale);
 #endif
   }
 

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -203,7 +203,7 @@ int Fun4All_G4_sPHENIX(
   // this would be:
   //  rc->set_IntFlag("RANDOMSEED",PHRandomSeed());
   // or set it to a fixed value so you can debug your code
-  rc->set_IntFlag("RANDOMSEED", 12345);
+  //rc->set_IntFlag("RANDOMSEED", 12345);
 
   //-----------------
   // Event generation

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -9,6 +9,7 @@
 #include "G4_HcalOut_ref.C"
 #include "G4_PlugDoor.C"
 #include "G4_FEMC.C"
+#include "G4_MvtxService.C"
 
 #include <g4eval/PHG4DstCompressReco.h>
 #include <fun4all/Fun4AllServer.h>
@@ -40,7 +41,8 @@ void G4Init(const bool do_tracking = true,
 	    const bool do_hcalout = true,
 	    const bool do_pipe = true,
 	    const bool do_plugdoor = false,
-	    const bool do_FEMC = false
+	    const bool do_FEMC = false,
+            const bool do_mvtxservice = false
 	    )
   {
 
@@ -96,6 +98,11 @@ void G4Init(const bool do_tracking = true,
       gROOT->LoadMacro("G4_FEMC.C");
       FEMCInit();
     }
+  if (do_mvtxservice)
+    {
+      gROOT->LoadMacro("G4_MvtxService.C");
+      MVTXServiceInit();
+    }
 
 }
 
@@ -117,6 +124,7 @@ int G4Setup(const int absorberactive = 0,
       const bool do_plugdoor = false,
 //	    const bool do_plugdoor = true,
 	    const bool do_FEMC = false, 
+            const bool do_mvtxservice = false,
 	    const float magfield_rescale = 1.0) {
   
   //---------------
@@ -208,6 +216,9 @@ int G4Setup(const int absorberactive = 0,
   // forward EMC
   if(do_FEMC) FEMCSetup(g4Reco, absorberactive);
 
+  //MVTX service barrel
+  if(do_mvtxservice) radius = MVTXService(g4Reco, radius);
+
   //----------------------------------------
   // BLACKHOLE
   
@@ -297,6 +308,7 @@ void ShowerCompress(int verbosity = 0) {
   compress->AddTowerContainer("TOWER_SIM_FEMC");
   compress->AddTowerContainer("TOWER_RAW_FEMC");
   compress->AddTowerContainer("TOWER_CALIB_FEMC");
+  compress->AddHitContainer("G4HIT_MVTXSERVICE");
   se->registerSubsystem(compress);
   
   return; 
@@ -325,5 +337,6 @@ void DstCompress(Fun4AllDstOutputManager* out) {
     out->StripNode("G4HIT_FEMC");
     out->StripNode("G4HIT_ABSORBER_FEMC");
     out->StripNode("G4CELL_FEMC");
+    out->StripNode("G4HIT_MVTXSERVICE");
   }
 }

--- a/macros/g4simulations/G4_MvtxService.C
+++ b/macros/g4simulations/G4_MvtxService.C
@@ -1,0 +1,209 @@
+/******************************/
+/*     MVTX Service Barrel    */
+/*        Cameron Dean        */
+/*       cdean@lanl.gov       */
+/*        07/17/2020          */
+/******************************/
+
+#ifndef MACRO_G4MVTXSERVICE_C
+#define MACRO_G4MVTXSERVICE_C
+
+#include "GlobalVariables.C"
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+
+const double pi = 3.14159265358979323846;
+
+namespace Enable
+{
+  bool MVTXSERVICE = false;
+  bool MVTXSERVICE_ABSORBER = false;
+  bool MVTXSERVICE_OVERLAPCHECK = false;
+   int MVTXSERVICE_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace G4MVTXSERVICE
+{
+  /*
+   * These are the parameters for all cables/wires/tubes for the MVTX service barrel
+   * Uncomment and use these when it is time to make a more detailed service barrel model
+   * DEFAULT G4 UNITS ARE CM, GEV AND NS 
+
+  double signal_wire_copper_area = 0.0102; //[mm^2] Cross sectional area of copper for one signal wire
+  double signal_wire_plastic_area = 0.0407; //[mm^2] Cross sectional area of plastic for one signal wire
+     int n_signal_wires_per_stave = 12; //Number of signal wires for each stave
+
+  double digital_power_OR = 1.175; //Digital power parameters, [OR/IR] is the [outer/inner] radius of the cable sheath
+  double digital_power_IR = 0.775;
+  double digital_power_copper_area =  calculateArea( 0, digital_power_IR );
+  double digital_power_plastic_area = calculateArea( digital_power_IR, digital_power_OR );
+     int n_digital_power = 2;
+
+  double analogue_power_OR = 0.775; //Analogue power parameters
+  double analogue_power_IR = 0.375;
+  double analogue_power_copper_area =  calculateArea( 0, analogue_power_IR );
+  double analogue_power_plastic_area = calculateArea( analogue_power_IR, analogue_power_OR );
+     int n_analogue_power = 2;
+
+  double ground_power_OR = 0.725; //Ground power parameters
+  double ground_power_IR = 0.325;
+  double ground_power_copper_area =  calculateArea( 0, ground_power_IR );
+  double ground_power_plastic_area = calculateArea( ground_power_IR, ground_power_OR );
+     int n_ground_power = 6;
+
+  double power_cable_sheath_OR = 4.3; //The power cables are enclosed within their own plastic sheath
+  double power_cable_sheath_IR = 3.3;
+  double power_cable_sheath_area = calculateArea( power_cable_sheath_IR, power_cable_sheath_OR );
+
+  double power_cable_copper_area = n_digital_power*digital_power_copper_area
+                                 + n_analogue_power*analogue_power_copper_area
+                                 + n_ground_power*ground_power_copper_area; //[mm^2] Cross sectional area of copper for one power cable
+  double power_cable_plastic_area = power_cable_sheath_area
+                                  + n_digital_power*digital_power_plastic_area
+                                  + n_analogue_power*analogue_power_plastic_area
+                                  + n_ground_power*ground_power_plastic_area;  //[mm^2] Cross sectional area of plastic for one power cable
+  double power_cable_air_area = 27.2; //[mm^2] Free space in each power cable
+     int n_power_cabless_per_stave = 1; //Number of power cables for each stave
+
+  double cooling_tube_OR = 0.794; //Outer radius of cooling tube
+  double cooling_tube_IR = 0.397; //Inner radius of cooling tube
+  double cooling_tube_water_area = calculateArea( 0, cooling_tube_IR); //[mm^2] Cross sectional area of water for one cooling tube
+  double cooling_tube_plastic_area = calculateArea( cooling_tube_IR, cooling_tube_OR); //[mm^2] Cross sectional area of plastic for one cooling tube
+     int n_cooling_tubes_per_stave = 2; //Number of cooling tubes for each stave
+
+  */
+  double single_stave_copper_area  = 0.0677; //Cross-sectional area of copper for 1 stave [cm^2]
+  double single_stave_water_area   = 0.0098; //Cross-sectional area of water for 1 stave [cm^2]
+  double single_stave_plastic_area = 0.4303; //Cross-sectional area of plastic for 1 stave [cm^2]
+
+  const int n_layers = 1; //Number of service cable layers to generate
+  double layer_start_radius[] = {8.5}; //Inner radius of where the cables begin [cm]
+     int n_staves_layer[] = {48}; //Number of staves associated to each layer
+
+  double service_barrel_radius = 10.75; // [cm] From final design review
+  double service_barrel_start  = 25; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
+  double service_barrel_length = 120; // [cm] length of service barrel ~(to patch panel)
+}  // namespace G4MVTXSERVICE
+
+
+double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
+{
+	return pi*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
+}
+
+double calculateOR( double inner_radius, double area ) //Calculate the outer radius of a disk, knowing the inner radius and the area
+{
+	return std::sqrt( area/pi + std::pow( inner_radius, 2 ) );
+}
+
+void calculateMaterialBoundaries(int& layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius) //Calculate where the transition between each material occurs
+{
+   outer_copper_radius  = calculateOR( G4MVTXSERVICE::layer_start_radius[layer_ID], G4MVTXSERVICE::n_staves_layer[layer_ID]*G4MVTXSERVICE::single_stave_copper_area );
+   outer_water_radius   = calculateOR( outer_copper_radius, G4MVTXSERVICE::n_staves_layer[layer_ID]*G4MVTXSERVICE::single_stave_water_area );
+   outer_plastic_radius = calculateOR( outer_water_radius, G4MVTXSERVICE::n_staves_layer[layer_ID]*G4MVTXSERVICE::single_stave_plastic_area );
+}
+
+void MVTXServiceInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MVTXSERVICE::service_barrel_radius);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start));
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, -G4MVTXSERVICE::service_barrel_start);
+}
+
+double MVTXService(PHG4Reco* g4Reco, double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::MVTXSERVICE_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::MVTXSERVICE_OVERLAPCHECK;
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTXSERVICE_VERBOSITY);
+/*
+  if (radius > G4MVTXSERVICE::service_barrel_radius)
+  {
+    std::cout << "inconsistency: radius: " << radius
+              << " larger than service barrel radius: " << G4MVTXSERVICE::service_barrel_radius << std::endl;
+    gSystem->Exit(-1);
+  }
+*/
+  // Note, cables are all south
+  //Setup layers
+  double copper_OR[G4MVTXSERVICE::n_layers], water_OR[G4MVTXSERVICE::n_layers], plastic_OR[G4MVTXSERVICE::n_layers]; //Objects for material outer radii
+  std::string copper_name, water_name, plastic_name;
+  PHG4CylinderSubsystem* cyl;
+
+  for (int i = 0; i < G4MVTXSERVICE::n_layers; ++i) //Build a layer of copper, then water, then plastic
+  {
+    calculateMaterialBoundaries(i, copper_OR[i], water_OR[i], plastic_OR[i]);
+
+    copper_name  = "MVTX_Service_copper_layer_"  + std::to_string(i);
+    water_name   = "MVTX_Service_water_layer_"   + std::to_string(i);
+    plastic_name = "MVTX_Service_plastic_layer_" + std::to_string(i);
+
+    cyl = new PHG4CylinderSubsystem(copper_name, G4MVTXSERVICE::n_layers*i);
+    cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", G4MVTXSERVICE::layer_start_radius[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTXSERVICE::service_barrel_length);
+    cyl->set_string_param("material", "G4_Cu");
+    cyl->set_double_param("thickness", copper_OR[i] - G4MVTXSERVICE::layer_start_radius[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+
+    cyl = new PHG4CylinderSubsystem(water_name, G4MVTXSERVICE::n_layers*i + 1);
+    cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", copper_OR[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTXSERVICE::service_barrel_length);
+    cyl->set_string_param("material", "G4_WATER");
+    cyl->set_double_param("thickness", water_OR[i] - copper_OR[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+
+    cyl = new PHG4CylinderSubsystem(plastic_name, G4MVTXSERVICE::n_layers*i + 2);
+    cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("radius", water_OR[i]);
+    cyl->set_int_param("lengthviarapidity", 0);
+    cyl->set_double_param("length", G4MVTXSERVICE::service_barrel_length);
+    cyl->set_string_param("material", "G4_POLYETHYLENE");
+    cyl->set_double_param("thickness", plastic_OR[i] - water_OR[i]);
+    cyl->SuperDetector("MVTXSERVICE");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+
+  }
+
+  radius = G4MVTXSERVICE::service_barrel_radius;
+
+  if (verbosity > 0)
+  {
+    cout << "=========================== G4_MVTXService.C::MVTXService() =============================" << endl;
+    cout << " MVTX Service Material Description:" << endl;
+
+    cout << "  Single stave copper area  = " << G4MVTXSERVICE::single_stave_copper_area << " cm^2" << endl;
+    cout << "  Single stave water area   = " << G4MVTXSERVICE::single_stave_water_area << " cm^2" << endl;
+    cout << "  Single stave plastic area = " << G4MVTXSERVICE::single_stave_plastic_area << " cm^2" << endl;
+
+    for (int j = 0; j < G4MVTXSERVICE::n_layers; ++j)
+    {
+        cout << "  Layer " << j << " starts at " << G4MVTXSERVICE::layer_start_radius[j] << " cm" << endl;
+        cout << "  Layer " << j << " services " << G4MVTXSERVICE::n_staves_layer[j] << " staves" << endl;
+    }
+
+    cout << "  Service barrel radius = " << G4MVTXSERVICE::service_barrel_radius << " cm" << endl;
+    cout << "  Service barrel start = " << G4MVTXSERVICE::service_barrel_start << " cm" << endl;
+    cout << "  Service barrel length = " << G4MVTXSERVICE::service_barrel_length << " cm" << endl;
+    cout << "=========================================================================================" << endl;
+  }
+
+  radius += no_overlapp;
+
+  return radius;
+}
+#endif

--- a/macros/g4simulations/G4_MvtxService.C
+++ b/macros/g4simulations/G4_MvtxService.C
@@ -85,7 +85,7 @@ namespace G4MVTXSERVICE
      int n_staves_layer[] = {48}; //Number of staves associated to each layer
 
   double service_barrel_radius = 10.75; // [cm] From final design review
-  double service_barrel_start  = 10; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
+  double service_barrel_start  = -35; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
   double service_barrel_length = 150; // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTXSERVICE
 
@@ -130,7 +130,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
   // Note, cables are all south
   //Setup layers
   double copper_OR[G4MVTXSERVICE::n_layers], water_OR[G4MVTXSERVICE::n_layers], plastic_OR[G4MVTXSERVICE::n_layers]; //Objects for material outer radii
-  int subsystem_layer = 0
+  int subsystem_layer = 0;
   std::string copper_name, water_name, plastic_name;
   PHG4CylinderSubsystem* cyl;
 
@@ -185,7 +185,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 
   cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_layer", subsystem_layer);
   cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
-  cyl->set_double_param("radius", service_barrel_radius);
+  cyl->set_double_param("radius", G4MVTXSERVICE::service_barrel_radius);
   cyl->set_int_param("lengthviarapidity", 0);
   cyl->set_double_param("length", G4MVTXSERVICE::service_barrel_length);
   cyl->set_string_param("material", "PEEK"); //Service barrel is carbon fibre (peek?)

--- a/macros/g4simulations/G4_MvtxService.C
+++ b/macros/g4simulations/G4_MvtxService.C
@@ -85,8 +85,8 @@ namespace G4MVTXSERVICE
      int n_staves_layer[] = {48}; //Number of staves associated to each layer
 
   double service_barrel_radius = 10.75; // [cm] From final design review
-  double service_barrel_start  = 25; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
-  double service_barrel_length = 120; // [cm] length of service barrel ~(to patch panel)
+  double service_barrel_start  = 10; //[cm] Approx (Straight barrel length (419mm) - 0.5*stave active length (270mm/2))
+  double service_barrel_length = 150; // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTXSERVICE
 
 
@@ -130,6 +130,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
   // Note, cables are all south
   //Setup layers
   double copper_OR[G4MVTXSERVICE::n_layers], water_OR[G4MVTXSERVICE::n_layers], plastic_OR[G4MVTXSERVICE::n_layers]; //Objects for material outer radii
+  int subsystem_layer = 0
   std::string copper_name, water_name, plastic_name;
   PHG4CylinderSubsystem* cyl;
 
@@ -141,7 +142,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     water_name   = "MVTX_Service_water_layer_"   + std::to_string(i);
     plastic_name = "MVTX_Service_plastic_layer_" + std::to_string(i);
 
-    cyl = new PHG4CylinderSubsystem(copper_name, G4MVTXSERVICE::n_layers*i);
+    cyl = new PHG4CylinderSubsystem(copper_name, subsystem_layer);
     cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", G4MVTXSERVICE::layer_start_radius[i]);
     cyl->set_int_param("lengthviarapidity", 0);
@@ -152,8 +153,9 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     if (AbsorberActive) cyl->SetActive();
     cyl->OverlapCheck(OverlapCheck);
     g4Reco->registerSubsystem(cyl);
+    subsystem_layer += 1;
 
-    cyl = new PHG4CylinderSubsystem(water_name, G4MVTXSERVICE::n_layers*i + 1);
+    cyl = new PHG4CylinderSubsystem(water_name, subsystem_layer);
     cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", copper_OR[i]);
     cyl->set_int_param("lengthviarapidity", 0);
@@ -164,8 +166,9 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     if (AbsorberActive) cyl->SetActive();
     cyl->OverlapCheck(OverlapCheck);
     g4Reco->registerSubsystem(cyl);
+    subsystem_layer += 1;
 
-    cyl = new PHG4CylinderSubsystem(plastic_name, G4MVTXSERVICE::n_layers*i + 2);
+    cyl = new PHG4CylinderSubsystem(plastic_name, subsystem_layer);
     cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", water_OR[i]);
     cyl->set_int_param("lengthviarapidity", 0);
@@ -176,8 +179,21 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     if (AbsorberActive) cyl->SetActive();
     cyl->OverlapCheck(OverlapCheck);
     g4Reco->registerSubsystem(cyl);
+    subsystem_layer += 1;
 
   }
+
+  cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_layer", subsystem_layer);
+  cyl->set_double_param("place_z", -1*(G4MVTXSERVICE::service_barrel_length + G4MVTXSERVICE::service_barrel_start) - no_overlapp);
+  cyl->set_double_param("radius", service_barrel_radius);
+  cyl->set_int_param("lengthviarapidity", 0);
+  cyl->set_double_param("length", G4MVTXSERVICE::service_barrel_length);
+  cyl->set_string_param("material", "PEEK"); //Service barrel is carbon fibre (peek?)
+  cyl->set_double_param("thickness", 0.1); //Service barrel is 1mm thick
+  cyl->SuperDetector("MVTXSERVICE");
+  if (AbsorberActive) cyl->SetActive();
+  cyl->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(cyl);
 
   radius = G4MVTXSERVICE::service_barrel_radius;
 

--- a/macros/g4simulations/G4_MvtxService.C
+++ b/macros/g4simulations/G4_MvtxService.C
@@ -14,9 +14,9 @@
 
 #include <g4main/PHG4Reco.h>
 
-R__LOAD_LIBRARY(libg4detectors.so)
+#include <cmath>
 
-const double pi = 3.14159265358979323846;
+R__LOAD_LIBRARY(libg4detectors.so)
 
 namespace Enable
 {
@@ -92,12 +92,12 @@ namespace G4MVTXSERVICE
 
 double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
 {
-	return pi*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
+	return M_PI*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
 }
 
 double calculateOR( double inner_radius, double area ) //Calculate the outer radius of a disk, knowing the inner radius and the area
 {
-	return std::sqrt( area/pi + std::pow( inner_radius, 2 ) );
+	return std::sqrt( area/M_PI + std::pow( inner_radius, 2 ) );
 }
 
 void calculateMaterialBoundaries(int& layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius) //Calculate where the transition between each material occurs


### PR DESCRIPTION
 Beta version of MVTX service barrel

This version contains three concentric cylinders of copper, water and finally polyethylene. The layers begin at r = 8.5cm and z = -25cm (the z-gap will likely be filled by the FPC extensions). Each layer is a solid ring, accounting for the total material contribution from 48 staves.

The number of service layers can be easily configured by setting the number of layers, layer start position and number of staves supplied by that layer. The calculations and placements are then done by the rest of the macro

Additionally, this macro contains code with parameters for all the individual cables and tubing but is currently commented out. For example, this means there is code for the number of ground wires with the inner and outer radii of the wire that each stave requires. A function can be written at a later date to correctly produce each service bundle when this is defined, if required.