### PR TITLE
added missing header.

### DIFF
--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -3,6 +3,7 @@
 
 #include "GlobalVariables.C"
 
+#include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4mvtx/PHG4MvtxDefs.h>
 #include <g4mvtx/PHG4MvtxDigitizer.h>
 #include <g4mvtx/PHG4MvtxHitReco.h>


### PR DESCRIPTION
PHG4CylinderSubsystem is used explicitly later in the macro, so header should be there. 
Not having it prevents to load the macro "standalone" or for instance to load G4_Tracking.C without loading first G4Setup_sPHENIX.C (which is otherwise unnecessary when running standalone reconstruction, or evaluation macro).