### PR TITLE
Add gap for black hole to determine worl size

### DIFF
--- a/common/G4_World.C
+++ b/common/G4_World.C
@@ -22,11 +22,11 @@ void WorldInit(PHG4Reco *g4Reco)
 
 void WorldSize(PHG4Reco *g4Reco, double radius)
 {
-  double world_radius = std::max(radius, BlackHoleGeometry::max_radius);
+  double world_radius = std::max((BlackHoleGeometry::max_radius+BlackHoleGeometry::gap), radius);
   g4Reco->SetWorldSizeY(std::max(g4Reco->GetWorldSizeY(), world_radius + G4WORLD::AddSpace));
   // our world is a symmetric cylinder so the center is at 0/0/0, pick the largest of abs(min_z) || abs(max_z)
-  double min_zval = std::min(BlackHoleGeometry::min_z, -((g4Reco->GetWorldSizeZ() - 100) / 2.));
-  double max_zval = std::max(BlackHoleGeometry::max_z, (g4Reco->GetWorldSizeZ() - 100) / 2.);
+  double min_zval = std::min((BlackHoleGeometry::min_z-BlackHoleGeometry::gap), -((g4Reco->GetWorldSizeZ() - 100) / 2.));
+  double max_zval = std::max((BlackHoleGeometry::max_z+BlackHoleGeometry::gap), (g4Reco->GetWorldSizeZ() - 100) / 2.);
   double final_zval = std::max(fabs(min_zval), fabs(max_zval) + G4WORLD::AddSpace);
   g4Reco->SetWorldSizeZ(std::max(g4Reco->GetWorldSizeZ(), 2 * (final_zval)));
   return;


### PR DESCRIPTION
This PR adds a small modification to the world size readjusting. It now takes the gap between the detector and the black hole into account which is user adjustable. It needs to be added to the calculated black hole dimensions which are given by the detector size