### PR TITLE
Acts tracking macro

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -23,6 +23,8 @@
 #include <trackreco/PHCASeeding.h>
 #include <trackreco/PHSiliconTruthTrackSeeding.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
+#include <trackreco/PHTruthSiliconAssociation.h>
+#include <trackreco/PHMicromegasTpcTrackMatching.h>
 
 #if __cplusplus >= 201703L
 #include <trackreco/PHActsSourceLinks.h>
@@ -53,24 +55,35 @@ namespace G4TRACKING
 {
   // Tracking reconstruction setup parameters and flags
   //=====================================
+
+  // The normal (default) Acts tracking chain is:
+  //   PHTruthVertexing                            // event vertex
+  //   PHCASeeding                                  // TPC track seeds
+  //   PHSiliconTruthTrackSeeding           // make silicon layer track stubs
+  //   PHSiliconTpcTrackMatching           // match TPC track seeds to silicon layers track stubs
+  //   PHMicromegasTpcTrackMatching   // associate Micromagas clusters with TPC track stubs
+  //   PHActsSourceLinks                         // convert TrkrClusters to Acts measurements
+  //   PHActsTracks                                  // convert SvtxTracks to Acts tracks
+  //   PHActsTrkFitter                               // Kalman fitter makes final fit to assembled tracks
+
+  // Possible variations - these are normally false
+  bool use_PHTpcTracker_seeding = false;    // false for using the default PHCASeeding to get TPC track seeds, true to use PHTpcTracker
+  bool use_truth_si_matching = false;             // if true, associates silicon clusters using best truth track match to TPC seed tracks - for diagnostics only
+  bool use_truth_track_seeding = false;          // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
+  bool use_Genfit = false;                              // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
+  bool use_init_vertexing = false;                   // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
+  bool useActsProp = false;                            // if true, runs Acts CKF with only a seeder  ***** NOT FULLY FUNCTIONAL YET
+  bool g4eval_use_initial_vertex = false;        // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
+  bool use_primary_vertex = false;                 // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
+
   int init_vertexing_min_zvtx_tracks = 2;  // PHInitZvertexing parameter for reducing spurious vertices, use 2 for Pythia8 events, 5 for large multiplicity events
                                            //default seed is PHTpcTracker
-  bool use_ca_seeding = false;
-
-  bool use_track_prop = true;              // true for normal track seeding, false to run with truth track seeding instead
-
-  bool useActsFitting = true; // if true, acts KF is run with PHGenFitTrkProp
-  bool useActsProp = useActsFitting and false;  // if true, runs Acts CKF with only a seeder
-  bool g4eval_use_initial_vertex = false;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
-  bool use_primary_vertex = false;         // if true, refit tracks with primary vertex included - adds second node to node tree, adds second evaluator and outputs separate ntuples
 
   // This is the setup we have been using before PHInitZVertexing was implemented - smeared truth vertex for a single collision per event. Make it the default for now.
   std::string vmethod("avf-smoothing:1");  // only good for 1 vertex events // vmethod is a string used to set the Rave final-vertexing method:
-  bool use_truth_vertex = true;            // set to false to get initial vertex from MVTX hits using PHInitZVertexing, true for using smeared truth vertex
-
   // This is the setup that uses PHInitZvertexing to find initial vertices, and allows for multiple collisions per event
-  //const bool use_truth_vertex = false;   // set to false to get initial vertex from MVTX hits using PHInitZVertexing, true for using smeared truth vertex
   //std::string vmethod("avr-smoothing:1-minweight:0.5-primcut:9-seccut:9");  // seems to handle multi-vertex events.
+
 }  // namespace G4TRACKING
 
 void TrackingInit()
@@ -96,31 +109,16 @@ void Tracking_Reco()
   // Tracking
   //------------
 
