### PR TITLE
Variable CEMC parameters from calibrations file

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -368,11 +368,15 @@ void CEMC_Towers()
   TowerDigitizer->Detector("CEMC");
   TowerDigitizer->Verbosity(verbosity);
   TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
-  TowerDigitizer->set_pedstal_central_ADC(0);
-  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  TowerDigitizer->set_variable_pedestal(true); //read ped central and width from calibrations file comment next 2 lines if true
+//  TowerDigitizer->set_pedstal_central_ADC(0);
+//  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
   TowerDigitizer->set_photonelec_ADC(1);     //not simulating ADC discretization error
   TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
-  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  TowerDigitizer->set_variable_zero_suppression(true); //read zs values from calibrations file comment next line if true
+//  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  TowerDigitizer->GetParameters().ReadFromFile("CEMC", "xml", 0, 0,
+                                               string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
   se->registerSubsystem(TowerDigitizer);
 
   if (G4CEMC::Cemc_spacal_configuration == PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal)
@@ -392,9 +396,11 @@ void CEMC_Towers()
     TowerCalibration->Verbosity(verbosity);
     TowerCalibration->set_calib_algorithm(RawTowerCalibration::kTower_by_tower_calibration);
     TowerCalibration->GetCalibrationParameters().ReadFromFile("CEMC", "xml", 0, 0,
-                                                              string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalib_2017ProjTilted/"));  // calibration database
-    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
-    TowerCalibration->set_pedstal_ADC(0);
+                                                              string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
+    TowerCalibration->set_variable_GeV_ADC(true); //read GeV per ADC from calibrations file comment next line if true
+//    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
+    TowerCalibration->set_variable_pedestal(true); //read pedestals from calibrations file comment next line if true
+//    TowerCalibration->set_pedstal_ADC(0);
     se->registerSubsystem(TowerCalibration);
   }
   else

--- a/macros/g4simulations/G4_CEmc_Spacal.C
+++ b/macros/g4simulations/G4_CEmc_Spacal.C
@@ -371,11 +371,15 @@ void CEMC_Towers()
   TowerDigitizer->Detector("CEMC");
   TowerDigitizer->Verbosity(verbosity);
   TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
-  TowerDigitizer->set_pedstal_central_ADC(0);
-  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  TowerDigitizer->set_variable_pedestal(true); //read ped central and width from calibrations file comment next 2 lines if true
+//  TowerDigitizer->set_pedstal_central_ADC(0);
+//  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
   TowerDigitizer->set_photonelec_ADC(1);     //not simulating ADC discretization error
   TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
-  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  TowerDigitizer->set_variable_zero_suppression(true); //read zs values from calibrations file comment next line if true
+//  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  TowerDigitizer->GetParameters().ReadFromFile("CEMC", "xml", 0, 0,
+                                               string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
   se->registerSubsystem(TowerDigitizer);
 
   if (G4CEMC::Cemc_spacal_configuration == PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal)
@@ -395,9 +399,11 @@ void CEMC_Towers()
     TowerCalibration->Verbosity(verbosity);
     TowerCalibration->set_calib_algorithm(RawTowerCalibration::kTower_by_tower_calibration);
     TowerCalibration->GetCalibrationParameters().ReadFromFile("CEMC", "xml", 0, 0,
-                                                              string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalib_2017ProjTilted/"));  // calibration database
-    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
-    TowerCalibration->set_pedstal_ADC(0);
+                                                              string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
+    TowerCalibration->set_variable_GeV_ADC(true); //read GeV per ADC from calibrations file comment next line if true
+//    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
+    TowerCalibration->set_variable_pedestal(true); //read pedestals from calibrations file comment next line if true
+//    TowerCalibration->set_pedstal_ADC(0);
     se->registerSubsystem(TowerCalibration);
   }
   else


### PR DESCRIPTION
Pull request for variable zero suppression, pedestal, and GeV per ADC in CEMC. This request implements the changes made in PR #889 in coresoftware and PR #64 in calibrations. Previous structure with statically defined pedestal, zero suppression threshold, and GeV per ADC remains but is commented out. This may be useful for quickly testing new parameters since it does not require generating a new calibrations xml.