### PR TITLE
added missing include

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -3,6 +3,7 @@
 
 #include "GlobalVariables.C"
 
+#include "G4_Magnet.C"
 #include "G4_Intt.C"
 #include "G4_Micromegas.C"
 #include "G4_Mvtx.C"


### PR DESCRIPTION
G4MAGNET namespace is used later in the macro. Without the include this might crash the main macro if includes are not added there in the proper order.