-  if(G4TRACKING::useActsFitting)
-    {
-      #if __cplusplus >= 201703L
-      PHActsSourceLinks *sl = new PHActsSourceLinks();
-      sl->Verbosity(0);
-      sl->setMagField(G4MAGNET::magfield);
-      sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
-      se->registerSubsystem(sl);
-      #endif
-    }
-
-  if (G4TRACKING::use_track_prop)
-  {
-    //--------------------------------------------------
-    // Normal track seeding and propagation
-    //--------------------------------------------------
-
-    if (G4TRACKING::use_truth_vertex)
+  // Initial vertex finding (independent of tracking)
+  //=================================
+  if (!G4TRACKING::use_init_vertexing)
     {
       // We cheat to get the initial vertex for the full track reconstruction case
       PHInitVertexing* init_vtx = new PHTruthVertexing("PHTruthVertexing");
       init_vtx->Verbosity(verbosity);
       se->registerSubsystem(init_vtx);
     }
-    else
+  else
     {
       // get the initial vertex for track fitting from the MVTX hits
       PHInitZVertexing* init_zvtx = new PHInitZVertexing(7, 7, "PHInitZVertexing");
@@ -133,115 +131,83 @@ void Tracking_Reco()
       se->registerSubsystem(init_zvtx);
     }
 
-    /// Create silicon track stubs
-    auto siliconSeeder = new PHSiliconTruthTrackSeeding("PHSiliconTruthTrackSeeding");
-    se->registerSubsystem(siliconSeeder);
-    
-    /// Pick which TPC seeder to use
-    if (G4TRACKING::use_ca_seeding)
+  // Truth track seeding and propagation in one module 
+  // ====================================  
+  if(G4TRACKING::use_truth_track_seeding)
     {
-      auto seeder = new PHCASeeding("PHCASeeding");
-      se->registerSubsystem(seeder);
-    }
-    else
-    {
-      PHTpcTracker* tracker = new PHTpcTracker("PHTpcTracker");
-      tracker->set_seed_finder_options(3.0, M_PI / 8, 10, 6.0, M_PI / 8, 5, 1);   // two-pass CA seed params
-      tracker->set_seed_finder_optimization_remove_loopers(true, 20.0, 10000.0);  // true if loopers not needed
-      tracker->set_track_follower_optimization_helix(true);                       // false for quality, true for speed
-      tracker->set_track_follower_optimization_precise_fit(false);                // true for quality, false for speed
-      tracker->enable_json_export(false);                                         // save event as json, filename is automatic and stamped by current time in ms
-      tracker->enable_vertexing(false);                                           // rave vertexing is pretty slow at large multiplicities...
-      se->registerSubsystem(tracker);
+      std::cout << "Using truth track seeding " << std::endl;
+
+      // For each truth particle, create a track and associate clusters with it using truth information
+      PHTruthTrackSeeding* pat_rec = new PHTruthTrackSeeding("PHTruthTrackSeeding");
+      pat_rec->Verbosity(verbosity);
+      se->registerSubsystem(pat_rec);
     }
 
-    if(G4TRACKING::useActsFitting)
-      {
-	/// Match the silicon and TPC track stubs
-	auto stubMatcher = new PHSiliconTpcTrackMatching("PHSiliconTpcTrackMatching");
-	stubMatcher->set_phi_search_window(0.02);  // tune8 - optimum
-	stubMatcher->set_eta_search_window(0.015);   // tune8 - optimum
-	stubMatcher->Verbosity(0);
-	stubMatcher->set_field_dir(G4MAGNET::magfield_rescale);
-	stubMatcher->set_field(G4MAGNET::magfield);
-	se->registerSubsystem(stubMatcher);
-      }
-    else
-      {
-	// Use GenFit to find all clusters associated with each seed track
-	auto track_prop = new PHGenFitTrkProp("PHGenFitTrkProp", G4MVTX::n_maps_layer, G4INTT::n_intt_layer, G4TPC::n_gas_layer, G4MICROMEGAS::n_micromegas_layer);
-	track_prop->Verbosity(verbosity);
-	se->registerSubsystem(track_prop);
-	for (int i = 0; i < G4INTT::n_intt_layer; i++)
-	  {
-	    // strip length is along theta
-	    track_prop->set_max_search_win_theta_intt(i, 0.200);
-	    track_prop->set_min_search_win_theta_intt(i, 0.200);
-	    track_prop->set_max_search_win_phi_intt(i, 0.0050);
-	    track_prop->set_min_search_win_phi_intt(i, 0.000);
-	  }
-      }
-  }
-  else
-  {
-    //-------------------------------------------------------
-    // Track finding using truth information only
-    //------------------------------------------------------
-
-    PHInitVertexing* init_vtx = new PHTruthVertexing("PHTruthVertexing");
-    init_vtx->Verbosity(verbosity);
-    se->registerSubsystem(init_vtx);
-
-    // For each truth particle, create a track and associate clusters with it using truth information
-    PHTruthTrackSeeding* pat_rec = new PHTruthTrackSeeding("PHTruthTrackSeeding");
-    pat_rec->Verbosity(verbosity);
-    se->registerSubsystem(pat_rec);
-  }
-
-  //------------------------------------------------
-  // Fitting of tracks using Kalman Filter
-  //------------------------------------------------
-
-  if(G4TRACKING::useActsFitting)
+  // TPC track seeding (finds all clusters in TPC for tracks)
+  //=======================================
+  if(!G4TRACKING::use_truth_track_seeding)
     {
-      #if __cplusplus >= 201703L
-      PHActsTracks *actsTracks = new PHActsTracks();
-      actsTracks->Verbosity(0);
-      se->registerSubsystem(actsTracks);
-      
-      /// Use either PHActsTrkFitter to run the ACTS
-      /// KF track fitter, or PHActsTrkProp to run the ACTS Combinatorial 
-      /// Kalman Filter which runs track finding and track fitting
-      /// Always run PHActsTracks first to take the SvtxTrack and convert it
-      /// to a form that Acts can process
-      if(G4TRACKING::useActsProp)
+      std::cout << "Using normal TPC track seeding " << std::endl;
+
+      // TPC track seeding from data
+      if (G4TRACKING::use_PHTpcTracker_seeding)
 	{
-	  PHActsTrkProp *actsProp = new PHActsTrkProp();
-	  actsProp->Verbosity(0);
-	  actsProp->doTimeAnalysis(true);
-	  actsProp->resetCovariance(true);
-	  actsProp->setVolumeMaxChi2(7,60); /// MVTX 
-	  actsProp->setVolumeMaxChi2(9,60); /// INTT
-	  actsProp->setVolumeMaxChi2(11,60); /// TPC
-	  actsProp->setVolumeLayerMaxChi2(9, 2, 100); /// INTT first few layers
-	  actsProp->setVolumeLayerMaxChi2(9, 4, 100);
-	  actsProp->setVolumeLayerMaxChi2(11,2, 200); /// TPC first few layers 
-	  actsProp->setVolumeLayerMaxChi2(11,4, 200);
-	  
-	  se->registerSubsystem(actsProp);
+	  std::cout << "   Using PHTpcTracker track seeding " << std::endl;
+
+	  PHTpcTracker* tracker = new PHTpcTracker("PHTpcTracker");
+	  tracker->set_seed_finder_options(3.0, M_PI / 8, 10, 6.0, M_PI / 8, 5, 1);   // two-pass CA seed params
+	  tracker->set_seed_finder_optimization_remove_loopers(true, 20.0, 10000.0);  // true if loopers not needed
+	  tracker->set_track_follower_optimization_helix(true);                       // false for quality, true for speed
+	  tracker->set_track_follower_optimization_precise_fit(false);                // true for quality, false for speed
+	  tracker->enable_json_export(false);                                         // save event as json, filename is automatic and stamped by current time in ms
+	  tracker->enable_vertexing(false);                                           // rave vertexing is pretty slow at large multiplicities...
+	  tracker->Verbosity(0);
+	  se->registerSubsystem(tracker);
 	}
       else
 	{
-	  PHActsTrkFitter *actsFit = new PHActsTrkFitter();
-	  actsFit->Verbosity(0);
-	  actsFit->doTimeAnalysis(false);
-	  se->registerSubsystem(actsFit);
+	  std::cout << "   Using PHCASeeding track seeding " << std::endl;
+
+	  auto seeder = new PHCASeeding("PHCASeeding");
+	  seeder->set_field_dir(G4MAGNET::magfield_rescale);   // to get charge sign right
+	  seeder->Verbosity(0);
+	  seeder->SetLayerRange(7,55);
+	  seeder->SetSearchWindow(0.01,0.02); // (eta width, phi width)
+	  seeder->SetMinHitsPerCluster(2);
+	  seeder->SetMinClustersPerTrack(20);
+	  se->registerSubsystem(seeder);
 	}
-      
-      #endif   
     }
