### PR TITLE
Hepmc pileup fix

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -105,6 +105,7 @@ namespace INPUTGENERATOR
 namespace INPUTMANAGER
 {
   Fun4AllHepMCInputManager *HepMCInputManager = nullptr;
+  Fun4AllHepMCPileupInputManager *HepMCPileupInputManager = nullptr;
 }
 
 void InputInit()
@@ -162,6 +163,10 @@ void InputInit()
   if (Input::HEPMC)
   {
     INPUTMANAGER::HepMCInputManager = new Fun4AllHepMCInputManager("HEPMCin");
+  }
+  if (Input::PILEUPRATE > 0)
+  {
+    INPUTMANAGER::HepMCPileupInputManager = new Fun4AllHepMCPileupInputManager("HepMCPileupInput");
   }
 }
 
@@ -273,13 +278,13 @@ void InputManagers()
   }
   if (Input::PILEUPRATE > 0)
   {
-    Fun4AllHepMCPileupInputManager *pileup = new Fun4AllHepMCPileupInputManager("HepMCPileupInput");
-    pileup->Verbosity(Input::VERBOSITY);
-    pileup->AddFile(PILEUP::pileupfile);
-    pileup->set_collision_rate(Input::PILEUPRATE);
+    INPUTMANAGER::HepMCPileupInputManager->SignalInputManager(INPUTMANAGER::HepMCInputManager);
+    INPUTMANAGER::HepMCPileupInputManager->Verbosity(Input::VERBOSITY);
+    INPUTMANAGER::HepMCPileupInputManager->AddFile(PILEUP::pileupfile);
+    INPUTMANAGER::HepMCPileupInputManager->set_collision_rate(Input::PILEUPRATE);
     double time_window = 105.5 / PILEUP::TpcDriftVelocity;
-    pileup->set_time_window(-time_window, time_window);
-    se->registerInputManager(pileup);
+    INPUTMANAGER::HepMCPileupInputManager->set_time_window(-time_window, time_window);
+    se->registerInputManager(INPUTMANAGER::HepMCPileupInputManager);
   }
 }
 #endif

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -57,6 +57,8 @@ int Fun4All_G4_fsPHENIX(
   //===============
   // Input options
   //===============
+  // verbosity setting (applies to all input managers)
+  Input::VERBOSITY = 0;
   // Either:
   // read previously generated g4-hits files, in this case it opens a DST and skips
   // the simulations step completely. The G4Setup macro is only loaded to get information
@@ -84,9 +86,11 @@ int Fun4All_G4_fsPHENIX(
   //  Input::GUN = true;
   //Input::GUN_VERBOSITY = 0;
 
-  //  Input::HEPMC = true;
-  //Input::VERBOSITY = 0;
+  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
+
+  // Event pile up simulation with collision rate in Hz MB collisions.
+  Input::PILEUPRATE = 100e3;
 
   //-----------------
   // Initialize the selected Input/Event generation
@@ -142,22 +146,29 @@ int Fun4All_G4_fsPHENIX(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4,100e-4,30,0);//optional collision smear in space, time
-//    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
+                                                                                           //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus);
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     //! embedding ID for the event
     //! positive ID is the embedded event of interest, e.g. jetty event from pythia
     //! negative IDs are backgrounds, .e.g out of time pile up collisions
     //! Usually, ID = 0 means the primary Au+Au collision background
     //INPUTMANAGER::HepMCInputManager->set_embedding_id(2);
+    if (Input::PILEUPRATE > 0)
+    {
+      // Copy vertex settings from foreground hepmc input
+      INPUTMANAGER::HepMCPileupInputManager->CopyHelperSettings(INPUTMANAGER::HepMCInputManager);
+      // and then modify the ones you want to be different
+      // INPUTMANAGER::HepMCPileupInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);
+    }
   }
 
   // register all input generators with Fun4All
   InputRegister();
 
-// set up production relatedstuff
-//   Enable::PRODUCTION = true;
+  // set up production relatedstuff
+  //   Enable::PRODUCTION = true;
 
   //======================
   // Write the DST

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -55,6 +55,8 @@ int Fun4All_G4_sPHENIX(
   //===============
   // Input options
   //===============
+// verbosity setting (applies to all input managers)
+  Input::VERBOSITY = 0;
   // First enable the input generators
   // Either:
   // read previously generated g4-hits files, in this case it opens a DST and skips
@@ -86,8 +88,7 @@ int Fun4All_G4_sPHENIX(
   //  Input::UPSILON = true;
   Input::UPSILON_VERBOSITY = 0;
 
-//  Input::HEPMC = true;
-  Input::VERBOSITY = 0;
+  //  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
 
   // Event pile up simulation with collision rate in Hz MB collisions.
@@ -148,7 +149,7 @@ int Fun4All_G4_sPHENIX(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4,100e-4,30,0);//optional collision smear in space, time
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);//optional collision smear in space, time
 //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
     INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus);
@@ -157,6 +158,13 @@ int Fun4All_G4_sPHENIX(
     //! negative IDs are backgrounds, .e.g out of time pile up collisions
     //! Usually, ID = 0 means the primary Au+Au collision background
     //INPUTMANAGER::HepMCInputManager->set_embedding_id(2);
+    if (Input::PILEUPRATE > 0)
+    {
+      // Copy vertex settings from foreground hepmc input
+      INPUTMANAGER::HepMCPileupInputManager->CopyHelperSettings(INPUTMANAGER::HepMCInputManager);
+      // and then modify the ones you want to be different
+      // INPUTMANAGER::HepMCPileupInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);
+    }
   }
   // register all input generators with Fun4All
   InputRegister();

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -55,7 +55,7 @@ int Fun4All_G4_sPHENIX(
   //===============
   // Input options
   //===============
-// verbosity setting (applies to all input managers)
+  // verbosity setting (applies to all input managers)
   Input::VERBOSITY = 0;
   // First enable the input generators
   // Either:
@@ -149,10 +149,10 @@ int Fun4All_G4_sPHENIX(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);//optional collision smear in space, time
-//    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
+                                                                                           //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus);
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     //! embedding ID for the event
     //! positive ID is the embedded event of interest, e.g. jetty event from pythia
     //! negative IDs are backgrounds, .e.g out of time pile up collisions
@@ -169,14 +169,14 @@ int Fun4All_G4_sPHENIX(
   // register all input generators with Fun4All
   InputRegister();
 
-// set up production relatedstuff
-//   Enable::PRODUCTION = true;
+  // set up production relatedstuff
+  //   Enable::PRODUCTION = true;
 
   //======================
   // Write the DST
   //======================
 
-//  Enable::DSTOUT = true;
+  //  Enable::DSTOUT = true;
   Enable::DSTOUT_COMPRESS = false;
   DstOut::OutputDir = outdir;
   DstOut::OutputFile = outputFile;
@@ -223,9 +223,9 @@ int Fun4All_G4_sPHENIX(
   Enable::TRACKING_TRACK = true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
 
-//  cemc electronics + thin layer of W-epoxy to get albedo from cemc 
-//  into the tracking, cannot run together with CEMC
-//  Enable::CEMCALBEDO = true;
+  //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
+  //  into the tracking, cannot run together with CEMC
+  //  Enable::CEMCALBEDO = true;
 
   Enable::CEMC = true;
   Enable::CEMC_ABSORBER = true;
@@ -486,10 +486,10 @@ int Fun4All_G4_sPHENIX(
     gROOT->ProcessLine("Fun4AllServer *se = Fun4AllServer::instance();");
     gROOT->ProcessLine("PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");");
 
-    cout <<"-------------------------------------------------"<<endl;
-    cout <<"You are in event display mode. Run one event with"<<endl;
-    cout <<"se->run(1)"<<endl;
-    cout <<"Run Geant4 command with following examples"<<endl;
+    cout << "-------------------------------------------------" << endl;
+    cout << "You are in event display mode. Run one event with" << endl;
+    cout << "se->run(1)" << endl;
+    cout << "Run Geant4 command with following examples" << endl;
     gROOT->ProcessLine("displaycmd()");
 
     return 0;


### PR DESCRIPTION
This PR makes the necessary changes to the macros to use the improved pileup manager (copying vertex settings from foreground input manager, remove duplicated events)