### PR TITLE
add event-plane detector to simulations

### DIFF
--- a/common/G4_DSTReader.C
+++ b/common/G4_DSTReader.C
@@ -5,6 +5,7 @@
 
 #include "G4_BlackHole.C"
 #include "G4_CEmc_Spacal.C"
+#include "G4_EPD.C"
 #include "G4_HcalIn_ref.C"
 #include "G4_HcalOut_ref.C"
 #include "G4_Intt.C"
@@ -110,6 +111,11 @@ void G4DSTreader(const string &outputFile = "G4sPHENIXCells.root")
       {
         ana->AddNode("ABSORBER_HCALOUT");
       }
+    }
+
+    if (Enable::EPD)
+    {
+      ana->AddNode("EPD");
     }
 
     if (Enable::BLACKHOLE)

--- a/common/G4_EPD.C
+++ b/common/G4_EPD.C
@@ -1,0 +1,24 @@
+#ifndef COMMON_G4EPD_C
+#define COMMON_G4EPD_C
+
+#include <g4epd/PHG4EPDSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4epd.so)
+
+namespace Enable {
+  bool EPD = false;
+}
+
+void EPDInit() { }
+
+void EPD(PHG4Reco* g4Reco) {
+  PHG4EPDSubsystem* epd = new PHG4EPDSubsystem("EPD");
+
+  epd->SuperDetector("EPD");
+
+  g4Reco->registerSubsystem(epd);
+}
+
+#endif /* COMMON_G4EPD_C */

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -251,6 +251,8 @@ int Fun4All_G4_sPHENIX(
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
 
+  Enable::EPD = false;
+
   //! forward flux return plug door. Out of acceptance and off by default.
   //Enable::PLUGDOOR = true;
   Enable::PLUGDOOR_ABSORBER = true;

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -6,6 +6,7 @@
 #include "G4_BlackHole.C"
 #include "G4_CEmc_Spacal.C"
 #include "G4_CEmc_Albedo.C"
+#include "G4_EPD.C"
 #include "G4_FEMC.C"
 #include "G4_HcalIn_ref.C"
 #include "G4_HcalOut_ref.C"
@@ -91,6 +92,10 @@ void G4Init()
   if (Enable::FEMC)
   {
     FEMCInit();
+  }
+  if (Enable::EPD)
+  {
+    EPDInit();
   }
   if (Enable::USER)
   {
@@ -185,6 +190,8 @@ int G4Setup()
 
   // forward EMC
   if (Enable::FEMC) FEMCSetup(g4Reco);
+
+  if (Enable::EPD) EPD(g4Reco);
 
   if (Enable::USER)
   {

--- a/macros/g4simulations/Fun4All_G4_sPHENIX.C
+++ b/macros/g4simulations/Fun4All_G4_sPHENIX.C
@@ -133,6 +133,8 @@ int Fun4All_G4_sPHENIX(
   bool do_femc_cluster = do_femc_twr && true;
   bool do_femc_eval = do_femc_cluster && true;
 
+  bool do_epd = false;
+
   //! forward flux return plug door. Out of acceptance and off by default.
   bool do_plugdoor = false;
 
@@ -170,7 +172,7 @@ int Fun4All_G4_sPHENIX(
   gSystem->Load("libg4intt.so");
   // establish the geometry and reconstruction setup
   gROOT->LoadMacro("G4Setup_sPHENIX.C");
-  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, do_femc, do_mvtxservice);
+  G4Init(do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe, do_plugdoor, do_femc, do_epd, do_mvtxservice);
 
   int absorberactive = 1;  // set to 1 to make all absorbers active volumes
   //  const string magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
@@ -363,10 +365,10 @@ int Fun4All_G4_sPHENIX(
 
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
     G4Setup(absorberactive, magfield, EDecayType::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservice, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_epd, do_mvtxservice, magfield_rescale);
 #else
     G4Setup(absorberactive, magfield, TPythia6Decayer::kAll,
-            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_mvtxservice, magfield_rescale);
+            do_tracking, do_pstof, do_cemc, do_hcalin, do_magnet, do_hcalout, do_pipe,do_plugdoor, do_femc, do_epd, do_mvtxservice, magfield_rescale);
 #endif
   }
 
@@ -598,6 +600,7 @@ int Fun4All_G4_sPHENIX(
                 /*bool*/ do_hcalin,
                 /*bool*/ do_magnet,
                 /*bool*/ do_hcalout,
+                /*bool*/ do_epd,
                 /*bool*/ do_cemc_twr,
                 /*bool*/ do_hcalin_twr,
                 /*bool*/ do_hcalout_twr);

--- a/macros/g4simulations/G4Setup_sPHENIX.C
+++ b/macros/g4simulations/G4Setup_sPHENIX.C
@@ -9,6 +9,7 @@
 #include "G4_HcalOut_ref.C"
 #include "G4_PlugDoor.C"
 #include "G4_FEMC.C"
+#include "G4_EPD.C"
 #include "G4_MvtxService.C"
 
 #include <g4eval/PHG4DstCompressReco.h>
@@ -42,6 +43,7 @@ void G4Init(const bool do_tracking = true,
 	    const bool do_pipe = true,
 	    const bool do_plugdoor = false,
 	    const bool do_FEMC = false,
+	    const bool do_epd = false,
             const bool do_mvtxservice = false
 	    )
   {
@@ -98,6 +100,11 @@ void G4Init(const bool do_tracking = true,
       gROOT->LoadMacro("G4_FEMC.C");
       FEMCInit();
     }
+  if (do_epd)
+    {
+      gROOT->LoadMacro("G4_EPD.C");
+      EPDInit();
+    }
   if (do_mvtxservice)
     {
       gROOT->LoadMacro("G4_MvtxService.C");
@@ -124,6 +131,7 @@ int G4Setup(const int absorberactive = 0,
       const bool do_plugdoor = false,
 //	    const bool do_plugdoor = true,
 	    const bool do_FEMC = false, 
+	    const bool do_epd = true,
             const bool do_mvtxservice = false,
 	    const float magfield_rescale = 1.0) {
   
@@ -215,6 +223,8 @@ int G4Setup(const int absorberactive = 0,
 
   // forward EMC
   if(do_FEMC) FEMCSetup(g4Reco, absorberactive);
+
+  if (do_epd) EPDSetup(g4Reco);
 
   //MVTX service barrel
   if(do_mvtxservice) radius = MVTXService(g4Reco, radius);

--- a/macros/g4simulations/G4_DSTReader.C
+++ b/macros/g4simulations/G4_DSTReader.C
@@ -28,6 +28,7 @@ G4DSTreader( const char * outputFile = "G4sPHENIXCells.root",//
     bool do_hcalin = true, //
     bool do_magnet = true, //
     bool do_hcalout = true, //
+    bool do_epd = true, //
     bool do_cemc_twr = true, //
     bool do_hcalin_twr = true, //
     bool do_hcalout_twr = true //
@@ -96,6 +97,10 @@ G4DSTreader( const char * outputFile = "G4sPHENIXCells.root",//
             ana->AddNode("ABSORBER_HCALOUT");
         }
 
+      if (do_epd)
+        {
+          ana->AddNode("EPD");
+        }
 
       ana->AddNode("BH_1");
       ana->AddNode("BH_FORWARD_PLUS");

--- a/macros/g4simulations/G4_EPD.C
+++ b/macros/g4simulations/G4_EPD.C
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <g4epd/PHG4EPDSubsystem.h>
+
+#include <g4main/PHG4Reco.h>
+
+R__LOAD_LIBRARY(libg4detectors.so)
+R__LOAD_LIBRARY(libg4epd.so)
+
+namespace Enable {
+  bool EPD = false;
+}
+
+void EPDInit() { }
+
+void EPDSetup(PHG4Reco* g4Reco) {
+  PHG4EPDSubsystem* epd = new PHG4EPDSubsystem("EPD");
+
+  epd->SuperDetector("EPD");
+
+  g4Reco->registerSubsystem(epd);
+}


### PR DESCRIPTION
add macros to init and register the EPD subsystem. the flags are set to false by default.