-  else
+
+  // Genfit track propagation and final fitting (starts from TPC track seeds)
+  //=================================================
+  if(G4TRACKING::use_Genfit)
     {
+      if(!G4TRACKING::use_truth_track_seeding)
+	{
+	  std::cout << "   Using PHGenFitTrkProp " << std::endl;
+	  
+	  // Association of TPC track seeds with silicon layers and Micromegas layers	  
+	  // Find all clusters associated with each seed track
+	  auto track_prop = new PHGenFitTrkProp("PHGenFitTrkProp", 
+						G4MVTX::n_maps_layer, 
+						G4INTT::n_intt_layer, 
+						G4TPC::n_gas_layer, 
+						G4MICROMEGAS::n_micromegas_layer);
+	  track_prop->Verbosity(verbosity);
+	  se->registerSubsystem(track_prop);
+	  for (int i = 0; i < G4INTT::n_intt_layer; i++)
+	    {
+	      // strip length is along theta
+	      track_prop->set_max_search_win_theta_intt(i, 0.200);
+	      track_prop->set_min_search_win_theta_intt(i, 0.200);
+	      track_prop->set_max_search_win_phi_intt(i, 0.0050);
+	      track_prop->set_min_search_win_phi_intt(i, 0.000);
+	    }
+	}
+
+      std::cout << "   Using Genfit track fitting " << std::endl;
+
       PHGenFitTrkFitter* kalman = new PHGenFitTrkFitter();
       kalman->Verbosity(verbosity);
       
@@ -261,6 +227,115 @@ void Tracking_Reco()
       projection->Verbosity(verbosity);
       se->registerSubsystem(projection);
     }
