### PR TITLE
Generators config

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -69,17 +69,17 @@ namespace INPUTEMBED
 
 namespace PYTHIA6
 {
-  string config_file = "phpythia6.cfg";
+  string config_file = string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6.cfg";
 }
 
 namespace PYTHIA8
 {
-  string config_file = "phpythia8.cfg";
+  string config_file = string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia8.cfg";
 }
 
 namespace SARTRE
 {
-  string config_file = "sartre.cfg";
+  string config_file = string(getenv("CALIBRATIONROOT")) + "/Generators/sartre.cfg";
 }
 
 namespace PILEUP

--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -103,7 +103,7 @@ double Pipe(PHG4Reco* g4Reco,
   if (do_pipe_electron_forward_extension)
   {
     PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
-    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.gdml");
     gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
     gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
     gdml->OverlapCheck(OverlapCheck);
@@ -113,7 +113,7 @@ double Pipe(PHG4Reco* g4Reco,
   if (do_pipe_hadron_forward_extension)
   {
     PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
-    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector chamber 3-20-20.G4Import.gdml");
+    gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.gdml");
     gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
     gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
     gdml->OverlapCheck(OverlapCheck);

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -146,7 +146,7 @@ int Fun4All_G4_EICDetector(
   // pythia6
   if (Input::PYTHIA6)
   {
-    INPUTGENERATOR::Pythia6->set_config_file("phpythia6_ep.cfg");
+    INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
   }
 
   //--------------


### PR DESCRIPTION
This PR reads the generator config files (phpythia6.cfg, phpythia6_ep.cfg, phpythia8.cfg and sartre.cfg) from CALIBRATIONSROOT so we do not need local copies anymore. The location can be changed in the Fun4All_G4 macro to read private configs.
The original gdml file for the eic beampipe had spaces in the filename. While legal this is asking for problems. The file was changed a while ago using underscores instead of spaces (the original file is now a softlink to this one). This PR now changes the filename in the macro accordingly