### PR TITLE
Introduced CA seeding with tuning options

### DIFF
--- a/macros/g4simulations/G4_Tracking.C
+++ b/macros/g4simulations/G4_Tracking.C
@@ -37,6 +37,7 @@
 #include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHGenFitTrkProp.h>
 #include <trackreco/PHHoughSeeding.h>
+#include <trackreco/PHCASeeding.h>
 #include <trackreco/PHInitZVertexing.h>
 #include <trackreco/PHTrackSeeding.h>
 #include <trackreco/PHTruthVertexing.h>
@@ -601,6 +602,12 @@ void Tracking_Reco(int verbosity = 0)
 	track_seed->Verbosity(0);
 	se->registerSubsystem(track_seed);
       }else if(use_ca_seeding){
+        auto ca_seed = new PHCASeeding();
+        ca_seed->SetLayerRange(7,55);
+        ca_seed->SetSearchWindow(0.01,0.02); // (eta width, phi width)
+        ca_seed->SetMinHitsPerCluster(2);
+        ca_seed->SetMinClustersPerTrack(20);
+        se->registerSubsystem(ca_seed);
       }else{
 	PHTpcTracker* tracker = new PHTpcTracker("PHTpcTracker");
 	tracker->set_seed_finder_options( 3.0, M_PI / 8, 10, 6.0, M_PI / 8, 5, 1 ); // two-pass CA seed params


### PR DESCRIPTION
use_ca_seeding is still set to false by default, but now no further configuration is needed - just turn it to true and you have CA seeding.