+
+  // Acts tracking chain (starts from TPC track seeds)
+  //===================================
+  if(!G4TRACKING::use_truth_track_seeding && !G4TRACKING::use_Genfit)
+    {		
+      std::cout << "   Using normal Acts matching chain for silicon and MM's " << std::endl;
+      
+      // Silicon cluster matching to TPC track seeds
+     if(G4TRACKING::use_truth_si_matching)
+	{
+	  std::cout << "      Using truth Si matching " << std::endl;
+	  // use truth particle matching in TPC to assign clusters in silicon to TPC tracks from CA seeder
+	  // intended only for diagnostics 
+	  PHTruthSiliconAssociation *silicon_assoc = new PHTruthSiliconAssociation();
+	  silicon_assoc ->Verbosity(0);
+	  se->registerSubsystem(silicon_assoc);
+	}
+      else
+	{
+	  std::cout << "      Using stub matching for Si matching " << std::endl;
+	  
+	  // The normal silicon association methods
+	  // start with a complete TPC track seed from one of the CA seeders
+	  
+	  // use truth information to assemble silicon clusters into track stubs for now
+	  PHSiliconTruthTrackSeeding *silicon_seeding = new PHSiliconTruthTrackSeeding();
+	  silicon_seeding->Verbosity(0);
+	  se->registerSubsystem(silicon_seeding);
+	  
+	  // Match the TPC track stubs from Cthe A seeder to silicon track stubs from PHSiliconTruthTrackSeeding
+	  PHSiliconTpcTrackMatching *silicon_match = new PHSiliconTpcTrackMatching();
+	  silicon_match ->Verbosity(0);
+	  if(!G4TRACKING::use_PHTpcTracker_seeding)
+	    silicon_match->set_seeder(true);    // defaults to PHTpcTracker seeding, use true for PHCASeeding
+	  silicon_match->set_field(G4MAGNET::magfield);
+	  silicon_match->set_field_dir(G4MAGNET::magfield_rescale);
+	  silicon_match->set_phi_search_window(0.02);  // tune8 - optimum
+	  silicon_match->set_eta_search_window(0.015);   // tune8 - optimum
+	  se->registerSubsystem(silicon_match);
+	}
+      
+      // Associate Micromegas clusters with the tracks
+      if(G4MICROMEGAS::n_micromegas_layer > 0)
+	{
+	  std::cout << "      Using Micromegas matching " << std::endl;
+	  
+	  // Match TPC track stubs from CA seeder to clusters in the micromegas layers
+	  PHMicromegasTpcTrackMatching *mm_match = new PHMicromegasTpcTrackMatching();
+	  mm_match ->Verbosity(0);
+	  // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
+	  mm_match-> set_rphi_search_window_lyr1(0.2);
+	  mm_match-> set_rphi_search_window_lyr2(13.0);
+	  mm_match-> set_z_search_window_lyr1(26.0);
+	  mm_match-> set_z_search_window_lyr2(0.2);
+	  mm_match->set_min_tpc_layer(38);   // layer in TPC to start projection fit
+	  mm_match->print_test_windows_data(false);   // normally false
+	  se->registerSubsystem(mm_match);
+	}
+    }
+
+  // Final fitting of tracks using Acts Kalman Filter
+  //=================================    
+  if(!G4TRACKING::use_Genfit)
+    {
+      std::cout << "   Using Acts track fitting " << std::endl;
+
+#if __cplusplus >= 201703L
+
+      /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
+
+      PHActsSourceLinks *sl = new PHActsSourceLinks();
+      sl->Verbosity(0);
+      sl->setMagField(G4MAGNET::magfield);
+      sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
+      se->registerSubsystem(sl);
+      
+      PHActsTracks *actsTracks = new PHActsTracks();
+      actsTracks->Verbosity(0);
+      se->registerSubsystem(actsTracks);
+      
+      /// Use either PHActsTrkFitter to run the ACTS
+      /// KF track fitter, or PHActsTrkProp to run the ACTS Combinatorial 
+      /// Kalman Filter which runs track finding and track fitting
+      if(G4TRACKING::useActsProp)
+	{
+	  // Not fully functional yet
+	  PHActsTrkProp *actsProp = new PHActsTrkProp();
+	  actsProp->Verbosity(0);
+	  actsProp->doTimeAnalysis(true);
+	  actsProp->resetCovariance(true);
+	  actsProp->setVolumeMaxChi2(7,60); /// MVTX 
+	  actsProp->setVolumeMaxChi2(9,60); /// INTT
+	  actsProp->setVolumeMaxChi2(11,60); /// TPC
+	  actsProp->setVolumeLayerMaxChi2(9, 2, 100); /// INTT first few layers
+	  actsProp->setVolumeLayerMaxChi2(9, 4, 100);
+	  actsProp->setVolumeLayerMaxChi2(11,2, 200); /// TPC first few layers 
+	  actsProp->setVolumeLayerMaxChi2(11,4, 200);
+	  
+	  se->registerSubsystem(actsProp);
+	}
+      else
+	{
+	  PHActsTrkFitter *actsFit = new PHActsTrkFitter();
+	  actsFit->Verbosity(0);
+	  actsFit->doTimeAnalysis(true);
+	  se->registerSubsystem(actsFit);
+	}
+#endif   
+    }
   
   return;
 }
@@ -279,7 +354,11 @@ void Tracking_Eval(const std::string& outputfile)
   // Tracking evaluation
   //----------------
   SvtxEvaluator* eval;
-  eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile, "SvtxTrackMap", G4MVTX::n_maps_layer, G4INTT::n_intt_layer, G4TPC::n_gas_layer);
+  eval = new SvtxEvaluator("SVTXEVALUATOR", outputfile, "SvtxTrackMap", 
+			   G4MVTX::n_maps_layer, 
+			   G4INTT::n_intt_layer, 
+			   G4TPC::n_gas_layer, 
+			   G4MICROMEGAS::n_micromegas_layer);
   eval->do_cluster_eval(true);
   eval->do_g4hit_eval(true);
   eval->do_hit_eval(true);  // enable to see the hits that includes the chamber physics...
@@ -290,16 +369,15 @@ void Tracking_Eval(const std::string& outputfile)
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 
-  if(G4TRACKING::useActsFitting)
+  if(!G4TRACKING::use_Genfit)
     {
-      #if __cplusplus >= 201703L
+#if __cplusplus >= 201703L
       ActsEvaluator *actsEval = new ActsEvaluator(outputfile+"_acts.root", eval);
       actsEval->Verbosity(0);
       actsEval->setEvalCKF(false);
       se->registerSubsystem(actsEval);
-      #endif
+#endif
     }
-  
 
   if (G4TRACKING::use_primary_vertex)
   {

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -91,7 +91,7 @@ void TrackingInit()
 #if __cplusplus < 201703L
   std::cout << "Cannot run tracking without gcc-8 environment. Please run:" << std::endl;
   std::cout << "source /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/opt/sphenix/core/bin/sphenix_setup.csh -n" << std::endl;
-  gSystem->Exit(1);
+  gSystem->Exit(0);
 #endif
 
   if (!Enable::MICROMEGAS)

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -88,6 +88,12 @@ namespace G4TRACKING
 
 void TrackingInit()
 {
+#if __cplusplus < 201703L
+  std::cout << "Cannot run tracking without gcc-8 environment. Please run:" << std::endl;
+  std::cout << "source /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/opt/sphenix/core/bin/sphenix_setup.csh -n" << std::endl;
+  gSystem->Exit(1);
+#endif
+
   if (!Enable::MICROMEGAS)
   {
     G4MICROMEGAS::n_micromegas_layer = 0;

--- a/macros/g4simulations/vis.mac
+++ b/macros/g4simulations/vis.mac
@@ -29,11 +29,13 @@
 /vis/open OGL 1200x900-0+0
 # increase display limit for more complex detectors
 /vis/ogl/set/displayListLimit 500000
-/vis/viewer/set/viewpointThetaPhi 240 -10
-/vis/viewer/addCutawayPlane 0 0 0 m 1 0 0
+/vis/viewer/set/viewpointThetaPhi -100  -10
+#/vis/viewer/set/viewpointThetaPhi 10 -10
+/vis/viewer/addCutawayPlane -0.5 0 0 m 1 0 0
 # our world is 4x4 meters, the detector is about 1m across
 # zooming by 4 makes it fill the display
-/vis/viewer/zoom 1.5
+#/vis/viewer/panTo 0.5 0 
+/vis/viewer/zoom 2
 #
 # Use this open statement instead to get a HepRep version 1 file
 # suitable for viewing in WIRED.
@@ -52,7 +54,7 @@
 /vis/modeling/trajectories/create/drawByCharge
 /vis/modeling/trajectories/drawByCharge-0/default/setDrawStepPts true
 /vis/modeling/trajectories/drawByCharge-0/default/setStepPtsSize 2
-# (if too many tracks cause core dump => /tracking/storeTrajectory 0)
+#(if too many tracks cause core dump => /tracking/storeTrajectory 0)
 #
 # To draw gammas only
 #/vis/filtering/trajectories/create/particleFilter


### PR DESCRIPTION
We should discuss this at the sims meeting before merging. Running this macro will require a special environment setup.

The G4_Tracking.C macro is updated so that it runs the Acts tracking chain by default. Track seeding is done by PHCASeeding (default), with the option of using PHTpcTracker instead. The Genfit track propagation and fitting chain can be run instead of the Acts chain after the seeding is done. The Hough seeding is dropped from the macro.

The truth track seeding works for the Genfit fitter, not for the Acts fitter. We will likely have to sett good enough starting track parameters in the truth seeding module (or after it) for Acts to function properly. 