### PR TITLE
Multiple generators

### DIFF
--- a/common/G4_Aerogel.C
+++ b/common/G4_Aerogel.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4AEROGEL_C
 #define MACRO_G4AEROGEL_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4SectorSubsystem.h>
 

--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4BARRELEIC_C
 #define MACRO_G4BARRELEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_BlackHole.C
+++ b/common/G4_BlackHole.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4BLACKHOLE_C
 #define MACRO_G4BLACKHOLE_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4main/PHG4Reco.h>

--- a/common/G4_CEmc_Albedo.C
+++ b/common/G4_CEmc_Albedo.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4CEMCALBEDO_C
 #define MACRO_G4CEMCALBEDO_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_CEmc_EIC.C
+++ b/common/G4_CEmc_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4CEMCEIC_C
 #define MACRO_G4CEMCEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/RawTowerBuilder.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4CEMCSPACAL_C
 #define MACRO_G4CEMCSPACAL_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderCellReco.h>
 #include <g4detectors/PHG4CylinderGeom_Spacalv1.h>

--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -368,13 +368,13 @@ void CEMC_Towers()
   TowerDigitizer->Detector("CEMC");
   TowerDigitizer->Verbosity(verbosity);
   TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
-  TowerDigitizer->set_variable_pedestal(true); //read ped central and width from calibrations file comment next 2 lines if true
-//  TowerDigitizer->set_pedstal_central_ADC(0);
-//  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
-  TowerDigitizer->set_photonelec_ADC(1);     //not simulating ADC discretization error
+  TowerDigitizer->set_variable_pedestal(true);  //read ped central and width from calibrations file comment next 2 lines if true
+                                                //  TowerDigitizer->set_pedstal_central_ADC(0);
+                                                //  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+  TowerDigitizer->set_photonelec_ADC(1);        //not simulating ADC discretization error
   TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
-  TowerDigitizer->set_variable_zero_suppression(true); //read zs values from calibrations file comment next line if true
-//  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
+  TowerDigitizer->set_variable_zero_suppression(true);  //read zs values from calibrations file comment next line if true
+                                                        //  TowerDigitizer->set_zero_suppression_ADC(16);  // eRD1 test beam setting
   TowerDigitizer->GetParameters().ReadFromFile("CEMC", "xml", 0, 0,
                                                string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
   se->registerSubsystem(TowerDigitizer);
@@ -397,10 +397,10 @@ void CEMC_Towers()
     TowerCalibration->set_calib_algorithm(RawTowerCalibration::kTower_by_tower_calibration);
     TowerCalibration->GetCalibrationParameters().ReadFromFile("CEMC", "xml", 0, 0,
                                                               string(getenv("CALIBRATIONROOT")) + string("/CEMC/TowerCalibCombinedParams_2020/"));  // calibration database
-    TowerCalibration->set_variable_GeV_ADC(true); //read GeV per ADC from calibrations file comment next line if true
-//    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
-    TowerCalibration->set_variable_pedestal(true); //read pedestals from calibrations file comment next line if true
-//    TowerCalibration->set_pedstal_ADC(0);
+    TowerCalibration->set_variable_GeV_ADC(true);                                                                                                   //read GeV per ADC from calibrations file comment next line if true
+                                                                                                                                                    //    TowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);                                                             // overall energy scale based on 4-GeV photon simulations
+    TowerCalibration->set_variable_pedestal(true);                                                                                                  //read pedestals from calibrations file comment next line if true
+                                                                                                                                                    //    TowerCalibration->set_pedstal_ADC(0);
     se->registerSubsystem(TowerCalibration);
   }
   else

--- a/common/G4_CaloTrigger.C
+++ b/common/G4_CaloTrigger.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4CALOTRIGGER_C
 #define MACRO_G4CALOTRIGGER_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <calotrigger/CaloTriggerSim.h>
 

--- a/common/G4_DIRC.C
+++ b/common/G4_DIRC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4DIRC_C
 #define MACRO_G4DIRC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4detectors/PHG4SectorSubsystem.h>

--- a/common/G4_DSTReader.C
+++ b/common/G4_DSTReader.C
@@ -1,17 +1,17 @@
 #ifndef MACRO_G4DSTREADER_C
 #define MACRO_G4DSTREADER_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_BlackHole.C"
-#include "G4_CEmc_Spacal.C"
-#include "G4_EPD.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Intt.C"
-#include "G4_Magnet.C"
-#include "G4_Mvtx.C"
-#include "G4_TPC.C"
+#include <G4_BlackHole.C>
+#include <G4_CEmc_Spacal.C>
+#include <G4_EPD.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Intt.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx.C>
+#include <G4_TPC.C>
 
 #include <g4eval/PHG4DSTReader.h>
 

--- a/common/G4_DSTReader_EICDetector.C
+++ b/common/G4_DSTReader_EICDetector.C
@@ -1,22 +1,22 @@
 #ifndef MACRO_G4DSTREADEREICDETECTOR_C
 #define MACRO_G4DSTREADEREICDETECTOR_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Barrel_EIC.C"
-#include "G4_CEmc_EIC.C"
-#include "G4_DIRC.C"
-#include "G4_EEMC.C"
-#include "G4_FEMC_EIC.C"
-#include "G4_FHCAL.C"
-#include "G4_FST_EIC.C"
-#include "G4_GEM_EIC.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Magnet.C"
-#include "G4_Mvtx_EIC.C"
-#include "G4_RICH.C"
-#include "G4_TPC_EIC.C"
+#include <G4_Barrel_EIC.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_FST_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
 
 #include <g4eval/PHG4DSTReader.h>
 

--- a/common/G4_DSTReader_fsPHENIX.C
+++ b/common/G4_DSTReader_fsPHENIX.C
@@ -1,18 +1,18 @@
 #ifndef MACRO_G4DSTREADERFSPHENIX_C
 #define MACRO_G4DSTREADERFSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_CEmc_Spacal.C"
-#include "G4_FEMC.C"
-#include "G4_FGEM_fsPHENIX.C"
-#include "G4_FHCAL.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Intt.C"
-#include "G4_Magnet.C"
-#include "G4_Mvtx.C"
-#include "G4_TPC.C"
+#include <G4_CEmc_Spacal.C>
+#include <G4_FEMC.C>
+#include <G4_FGEM_fsPHENIX.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Intt.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx.C>
+#include <G4_TPC.C>
 
 #include <g4eval/PHG4DSTReader.h>
 

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4EEMC_C
 #define MACRO_G4EEMC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_EPD.C
+++ b/common/G4_EPD.C
@@ -7,14 +7,16 @@
 
 R__LOAD_LIBRARY(libg4epd.so)
 
-namespace Enable {
+namespace Enable
+{
   bool EPD = false;
   bool EPD_OVERLAPCHECK = false;
-}
+}  // namespace Enable
 
-void EPDInit() { }
+void EPDInit() {}
 
-void EPD(PHG4Reco* g4Reco) {
+void EPD(PHG4Reco* g4Reco)
+{
   bool overlap_check = Enable::OVERLAPCHECK || Enable::EPD_OVERLAPCHECK;
 
   PHG4EPDSubsystem* epd = new PHG4EPDSubsystem("EPD");

--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4FEMC_C
 #define MACRO_G4FEMC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4FEMCEIC_C
 #define MACRO_G4FEMCEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <caloreco/RawClusterBuilderFwd.h>
 #include <caloreco/RawClusterBuilderTemplate.h>

--- a/common/G4_FGEM_fsPHENIX.C
+++ b/common/G4_FGEM_fsPHENIX.C
@@ -1,10 +1,10 @@
 #ifndef MACRO_G4FGEMFSPHENIX_C
 #define MACRO_G4FGEMFSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_FEMC.C"
-#include "G4_FHCAL.C"
+#include <G4_FEMC.C>
+#include <G4_FHCAL.C>
 
 #include <g4detectors/PHG4SectorSubsystem.h>
 

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4FHCAL_C
 #define MACRO_G4FHCAL_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/RawTowerBuilderByHitIndex.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4FSTEIC_C
 #define MACRO_G4FSTEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4SectorSubsystem.h>
 

--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4GEMEIC_C
 #define MACRO_G4GEMEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4SectorSubsystem.h>
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -2,7 +2,7 @@
 #ifndef MACRO_G4HCALINREF_C
 #define MACRO_G4HCALINREF_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/HcalRawTowerBuilder.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4HCALOUTREF_C
 #define MACRO_G4HCALOUTREF_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4calo/HcalRawTowerBuilder.h>
 #include <g4calo/RawTowerDigitizer.h>

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4INPUT_C
 #define MACRO_G4INPUT_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <phpythia6/PHPythia6.h>
 

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -64,13 +64,13 @@ namespace INPUTREADHITS
 {
   string filename;
   string listfile;
-}
+}  // namespace INPUTREADHITS
 
 namespace INPUTEMBED
 {
   string filename;
   string listfile;
-}
+}  // namespace INPUTEMBED
 
 namespace PYTHIA6
 {
@@ -109,7 +109,7 @@ namespace INPUTMANAGER
 {
   Fun4AllHepMCInputManager *HepMCInputManager = nullptr;
   Fun4AllHepMCPileupInputManager *HepMCPileupInputManager = nullptr;
-}
+}  // namespace INPUTMANAGER
 
 void InputInit()
 {
@@ -158,7 +158,7 @@ void InputInit()
 
   if (Input::SIMPLE)
   {
-    for (int i=0; i<Input::SIMPLE_NUMBER; ++i)
+    for (int i = 0; i < Input::SIMPLE_NUMBER; ++i)
     {
       std::string name = "EVTGENERATOR_" + std::to_string(i);
       PHG4SimpleEventGenerator *simple = new PHG4SimpleEventGenerator(name);
@@ -168,7 +168,7 @@ void InputInit()
   }
   if (Input::GUN)
   {
-    for (int i=0; i<Input::GUN_NUMBER; ++i)
+    for (int i = 0; i < Input::GUN_NUMBER; ++i)
     {
       std::string name = "GUN_" + std::to_string(i);
       PHG4ParticleGun *gun = new PHG4ParticleGun(name);
@@ -178,7 +178,7 @@ void InputInit()
   }
   if (Input::UPSILON)
   {
-    for (int i=0; i<Input::UPSILON_NUMBER; ++i)
+    for (int i = 0; i < Input::UPSILON_NUMBER; ++i)
     {
       std::string name = "UPSILON_" + std::to_string(i);
       PHG4ParticleGeneratorVectorMeson *upsilon = new PHG4ParticleGeneratorVectorMeson(name);
@@ -225,13 +225,13 @@ void InputRegister()
   {
     for (size_t icnt = 0; icnt < INPUTGENERATOR::VectorMesonGenerator.size(); ++icnt)
     {
-    if (Input::HEPMC || Input::SIMPLE)
-    {
-      INPUTGENERATOR::VectorMesonGenerator[icnt]->set_reuse_existing_vertex(true);
-    }
-    INPUTGENERATOR::VectorMesonGenerator[icnt]->Verbosity(Input::UPSILON_VERBOSITY);
-    INPUTGENERATOR::VectorMesonGenerator[icnt]->Embed(2);
-    se->registerSubsystem(INPUTGENERATOR::VectorMesonGenerator[icnt]);
+      if (Input::HEPMC || Input::SIMPLE)
+      {
+        INPUTGENERATOR::VectorMesonGenerator[icnt]->set_reuse_existing_vertex(true);
+      }
+      INPUTGENERATOR::VectorMesonGenerator[icnt]->Verbosity(Input::UPSILON_VERBOSITY);
+      INPUTGENERATOR::VectorMesonGenerator[icnt]->Embed(2);
+      se->registerSubsystem(INPUTGENERATOR::VectorMesonGenerator[icnt]);
     }
   }
   if (Input::GUN)
@@ -278,7 +278,7 @@ void InputManagers()
       cout << "no filename INPUTEMBED::filename or listfile INPUTEMBED::listfile given" << endl;
       gSystem->Exit(1);
     }
-    in1->Repeat();                       // if file(or filelist) is exhausted, start from beginning
+    in1->Repeat();  // if file(or filelist) is exhausted, start from beginning
     se->registerInputManager(in1);
   }
   if (Input::HEPMC)

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -35,14 +35,17 @@ namespace Input
 {
   bool GUN = false;
   int GUN_VERBOSITY = 0;
+  int GUN_NUMBER = 1;
   bool READHITS = false;
   bool PYTHIA6 = false;
   bool PYTHIA8 = false;
   bool SARTRE = false;
   bool SIMPLE = false;
   int SIMPLE_VERBOSITY = 0;
+  int SIMPLE_NUMBER = 1;
   bool UPSILON = false;
   int UPSILON_VERBOSITY = 0;
+  int UPSILON_NUMBER = 1;
   double PILEUPRATE = 0.;
   int VERBOSITY = 0;
 }  // namespace Input
@@ -93,9 +96,9 @@ namespace PILEUP
 // collection of pointers to particle generators we can grab in the Fun4All macro
 namespace INPUTGENERATOR
 {
-  PHG4ParticleGeneratorVectorMeson *VectorMesonGenerator = nullptr;
-  PHG4SimpleEventGenerator *SimpleEventGenerator = nullptr;
-  PHG4ParticleGun *Gun = nullptr;
+  std::vector<PHG4ParticleGeneratorVectorMeson *> VectorMesonGenerator;
+  std::vector<PHG4SimpleEventGenerator *> SimpleEventGenerator;
+  std::vector<PHG4ParticleGun *> Gun;
   PHPythia6 *Pythia6 = nullptr;
   PHPythia8 *Pythia8 = nullptr;
   PHSartre *Sartre = nullptr;
@@ -155,15 +158,33 @@ void InputInit()
 
   if (Input::SIMPLE)
   {
-    INPUTGENERATOR::SimpleEventGenerator = new PHG4SimpleEventGenerator();
+    for (int i=0; i<Input::SIMPLE_NUMBER; ++i)
+    {
+      std::string name = "EVTGENERATOR_" + std::to_string(i);
+      PHG4SimpleEventGenerator *simple = new PHG4SimpleEventGenerator(name);
+      simple->Embed(2);
+      INPUTGENERATOR::SimpleEventGenerator.push_back(simple);
+    }
   }
   if (Input::GUN)
   {
-    INPUTGENERATOR::Gun = new PHG4ParticleGun();
+    for (int i=0; i<Input::GUN_NUMBER; ++i)
+    {
+      std::string name = "GUN_" + std::to_string(i);
+      PHG4ParticleGun *gun = new PHG4ParticleGun(name);
+      gun->Embed(2);
+      INPUTGENERATOR::Gun.push_back(gun);
+    }
   }
   if (Input::UPSILON)
   {
-    INPUTGENERATOR::VectorMesonGenerator = new PHG4ParticleGeneratorVectorMeson();
+    for (int i=0; i<Input::UPSILON_NUMBER; ++i)
+    {
+      std::string name = "UPSILON_" + std::to_string(i);
+      PHG4ParticleGeneratorVectorMeson *upsilon = new PHG4ParticleGeneratorVectorMeson(name);
+      upsilon->Embed(2);
+      INPUTGENERATOR::VectorMesonGenerator.push_back(upsilon);
+    }
   }
   // input managers for which we might need to set options
   if (Input::HEPMC)
@@ -194,23 +215,32 @@ void InputRegister()
   }
   if (Input::SIMPLE)
   {
-    INPUTGENERATOR::SimpleEventGenerator->Verbosity(Input::SIMPLE_VERBOSITY);
-    se->registerSubsystem(INPUTGENERATOR::SimpleEventGenerator);
+    for (size_t icnt = 0; icnt < INPUTGENERATOR::SimpleEventGenerator.size(); ++icnt)
+    {
+      INPUTGENERATOR::SimpleEventGenerator[icnt]->Verbosity(Input::SIMPLE_VERBOSITY);
+      se->registerSubsystem(INPUTGENERATOR::SimpleEventGenerator[icnt]);
+    }
   }
   if (Input::UPSILON)
   {
+    for (size_t icnt = 0; icnt < INPUTGENERATOR::VectorMesonGenerator.size(); ++icnt)
+    {
     if (Input::HEPMC || Input::SIMPLE)
     {
-      INPUTGENERATOR::VectorMesonGenerator->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[icnt]->set_reuse_existing_vertex(true);
     }
-    INPUTGENERATOR::VectorMesonGenerator->Verbosity(Input::UPSILON_VERBOSITY);
-    INPUTGENERATOR::VectorMesonGenerator->Embed(2);
-    se->registerSubsystem(INPUTGENERATOR::VectorMesonGenerator);
+    INPUTGENERATOR::VectorMesonGenerator[icnt]->Verbosity(Input::UPSILON_VERBOSITY);
+    INPUTGENERATOR::VectorMesonGenerator[icnt]->Embed(2);
+    se->registerSubsystem(INPUTGENERATOR::VectorMesonGenerator[icnt]);
+    }
   }
   if (Input::GUN)
   {
-    INPUTGENERATOR::Gun->Verbosity(Input::GUN_VERBOSITY);
-    se->registerSubsystem(INPUTGENERATOR::Gun);
+    for (size_t icnt = 0; icnt < INPUTGENERATOR::Gun.size(); ++icnt)
+    {
+      INPUTGENERATOR::Gun[icnt]->Verbosity(Input::GUN_VERBOSITY);
+      se->registerSubsystem(INPUTGENERATOR::Gun[icnt]);
+    }
   }
   if (Input::READEIC)
   {

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -1,9 +1,9 @@
 #ifndef MACRO_G4INTT_C
 #define MACRO_G4INTT_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Mvtx.C"
+#include <G4_Mvtx.C>
 
 #include <g4intt/PHG4InttDefs.h>
 #include <g4intt/PHG4InttDigitizer.h>

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -40,7 +40,7 @@ namespace G4INTT
                        PHG4InttDefs::SEGMENTATION_PHI,
                        PHG4InttDefs::SEGMENTATION_PHI};
   int nladder[4] = {12, 12, 16, 16};
-  double sensor_radius[4] = { 7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
+  double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
   double offsetphi[4] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3]};
 

--- a/common/G4_Jets.C
+++ b/common/G4_Jets.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4JETS_C
 #define MACRO_G4JETS_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4jets/ClusterJetInput.h>
 #include <g4jets/FastJetAlgo.h>

--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -22,9 +22,6 @@ namespace G4MAGNET
   double magnet_outer_cryostat_wall_radius = 174.5;
   double magnet_outer_cryostat_wall_thickness = 2.5;
   double magnet_length = 379.;
-  double magfield_rescale = 1;
-  string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
-
 }  // namespace G4MAGNET
 
 void MagnetInit()

--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4MAGNET_C
 #define MACRO_G4MAGNET_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -1,11 +1,11 @@
 #ifndef MACRO_G4MICROMEGAS_C
 #define MACRO_G4MICROMEGAS_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Intt.C"
-#include "G4_Mvtx.C"
-#include "G4_TPC.C"
+#include <G4_Intt.C>
+#include <G4_Mvtx.C>
+#include <G4_TPC.C>
 
 #include <g4micromegas/PHG4MicromegasDigitizer.h>
 #include <g4micromegas/PHG4MicromegasHitReco.h>

--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -40,7 +40,7 @@ namespace G4MICROMEGAS
   };
 
   Config CONFIG = CONFIG_Z_ONE_SECTOR;
-}
+}  // namespace G4MICROMEGAS
 
 void MicromegasInit()
 {
@@ -85,79 +85,87 @@ void Micromegas_Cells()
   static constexpr double tile_length = 50;
   static constexpr double tile_width = 25;
 
-  switch( G4MICROMEGAS::CONFIG )
+  switch (G4MICROMEGAS::CONFIG)
   {
-    case G4MICROMEGAS::CONFIG_MINIMAL:
+  case G4MICROMEGAS::CONFIG_MINIMAL:
+  {
+    // one tile at mid rapidity in front of TPC sector
+    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MINIMAL" << std::endl;
+    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
+    reco->set_tiles({{{phi0, 0, tile_width / radius, tile_length}}});
+    break;
+  }
+
+  case G4MICROMEGAS::CONFIG_PHI_ONE_RING:
+  {
+    // 12 tiles at mid rapidity, one in front of each TPC sector
+    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_PHI_ONE_RING" << std::endl;
+    MicromegasTile::List tiles;
+    for (int i = 0; i < nsectors; ++i)
     {
-      // one tile at mid rapidity in front of TPC sector
-      std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MINIMAL" << std::endl;
-      static constexpr double phi0 = M_PI*(0.5 + 1./nsectors);
-      reco->set_tiles( {{{ phi0, 0, tile_width/radius, tile_length }}} );
-      break;
+      tiles.emplace_back(2. * M_PI * (0.5 + i) / nsectors, 0, tile_width / radius, tile_length);
+    }
+    reco->set_tiles(tiles);
+    break;
+  }
+
+  case G4MICROMEGAS::CONFIG_Z_ONE_SECTOR:
+  {
+    // 4 tiles with full z coverage in front of one TPC sector
+    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_Z_ONE_SECTOR" << std::endl;
+    MicromegasTile::List tiles;
+    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
+    static constexpr int ntiles = 4;
+    for (int i = 0; i < ntiles; ++i)
+    {
+      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles - 0.5), tile_width / radius, tile_length);
+    }
+    reco->set_tiles(tiles);
+    break;
+  }
+
+  case G4MICROMEGAS::CONFIG_BASELINE:
+  {
+    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_Z_ONE_SECTOR" << std::endl;
+    MicromegasTile::List tiles;
+
+    // for the first sector we put 4 tiles with full z coverage
+    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
+    static constexpr int ntiles_z = 4;
+    for (int i = 0; i < ntiles_z; ++i)
+    {
+      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles_z - 0.5), tile_width / radius, tile_length);
     }
 
-    case G4MICROMEGAS::CONFIG_PHI_ONE_RING:
+    // for the other sectors we put two tiles on either side of the central membrane
+    for (int i = 1; i < nsectors; ++i)
     {
-      // 12 tiles at mid rapidity, one in front of each TPC sector
-      std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_PHI_ONE_RING" << std::endl;
-      MicromegasTile::List tiles;
-      for (int i = 0; i < nsectors; ++i)
-      { tiles.emplace_back(2. * M_PI * (0.5 + i) / nsectors, 0, tile_width / radius, tile_length); }
-      reco->set_tiles(tiles);
-      break;
+      const double phi = phi0 + 2. * M_PI * i / nsectors;
+      tiles.emplace_back(phi, length * (1.5 / 4 - 0.5), tile_width / radius, tile_length);
+      tiles.emplace_back(phi, length * (2.5 / 4 - 0.5), tile_width / radius, tile_length);
     }
+    reco->set_tiles(tiles);
+    break;
+  }
 
-    case G4MICROMEGAS::CONFIG_Z_ONE_SECTOR:
+  case G4MICROMEGAS::CONFIG_MAXIMAL:
+  {
+    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MAXIMAL" << std::endl;
+    MicromegasTile::List tiles;
+
+    // 4 tiles with full z coverage in front of each TPC sector
+    static constexpr int ntiles_z = 4;
+    for (int iphi = 0; iphi < nsectors; ++iphi)
     {
-      // 4 tiles with full z coverage in front of one TPC sector
-      std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_Z_ONE_SECTOR" << std::endl;
-      MicromegasTile::List tiles;
-      static constexpr double phi0 = M_PI*(0.5 + 1./nsectors);
-      static constexpr int ntiles = 4;
-      for( int i = 0; i < ntiles; ++i )
-      { tiles.emplace_back( phi0, length*((0.5+i)/ntiles-0.5), tile_width/radius, tile_length ); }
-      reco->set_tiles( tiles );
-      break;
-    }
-
-    case G4MICROMEGAS::CONFIG_BASELINE:
-    {
-      std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_Z_ONE_SECTOR" << std::endl;
-      MicromegasTile::List tiles;
-
-      // for the first sector we put 4 tiles with full z coverage
-      static constexpr double phi0 = M_PI*(0.5 + 1./nsectors);
-      static constexpr int ntiles_z = 4;
-      for( int i = 0; i < ntiles_z; ++i )
-      { tiles.emplace_back( phi0, length*((0.5+i)/ntiles_z-0.5), tile_width/radius, tile_length ); }
-
-      // for the other sectors we put two tiles on either side of the central membrane
-      for( int i = 1; i < nsectors; ++i )
+      const double phi = 2. * M_PI * (0.5 + iphi) / nsectors;
+      for (int iz = 0; iz < ntiles_z; ++iz)
       {
-        const double phi = phi0 + 2.*M_PI*i/nsectors;
-        tiles.emplace_back( phi, length*(1.5/4-0.5), tile_width/radius, tile_length );
-        tiles.emplace_back( phi, length*(2.5/4-0.5), tile_width/radius, tile_length );
+        tiles.emplace_back(phi, length * ((0.5 + iz) / ntiles_z - 0.5), tile_width / radius, tile_length);
       }
-      reco->set_tiles( tiles );
-      break;
     }
-
-    case G4MICROMEGAS::CONFIG_MAXIMAL:
-    {
-      std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MAXIMAL" << std::endl;
-      MicromegasTile::List tiles;
-
-      // 4 tiles with full z coverage in front of each TPC sector
-      static constexpr int ntiles_z = 4;
-      for (int iphi = 0; iphi < nsectors; ++iphi)
-      {
-        const double phi = 2. * M_PI * (0.5 + iphi) / nsectors;
-        for (int iz = 0; iz < ntiles_z; ++iz )
-        { tiles.emplace_back( phi, length*((0.5+iz)/ntiles_z-0.5), tile_width/radius, tile_length ); }
-      }
-      reco->set_tiles( tiles );
-      break;
-    }
+    reco->set_tiles(tiles);
+    break;
+  }
   }
 
   se->registerSubsystem(reco);

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4MVTX_C
 #define MACRO_G4MVTX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4mvtx/PHG4MvtxDefs.h>

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -38,17 +38,17 @@ namespace G4MVTX
   int n_maps_layer = 3;        // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
   double radius_offset = 0.7;  // clearance around radius
 
-  double single_stave_service_copper_area  = 0.0677; //Cross-sectional area of copper for 1 stave [cm^2]
-  double single_stave_service_water_area   = 0.0098; //Cross-sectional area of water for 1 stave [cm^2]
-  double single_stave_service_plastic_area = 0.4303; //Cross-sectional area of plastic for 1 stave [cm^2]
+  double single_stave_service_copper_area = 0.0677;   //Cross-sectional area of copper for 1 stave [cm^2]
+  double single_stave_service_water_area = 0.0098;    //Cross-sectional area of water for 1 stave [cm^2]
+  double single_stave_service_plastic_area = 0.4303;  //Cross-sectional area of plastic for 1 stave [cm^2]
 
-  const int n_service_layers = 1; //Number of service cable service_layers to generate
-  double service_layer_start_radius[] = {8.5}; //Inner radius of where the cables begin [cm]
-     int n_staves_service_layer[] = {48}; //Number of staves associated to each service layer
+  const int n_service_layers = 1;               //Number of service cable service_layers to generate
+  double service_layer_start_radius[] = {8.5};  //Inner radius of where the cables begin [cm]
+  int n_staves_service_layer[] = {48};          //Number of staves associated to each service layer
 
-  double service_barrel_radius = 10.75; // [cm] From final design review
-  double service_barrel_start  = -35; //[cm] Approx.
-  double service_barrel_length = 150; // [cm] length of service barrel ~(to patch panel)
+  double service_barrel_radius = 10.75;  // [cm] From final design review
+  double service_barrel_start = -35;     //[cm] Approx.
+  double service_barrel_length = 150;    // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTX
 
 void MvtxInit()
@@ -56,50 +56,50 @@ void MvtxInit()
   //BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, (PHG4MvtxDefs::mvtxdat[G4MVTX::n_maps_layer - 1][PHG4MvtxDefs::kRmd]) / 10. + G4MVTX::radius_offset);
   //BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 16.);
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MVTX::service_barrel_radius);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start));
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start));
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -17.);
 }
 
-double calculateArea( double inner_radius, double outer_radius ) //Calculate the area of a disk
+double calculateArea(double inner_radius, double outer_radius)  //Calculate the area of a disk
 {
-	return M_PI*( std::pow( outer_radius, 2 ) - std::pow( inner_radius, 2) );
+  return M_PI * (std::pow(outer_radius, 2) - std::pow(inner_radius, 2));
 }
 
-double calculateOR( double inner_radius, double area ) //Calculate the outer radius of a disk, knowing the inner radius and the area
+double calculateOR(double inner_radius, double area)  //Calculate the outer radius of a disk, knowing the inner radius and the area
 {
-	return std::sqrt( area/M_PI + std::pow( inner_radius, 2 ) );
+  return std::sqrt(area / M_PI + std::pow(inner_radius, 2));
 }
 
-void calculateMaterialBoundaries(int& service_layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius) //Calculate where the transition between each material occurs
+void calculateMaterialBoundaries(int& service_layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius)  //Calculate where the transition between each material occurs
 {
-   outer_copper_radius  = calculateOR( G4MVTX::service_layer_start_radius[service_layer_ID], G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_copper_area );
-   outer_water_radius   = calculateOR( outer_copper_radius, G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_water_area );
-   outer_plastic_radius = calculateOR( outer_water_radius, G4MVTX::n_staves_service_layer[service_layer_ID]*G4MVTX::single_stave_service_plastic_area );
+  outer_copper_radius = calculateOR(G4MVTX::service_layer_start_radius[service_layer_ID], G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_copper_area);
+  outer_water_radius = calculateOR(outer_copper_radius, G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_water_area);
+  outer_plastic_radius = calculateOR(outer_water_radius, G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_plastic_area);
 }
 
 double MVTXService(PHG4Reco* g4Reco, double radius)
 {
-// Note, cables are all south  
-// Setup service_layers
+  // Note, cables are all south
+  // Setup service_layers
   bool AbsorberActive = Enable::ABSORBER || Enable::MVTX_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
 
-  double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers]; //Objects for material outer radii
+  double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers];  //Objects for material outer radii
   int subsystem_service_layer = 0;
   std::string copper_name, water_name, plastic_name;
   PHG4CylinderSubsystem* cyl;
 
-  for (int i = 0; i < G4MVTX::n_service_layers; ++i) //Build a service_layer of copper, then water, then plastic
+  for (int i = 0; i < G4MVTX::n_service_layers; ++i)  //Build a service_layer of copper, then water, then plastic
   {
     calculateMaterialBoundaries(i, copper_OR[i], water_OR[i], plastic_OR[i]);
 
-    copper_name  = "MVTX_Service_copper_service_layer_"  + std::to_string(i);
-    water_name   = "MVTX_Service_water_service_layer_"   + std::to_string(i);
+    copper_name = "MVTX_Service_copper_service_layer_" + std::to_string(i);
+    water_name = "MVTX_Service_water_service_layer_" + std::to_string(i);
     plastic_name = "MVTX_Service_plastic_service_layer_" + std::to_string(i);
 
     cyl = new PHG4CylinderSubsystem(copper_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", G4MVTX::service_layer_start_radius[i]);
     cyl->set_int_param("lengthviarapidity", 0);
     cyl->set_double_param("length", G4MVTX::service_barrel_length);
@@ -112,7 +112,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     subsystem_service_layer += 1;
 
     cyl = new PHG4CylinderSubsystem(water_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", copper_OR[i]);
     cyl->set_int_param("lengthviarapidity", 0);
     cyl->set_double_param("length", G4MVTX::service_barrel_length);
@@ -125,7 +125,7 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     subsystem_service_layer += 1;
 
     cyl = new PHG4CylinderSubsystem(plastic_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
     cyl->set_double_param("radius", water_OR[i]);
     cyl->set_int_param("lengthviarapidity", 0);
     cyl->set_double_param("length", G4MVTX::service_barrel_length);
@@ -136,16 +136,15 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
     cyl->OverlapCheck(OverlapCheck);
     g4Reco->registerSubsystem(cyl);
     subsystem_service_layer += 1;
-
   }
 
   cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_service_layer", subsystem_service_layer);
-  cyl->set_double_param("place_z", -1*(G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
+  cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
   cyl->set_double_param("radius", G4MVTX::service_barrel_radius);
   cyl->set_int_param("lengthviarapidity", 0);
   cyl->set_double_param("length", G4MVTX::service_barrel_length);
-  cyl->set_string_param("material", "PEEK"); //Service barrel is carbon fibre (peek?)
-  cyl->set_double_param("thickness", 0.1); //Service barrel is 1mm thick
+  cyl->set_string_param("material", "PEEK");  //Service barrel is carbon fibre (peek?)
+  cyl->set_double_param("thickness", 0.1);    //Service barrel is 1mm thick
   cyl->SuperDetector("MVTXSERVICE");
   if (AbsorberActive) cyl->SetActive();
   cyl->OverlapCheck(OverlapCheck);
@@ -164,8 +163,8 @@ double MVTXService(PHG4Reco* g4Reco, double radius)
 
     for (int j = 0; j < G4MVTX::n_service_layers; ++j)
     {
-        cout << "  service_layer " << j << " starts at " << G4MVTX::service_layer_start_radius[j] << " cm" << endl;
-        cout << "  service_layer " << j << " services " << G4MVTX::n_staves_service_layer[j] << " staves" << endl;
+      cout << "  service_layer " << j << " starts at " << G4MVTX::service_layer_start_radius[j] << " cm" << endl;
+      cout << "  service_layer " << j << " services " << G4MVTX::n_staves_service_layer[j] << " staves" << endl;
     }
 
     cout << "  Service barrel radius = " << G4MVTX::service_barrel_radius << " cm" << endl;
@@ -238,6 +237,5 @@ void Mvtx_Clustering()
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
 }
-
 
 #endif

--- a/common/G4_Mvtx_EIC.C
+++ b/common/G4_Mvtx_EIC.C
@@ -3,8 +3,8 @@
 
 #include <GlobalVariables.C>
 
-#include <g4mvtx/PHG4MvtxDefs.h>
 #include <g4mvtx/PHG4EICMvtxSubsystem.h>
+#include <g4mvtx/PHG4MvtxDefs.h>
 
 #include <g4main/PHG4Reco.h>
 

--- a/common/G4_Mvtx_EIC.C
+++ b/common/G4_Mvtx_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4MVTXEIC_C
 #define MACRO_G4MVTXEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4mvtx/PHG4MvtxDefs.h>
 #include <g4mvtx/PHG4EICMvtxSubsystem.h>

--- a/common/G4_ParticleFlow.C
+++ b/common/G4_ParticleFlow.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PARTICLEFLOW_C
 #define MACRO_G4PARTICLEFLOW_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4jets/FastJetAlgo.h>
 

--- a/common/G4_ParticleFlow.C
+++ b/common/G4_ParticleFlow.C
@@ -31,8 +31,8 @@ void ParticleFlow()
 
   // note: assumes topoCluster input already configured
   ParticleFlowReco *pfr = new ParticleFlowReco();
-  pfr->set_energy_match_Nsigma( 1.5 );
-  pfr->set_emulated_efficiency( 1.0 );
+  pfr->set_energy_match_Nsigma(1.5);
+  pfr->set_emulated_efficiency(1.0);
   pfr->Verbosity(verbosity);
   se->registerSubsystem(pfr);
 

--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PIPE_C
 #define MACRO_G4PIPE_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4ConeSubsystem.h>
 #include <g4detectors/PHG4CylinderSubsystem.h>

--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -31,7 +31,7 @@ namespace G4PIPE
   double al_pipe_cone_length = 8.56;
 
   double al_pipe_ext_radius = 2.5005;
-  double al_pipe_ext_length = 60.0;   // extension beyond conical part
+  double al_pipe_ext_length = 60.0;  // extension beyond conical part
 }  // namespace G4PIPE
 
 void PipeInit()

--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PIPEEIC_C
 #define MACRO_G4PIPEEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4detectors/PHG4GDMLSubsystem.h>

--- a/common/G4_Piston.C
+++ b/common/G4_Piston.C
@@ -1,9 +1,9 @@
 #ifndef MACRO_G4PISTON_C
 #define MACRO_G4PISTON_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Pipe.C"
+#include <G4_Pipe.C>
 
 #include <g4detectors/PHG4ConeSubsystem.h>
 #include <g4detectors/PHG4CylinderSubsystem.h>

--- a/common/G4_PlugDoor.C
+++ b/common/G4_PlugDoor.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PLUGDOOR_C
 #define MACRO_G4PLUGDOOR_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_PlugDoor_EIC.C
+++ b/common/G4_PlugDoor_EIC.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PLUGDOOREIC_C
 #define MACRO_G4PLUGDOOREIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_PlugDoor_fsPHENIX.C
+++ b/common/G4_PlugDoor_fsPHENIX.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PLUGDOORFSPHENIX_C
 #define MACRO_G4PLUGDOORFSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_Production.C
+++ b/common/G4_Production.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4PRODUCTION_C
 #define MACRO_G4PRODUCTION_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 namespace Enable
 {

--- a/common/G4_RICH.C
+++ b/common/G4_RICH.C
@@ -8,7 +8,7 @@
 #ifndef MACRO_G4RICH_C
 #define MACRO_G4RICH_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4detectors/PHG4RICHSubsystem.h>
 

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -1,10 +1,10 @@
 #ifndef MACRO_G4TPC_C
 #define MACRO_G4TPC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Intt.C"
-#include "G4_Mvtx.C"
+#include <G4_Intt.C>
+#include <G4_Mvtx.C>
 
 #include <g4tpc/PHG4TpcDigitizer.h>
 #include <g4tpc/PHG4TpcElectronDrift.h>

--- a/common/G4_TPC_EIC.C
+++ b/common/G4_TPC_EIC.C
@@ -1,9 +1,9 @@
 #ifndef MACRO_G4TPCEIC_C
 #define MACRO_G4TPCEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Mvtx_EIC.C"
+#include <G4_Mvtx_EIC.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/common/G4_TopoClusterReco.C
+++ b/common/G4_TopoClusterReco.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4TOPOCLUSTERRECO_C
 #define MACRO_G4TOPOCLUSTERRECO_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <caloreco/RawClusterBuilderTopo.h>
 

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -27,8 +27,8 @@
 #include <trackreco/PHTruthVertexing.h>
 
 #if __cplusplus >= 201703L
-#include <trackreco/MakeActsGeometry.h>
 #include <trackreco/ActsEvaluator.h>
+#include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSourceLinks.h>
 #include <trackreco/PHActsTracks.h>
 #include <trackreco/PHActsTrkFitter.h>
@@ -324,30 +324,29 @@ void Tracking_Reco()
 
 #if __cplusplus >= 201703L
     /// Geometry must be built before any Acts modules
-    MakeActsGeometry *geom = new MakeActsGeometry();
+    MakeActsGeometry* geom = new MakeActsGeometry();
     geom->Verbosity(0);
     geom->setMagField(G4MAGNET::magfield);
     geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
     se->registerSubsystem(geom);
-    
+
     /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
-    PHActsSourceLinks *sl = new PHActsSourceLinks();
+    PHActsSourceLinks* sl = new PHActsSourceLinks();
     sl->Verbosity(0);
     sl->setMagField(G4MAGNET::magfield);
     sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
     se->registerSubsystem(sl);
-    
-    PHActsTracks *actsTracks = new PHActsTracks();
+
+    PHActsTracks* actsTracks = new PHActsTracks();
     actsTracks->Verbosity(0);
     se->registerSubsystem(actsTracks);
-    
-    PHActsTrkFitter *actsFit = new PHActsTrkFitter();
+
+    PHActsTrkFitter* actsFit = new PHActsTrkFitter();
     actsFit->Verbosity(0);
     actsFit->doTimeAnalysis(false);
     se->registerSubsystem(actsFit);
-      
-#endif   
-    
+
+#endif
   }
 
   return;

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -1,12 +1,12 @@
 #ifndef MACRO_G4TRACKING_C
 #define MACRO_G4TRACKING_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Intt.C"
-#include "G4_Micromegas.C"
-#include "G4_Mvtx.C"
-#include "G4_TPC.C"
+#include <G4_Intt.C>
+#include <G4_Micromegas.C>
+#include <G4_Mvtx.C>
+#include <G4_TPC.C>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -1,14 +1,14 @@
 #ifndef MACRO_G4TRACKINGEIC_C
 #define MACRO_G4TRACKINGEIC_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_CEmc_EIC.C"
-#include "G4_FEMC_EIC.C"
-#include "G4_FHCAL.C"
-#include "G4_GEM_EIC.C"
-#include "G4_Mvtx_EIC.C"
-#include "G4_TPC_EIC.C"
+#include <G4_CEmc_EIC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_GEM_EIC.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_TPC_EIC.C>
 
 #include <g4trackfastsim/PHG4TrackFastSim.h>
 

--- a/common/G4_World.C
+++ b/common/G4_World.C
@@ -22,11 +22,11 @@ void WorldInit(PHG4Reco *g4Reco)
 
 void WorldSize(PHG4Reco *g4Reco, double radius)
 {
-  double world_radius = std::max((BlackHoleGeometry::max_radius+BlackHoleGeometry::gap), radius);
+  double world_radius = std::max((BlackHoleGeometry::max_radius + BlackHoleGeometry::gap), radius);
   g4Reco->SetWorldSizeY(std::max(g4Reco->GetWorldSizeY(), world_radius + G4WORLD::AddSpace));
   // our world is a symmetric cylinder so the center is at 0/0/0, pick the largest of abs(min_z) || abs(max_z)
-  double min_zval = std::min((BlackHoleGeometry::min_z-BlackHoleGeometry::gap), -((g4Reco->GetWorldSizeZ() - 100) / 2.));
-  double max_zval = std::max((BlackHoleGeometry::max_z+BlackHoleGeometry::gap), (g4Reco->GetWorldSizeZ() - 100) / 2.);
+  double min_zval = std::min((BlackHoleGeometry::min_z - BlackHoleGeometry::gap), -((g4Reco->GetWorldSizeZ() - 100) / 2.));
+  double max_zval = std::max((BlackHoleGeometry::max_z + BlackHoleGeometry::gap), (g4Reco->GetWorldSizeZ() - 100) / 2.);
   double final_zval = std::max(fabs(min_zval), fabs(max_zval) + G4WORLD::AddSpace);
   g4Reco->SetWorldSizeZ(std::max(g4Reco->GetWorldSizeZ(), 2 * (final_zval)));
   return;

--- a/common/G4_World.C
+++ b/common/G4_World.C
@@ -1,7 +1,7 @@
 #ifndef MACRO_G4WORLD_C
 #define MACRO_G4WORLD_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
 #include <g4main/PHG4Reco.h>
 

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -52,4 +52,10 @@ namespace TRACKING
 {
   string TrackNodeName = "SvtxTrackMap";
 }
+
+namespace G4MAGNET
+{
+  double magfield_rescale = 1;
+  string magfield= string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
+}
 #endif

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -56,6 +56,6 @@ namespace TRACKING
 namespace G4MAGNET
 {
   double magfield_rescale = 1;
-  string magfield= string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
-}
+  string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
+}  // namespace G4MAGNET
 #endif

--- a/common/sPhenixStyle.C
+++ b/common/sPhenixStyle.C
@@ -2,29 +2,28 @@
 // sPHENIX Style, based on a style file from BaBar, v0.1
 //
 
-
 #include <sPhenixStyle.h>
 
-#include <TROOT.h>
 #include <TColor.h>
+#include <TROOT.h>
 
 #include <iostream>
 
-void SetsPhenixStyle ()
+void SetsPhenixStyle()
 {
   static TStyle* sphenixStyle = 0;
-  std::cout << "sPhenixStyle: Applying nominal settings." << std::endl ;
-  if ( sphenixStyle==0 ) sphenixStyle = sPhenixStyle();
+  std::cout << "sPhenixStyle: Applying nominal settings." << std::endl;
+  if (sphenixStyle == 0) sphenixStyle = sPhenixStyle();
   gROOT->SetStyle("sPHENIX");
   gROOT->ForceStyle();
 }
 
-TStyle* sPhenixStyle() 
+TStyle* sPhenixStyle()
 {
-  TStyle *sphenixStyle = new TStyle("sPHENIX","sPHENIX style");
+  TStyle* sphenixStyle = new TStyle("sPHENIX", "sPHENIX style");
 
   // use plain black on white colors
-  Int_t icol=0; // WHITE
+  Int_t icol = 0;  // WHITE
   sphenixStyle->SetFrameBorderMode(icol);
   sphenixStyle->SetFrameFillColor(icol);
   sphenixStyle->SetCanvasBorderMode(icol);
@@ -35,7 +34,7 @@ TStyle* sPhenixStyle()
   //sphenixStyle->SetFillColor(icol); // don't use: white fill color for *all* objects
 
   // set the paper & margin sizes
-  sphenixStyle->SetPaperSize(20,26);
+  sphenixStyle->SetPaperSize(20, 26);
 
   // set margin sizes
   sphenixStyle->SetPadTopMargin(0.05);
@@ -49,32 +48,32 @@ TStyle* sPhenixStyle()
 
   // use large fonts
   //Int_t font=72; // Helvetica italics
-  Int_t font=42; // Helvetica
-  Double_t tsize=0.05;
+  Int_t font = 42;  // Helvetica
+  Double_t tsize = 0.05;
   sphenixStyle->SetTextFont(font);
 
   sphenixStyle->SetTextSize(tsize);
-  sphenixStyle->SetLabelFont(font,"x");
-  sphenixStyle->SetTitleFont(font,"x");
-  sphenixStyle->SetLabelFont(font,"y");
-  sphenixStyle->SetTitleFont(font,"y");
-  sphenixStyle->SetLabelFont(font,"z");
-  sphenixStyle->SetTitleFont(font,"z");
-  
-  sphenixStyle->SetLabelSize(tsize,"x");
-  sphenixStyle->SetTitleSize(tsize,"x");
-  sphenixStyle->SetLabelSize(tsize,"y");
-  sphenixStyle->SetTitleSize(tsize,"y");
-  sphenixStyle->SetLabelSize(tsize,"z");
-  sphenixStyle->SetTitleSize(tsize,"z");
+  sphenixStyle->SetLabelFont(font, "x");
+  sphenixStyle->SetTitleFont(font, "x");
+  sphenixStyle->SetLabelFont(font, "y");
+  sphenixStyle->SetTitleFont(font, "y");
+  sphenixStyle->SetLabelFont(font, "z");
+  sphenixStyle->SetTitleFont(font, "z");
+
+  sphenixStyle->SetLabelSize(tsize, "x");
+  sphenixStyle->SetTitleSize(tsize, "x");
+  sphenixStyle->SetLabelSize(tsize, "y");
+  sphenixStyle->SetTitleSize(tsize, "y");
+  sphenixStyle->SetLabelSize(tsize, "z");
+  sphenixStyle->SetTitleSize(tsize, "z");
 
   // use bold lines and markers
   sphenixStyle->SetMarkerStyle(20);
   sphenixStyle->SetMarkerSize(1.2);
   sphenixStyle->SetHistLineWidth(2.);
-  sphenixStyle->SetLineStyleString(2,"[12 12]"); // postscript dashes
+  sphenixStyle->SetLineStyleString(2, "[12 12]");  // postscript dashes
 
-  // get rid of X error bars 
+  // get rid of X error bars
   //sphenixStyle->SetErrorX(0.001);
   // get rid of error bar caps
   sphenixStyle->SetEndErrorSize(0.);
@@ -95,8 +94,7 @@ TStyle* sPhenixStyle()
   sphenixStyle->SetLegendFillColor(0);
   sphenixStyle->SetLegendFont(font);
 
-
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6,00,0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 00, 0)
   std::cout << "sPhenixStyle: ROOT6 mode" << std::endl;
   sphenixStyle->SetLegendTextSize(tsize);
   sphenixStyle->SetPalette(kBird);
@@ -104,16 +102,14 @@ TStyle* sPhenixStyle()
   std::cout << "sPhenixStyle: ROOT5 mode" << std::endl;
   // color palette - manually define 'kBird' palette only available in ROOT 6
   Int_t alpha = 0;
-  Double_t stops[9] = { 0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000};
-  Double_t red[9]   = { 0.2082, 0.0592, 0.0780, 0.0232, 0.1802, 0.5301, 0.8186, 0.9956, 0.9764};
-  Double_t green[9] = { 0.1664, 0.3599, 0.5041, 0.6419, 0.7178, 0.7492, 0.7328, 0.7862, 0.9832};
-  Double_t blue[9]  = { 0.5293, 0.8684, 0.8385, 0.7914, 0.6425, 0.4662, 0.3499, 0.1968, 0.0539};
+  Double_t stops[9] = {0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000};
+  Double_t red[9] = {0.2082, 0.0592, 0.0780, 0.0232, 0.1802, 0.5301, 0.8186, 0.9956, 0.9764};
+  Double_t green[9] = {0.1664, 0.3599, 0.5041, 0.6419, 0.7178, 0.7492, 0.7328, 0.7862, 0.9832};
+  Double_t blue[9] = {0.5293, 0.8684, 0.8385, 0.7914, 0.6425, 0.4662, 0.3499, 0.1968, 0.0539};
   TColor::CreateGradientColorTable(9, stops, red, green, blue, 255, alpha);
 #endif
 
   sphenixStyle->SetNumberContours(80);
 
   return sphenixStyle;
-
 }
-

--- a/common/sPhenixStyle.C
+++ b/common/sPhenixStyle.C
@@ -3,7 +3,7 @@
 //
 
 
-#include "sPhenixStyle.h"
+#include <sPhenixStyle.h>
 
 #include <TROOT.h>
 #include <TColor.h>

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -125,8 +125,8 @@ int Fun4All_G4_EICDetector(
     else
     {
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform);
+                                                                                PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
@@ -166,10 +166,10 @@ int Fun4All_G4_EICDetector(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4,100e-4,30,0);//optional collision smear in space, time
-//    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 30, 0);  //optional collision smear in space, time
+                                                                                            //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Gaus);
+    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     //! embedding ID for the event
     //! positive ID is the embedded event of interest, e.g. jetty event from pythia
     //! negative IDs are backgrounds, .e.g out of time pile up collisions
@@ -180,8 +180,8 @@ int Fun4All_G4_EICDetector(
   // register all input generators with Fun4All
   InputRegister();
 
-// set up production relatedstuff
-//   Enable::PRODUCTION = true;
+  // set up production relatedstuff
+  //   Enable::PRODUCTION = true;
 
   //======================
   // Write the DST
@@ -221,7 +221,7 @@ int Fun4All_G4_EICDetector(
   // mvtx/tpc tracker
   Enable::MVTX = true;
   Enable::TPC = true;
-//  Enable::TPC_ENDCAP = true;
+  //  Enable::TPC_ENDCAP = true;
 
   Enable::TRACKING = true;
   Enable::TRACKING_EVAL = Enable::TRACKING && true;
@@ -499,15 +499,15 @@ int Fun4All_G4_EICDetector(
     gROOT->ProcessLine("Fun4AllServer *se = Fun4AllServer::instance();");
     gROOT->ProcessLine("PHG4Reco *g4 = (PHG4Reco *) se->getSubsysReco(\"PHG4RECO\");");
 
-    cout <<"-------------------------------------------------"<<endl;
-    cout <<"You are in event display mode. Run one event with"<<endl;
-    cout <<"se->run(1)"<<endl;
-    cout <<"Run Geant4 command with following examples"<<endl;
+    cout << "-------------------------------------------------" << endl;
+    cout << "You are in event display mode. Run one event with" << endl;
+    cout << "se->run(1)" << endl;
+    cout << "Run Geant4 command with following examples" << endl;
     gROOT->ProcessLine("displaycmd()");
 
     return 0;
   }
-// if we use a negative number of events we go back to the command line here
+  // if we use a negative number of events we go back to the command line here
   if (nEvents < 0)
   {
     return 0;

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -1,19 +1,19 @@
 #ifndef MACRO_FUN4ALLG4EICDETECTOR_C
 #define MACRO_FUN4ALLG4EICDETECTOR_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "DisplayOn.C"
-#include "G4Setup_EICDetector.C"
-#include "G4_Bbc.C"
-#include "G4_CaloTrigger.C"
-#include "G4_DSTReader_EICDetector.C"
-#include "G4_FwdJets.C"
-#include "G4_Global.C"
-#include "G4_HIJetReco.C"
-#include "G4_Input.C"
-#include "G4_Jets.C"
-#include "G4_Production.C"
+#include <DisplayOn.C>
+#include <G4Setup_EICDetector.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader_EICDetector.C>
+#include <G4_FwdJets.C>
+#include <G4_Global.C>
+#include <G4_HIJetReco.C>
+#include <G4_Input.C>
+#include <G4_Jets.C>
+#include <G4_Production.C>
 
 #include <TROOT.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
@@ -78,15 +78,18 @@ int Fun4All_G4_EICDetector(
 
   // Simple multi particle generator in eta/phi/pt ranges
   Input::SIMPLE = true;
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
   // Input::SIMPLE_VERBOSITY = 1;
 
   // Particle gun (same particles in always the same direction)
-  //  Input::GUN = true;
-  Input::GUN_VERBOSITY = 0;
+  // Input::GUN = true;
+  // Input::GUN_NUMBER = 3; // if you need 3 of them
+  // Input::GUN_VERBOSITY = 0;
 
   // Upsilon generator
-  //Input::UPSILON = true;
-  Input::UPSILON_VERBOSITY = 0;
+  // Input::UPSILON = true;
+  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  // Input::UPSILON_VERBOSITY = 0;
 
   // And/Or read generated particles from file
 
@@ -109,41 +112,46 @@ int Fun4All_G4_EICDetector(
   // can only be set after InputInit() is called
 
   // Simple Input generator:
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::SIMPLE)
   {
-    INPUTGENERATOR::SimpleEventGenerator->add_particles("pi-", 5);
+    INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
     if (Input::HEPMC || Input::EMBED)
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_reuse_existing_vertex(true);
-      INPUTGENERATOR::SimpleEventGenerator->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
     }
     else
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_mean(0., 0., 0.);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_width(0., 0., 5.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
-    INPUTGENERATOR::SimpleEventGenerator->set_eta_range(-3, 3);
-    INPUTGENERATOR::SimpleEventGenerator->set_phi_range(-M_PI, M_PI);
-    INPUTGENERATOR::SimpleEventGenerator->set_pt_range(0.1, 20.);
-    INPUTGENERATOR::SimpleEventGenerator->Embed(2);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-3, 3);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.1, 20.);
   }
   // Upsilons
+  // if you run more than one of these Input::UPSILON_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::UPSILON)
   {
-    INPUTGENERATOR::VectorMesonGenerator->add_decay_particles("mu", 0);
-    INPUTGENERATOR::VectorMesonGenerator->set_rapidity_range(-1, 1);
-    INPUTGENERATOR::VectorMesonGenerator->set_pt_range(0., 10.);
+    INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("mu", 0);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_rapidity_range(-1, 1);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
-    INPUTGENERATOR::VectorMesonGenerator->set_upsilon_1s();
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
   }
   // particle gun
+  // if you run more than one of these Input::GUN_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::GUN)
   {
-    INPUTGENERATOR::Gun->AddParticle("pi-", 0, 1, 0);
-    INPUTGENERATOR::Gun->set_vtx(0, 0, 0);
+    INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
+    INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
   }
   // pythia6
   if (Input::PYTHIA6)

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -1,30 +1,30 @@
 #ifndef MACRO_G4SETUPEICDETECTOR_C
 #define MACRO_G4SETUPEICDETECTOR_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_Aerogel.C"
-#include "G4_Barrel_EIC.C"
-#include "G4_BlackHole.C"
-#include "G4_CEmc_EIC.C"
-#include "G4_DIRC.C"
-#include "G4_EEMC.C"
-#include "G4_FEMC_EIC.C"
-#include "G4_FHCAL.C"
-#include "G4_FST_EIC.C"
-#include "G4_GEM_EIC.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Input.C"
-#include "G4_Magnet.C"
-#include "G4_Mvtx_EIC.C"
-#include "G4_Pipe_EIC.C"
-#include "G4_PlugDoor_EIC.C"
-#include "G4_RICH.C"
-#include "G4_TPC_EIC.C"
-#include "G4_Tracking_EIC.C"
-#include "G4_User.C"
-#include "G4_World.C"
+#include <G4_Aerogel.C>
+#include <G4_Barrel_EIC.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_EIC.C>
+#include <G4_DIRC.C>
+#include <G4_EEMC.C>
+#include <G4_FEMC_EIC.C>
+#include <G4_FHCAL.C>
+#include <G4_FST_EIC.C>
+#include <G4_GEM_EIC.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Input.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx_EIC.C>
+#include <G4_Pipe_EIC.C>
+#include <G4_PlugDoor_EIC.C>
+#include <G4_RICH.C>
+#include <G4_TPC_EIC.C>
+#include <G4_Tracking_EIC.C>
+#include <G4_User.C>
+#include <G4_World.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -1,18 +1,18 @@
 #ifndef MACRO_FUN4ALLG4FSPHENIX_C
 #define MACRO_FUN4ALLG4FSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "DisplayOn.C"
-#include "G4Setup_fsPHENIX.C"
-#include "G4_Bbc.C"
-#include "G4_CaloTrigger.C"
-#include "G4_DSTReader_fsPHENIX.C"
-#include "G4_FwdJets.C"
-#include "G4_Global.C"
-#include "G4_Input.C"
-#include "G4_Jets.C"
-#include "G4_Production.C"
+#include <DisplayOn.C>
+#include <G4Setup_fsPHENIX.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader_fsPHENIX.C>
+#include <G4_FwdJets.C>
+#include <G4_Global.C>
+#include <G4_Input.C>
+#include <G4_Jets.C>
+#include <G4_Production.C>
 
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllOutputManager.h>
@@ -77,14 +77,21 @@ int Fun4All_G4_fsPHENIX(
   INPUTEMBED::filename = embed_input_file;
 
   Input::SIMPLE = true;
-  //Input::SIMPLE_VERBOSITY = 1;
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
+  // Input::SIMPLE_VERBOSITY = 1;
 
   //  Input::PYTHIA6 = true;
 
   //  Input::PYTHIA8 = true;
 
   //  Input::GUN = true;
-  //Input::GUN_VERBOSITY = 0;
+  //  Input::GUN_NUMBER = 3; // if you need 3 of them
+  // Input::GUN_VERBOSITY = 1;
+
+  // Upsilon generator
+  //  Input::UPSILON = true;
+  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  // Input::UPSILON_VERBOSITY = 0;
 
 //  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
@@ -105,39 +112,39 @@ int Fun4All_G4_fsPHENIX(
   // Simple Input generator:
   if (Input::SIMPLE)
   {
-    INPUTGENERATOR::SimpleEventGenerator->add_particles("pi-", 5);
+    INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
     if (Input::HEPMC || Input::EMBED)
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_reuse_existing_vertex(true);
-      INPUTGENERATOR::SimpleEventGenerator->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
     }
     else
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_mean(0., 0., 0.);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_width(0., 0., 5.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
-    INPUTGENERATOR::SimpleEventGenerator->set_eta_range(-1, 3);
-    INPUTGENERATOR::SimpleEventGenerator->set_phi_range(-M_PI, M_PI);
-    INPUTGENERATOR::SimpleEventGenerator->set_pt_range(0.5, 50.);
-    INPUTGENERATOR::SimpleEventGenerator->Embed(2);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1, 3);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.5, 50.);
+    INPUTGENERATOR::SimpleEventGenerator[0]->Embed(2);
   }
   // Upsilons
   if (Input::UPSILON)
   {
-    INPUTGENERATOR::VectorMesonGenerator->add_decay_particles("mu", 0);
-    INPUTGENERATOR::VectorMesonGenerator->set_rapidity_range(-1, 1);
-    INPUTGENERATOR::VectorMesonGenerator->set_pt_range(0., 10.);
+    INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("mu", 0);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_rapidity_range(-1, 1);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
-    INPUTGENERATOR::VectorMesonGenerator->set_upsilon_1s();
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
   }
   // particle gun
   if (Input::GUN)
   {
-    INPUTGENERATOR::Gun->AddParticle("pi-", 0, 1, 0);
-    INPUTGENERATOR::Gun->set_vtx(0, 0, 0);
+    INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
+    INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
   }
 
   //--------------

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -93,7 +93,7 @@ int Fun4All_G4_fsPHENIX(
   // Input::UPSILON_NUMBER = 3; // if you need 3 of them
   // Input::UPSILON_VERBOSITY = 0;
 
-//  Input::HEPMC = true;
+  //  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
 
   // Event pile up simulation with collision rate in Hz MB collisions.
@@ -110,6 +110,8 @@ int Fun4All_G4_fsPHENIX(
   // can only be set after InputInit() is called
 
   // Simple Input generator:
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::SIMPLE)
   {
     INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
@@ -121,8 +123,8 @@ int Fun4All_G4_fsPHENIX(
     else
     {
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform);
+                                                                                PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
@@ -132,6 +134,8 @@ int Fun4All_G4_fsPHENIX(
     INPUTGENERATOR::SimpleEventGenerator[0]->Embed(2);
   }
   // Upsilons
+  // if you run more than one of these Input::UPSILON_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::UPSILON)
   {
     INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("mu", 0);
@@ -141,6 +145,8 @@ int Fun4All_G4_fsPHENIX(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
   }
   // particle gun
+  // if you run more than one of these Input::GUN_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::GUN)
   {
     INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
@@ -503,7 +509,7 @@ int Fun4All_G4_fsPHENIX(
     return 0;
   }
 
-// if we use a negative number of events we go back to the command line here
+  // if we use a negative number of events we go back to the command line here
   if (nEvents < 0)
   {
     return 0;

--- a/detectors/fsPHENIX/G4Setup_fsPHENIX.C
+++ b/detectors/fsPHENIX/G4Setup_fsPHENIX.C
@@ -1,24 +1,24 @@
 #ifndef MACRO_G4SETUPFSPHENIX_C
 #define MACRO_G4SETUPFSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_BlackHole.C"
-#include "G4_CEmc_Spacal.C"
-#include "G4_FEMC.C"
-#include "G4_FGEM_fsPHENIX.C"
-#include "G4_FHCAL.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Magnet.C"
-#include "G4_Mvtx.C"
-#include "G4_Pipe.C"
-#include "G4_Piston.C"
-#include "G4_PlugDoor_fsPHENIX.C"
-#include "G4_TPC.C"
-#include "G4_Tracking.C"
-#include "G4_User.C"
-#include "G4_World.C"
+#include <G4_BlackHole.C>
+#include <G4_CEmc_Spacal.C>
+#include <G4_FEMC.C>
+#include <G4_FGEM_fsPHENIX.C>
+#include <G4_FHCAL.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Magnet.C>
+#include <G4_Mvtx.C>
+#include <G4_Pipe.C>
+#include <G4_Piston.C>
+#include <G4_PlugDoor_fsPHENIX.C>
+#include <G4_TPC.C>
+#include <G4_Tracking.C>
+#include <G4_User.C>
+#include <G4_World.C>
 
 #include <g4eval/PHG4DstCompressReco.h>
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -1,21 +1,21 @@
 #ifndef MACRO_FUN4ALLG4SPHENIX_C
 #define MACRO_FUN4ALLG4SPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "DisplayOn.C"
-#include "G4Setup_sPHENIX.C"
-#include "G4_Bbc.C"
-#include "G4_CaloTrigger.C"
-#include "G4_DSTReader.C"
-#include "G4_Global.C"
-#include "G4_HIJetReco.C"
-#include "G4_Input.C"
-#include "G4_Jets.C"
-#include "G4_ParticleFlow.C"
-#include "G4_Production.C"
-#include "G4_TopoClusterReco.C"
-#include "G4_Tracking.C"
+#include <DisplayOn.C>
+#include <G4Setup_sPHENIX.C>
+#include <G4_Bbc.C>
+#include <G4_CaloTrigger.C>
+#include <G4_DSTReader.C>
+#include <G4_Global.C>
+#include <G4_HIJetReco.C>
+#include <G4_Input.C>
+#include <G4_Jets.C>
+#include <G4_ParticleFlow.C>
+#include <G4_Production.C>
+#include <G4_TopoClusterReco.C>
+#include <G4_Tracking.C>
 
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllOutputManager.h>
@@ -78,18 +78,21 @@ int Fun4All_G4_sPHENIX(
   INPUTEMBED::filename = embed_input_file;
 
   Input::SIMPLE = true;
-  //Input::SIMPLE_VERBOSITY = 1;
+  // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
+  // Input::SIMPLE_VERBOSITY = 1;
 
   //  Input::PYTHIA6 = true;
 
   // Input::PYTHIA8 = true;
 
   //  Input::GUN = true;
-  //Input::GUN_VERBOSITY = 1;
+  //  Input::GUN_NUMBER = 3; // if you need 3 of them
+  // Input::GUN_VERBOSITY = 1;
 
   // Upsilon generator
   //  Input::UPSILON = true;
-  Input::UPSILON_VERBOSITY = 0;
+  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  // Input::UPSILON_VERBOSITY = 0;
 
   //  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
@@ -109,41 +112,47 @@ int Fun4All_G4_sPHENIX(
   // can only be set after InputInit() is called
 
   // Simple Input generator:
+// if you run more than one of these Input::SIMPLE_NUMBER > 1
+// add the settings for other with [1], next with [2]...
   if (Input::SIMPLE)
   {
-    INPUTGENERATOR::SimpleEventGenerator->add_particles("pi-", 5);
+    INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
     if (Input::HEPMC || Input::EMBED)
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_reuse_existing_vertex(true);
-      INPUTGENERATOR::SimpleEventGenerator->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
     }
     else
     {
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform,
                                                                              PHG4SimpleEventGenerator::Uniform);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_mean(0., 0., 0.);
-      INPUTGENERATOR::SimpleEventGenerator->set_vertex_distribution_width(0., 0., 5.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
+      INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
-    INPUTGENERATOR::SimpleEventGenerator->set_eta_range(-1, 1);
-    INPUTGENERATOR::SimpleEventGenerator->set_phi_range(-M_PI, M_PI);
-    INPUTGENERATOR::SimpleEventGenerator->set_pt_range(0.1, 20.);
-    INPUTGENERATOR::SimpleEventGenerator->Embed(2);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_eta_range(-1, 1);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_phi_range(-M_PI, M_PI);
+    INPUTGENERATOR::SimpleEventGenerator[0]->set_pt_range(0.1, 20.);
+    INPUTGENERATOR::SimpleEventGenerator[0]->Embed(2);
   }
   // Upsilons
+// if you run more than one of these Input::UPSILON_NUMBER > 1
+// add the settings for other with [1], next with [2]...
   if (Input::UPSILON)
   {
-    INPUTGENERATOR::VectorMesonGenerator->add_decay_particles("e", 0);
-    INPUTGENERATOR::VectorMesonGenerator->set_rapidity_range(-1, 1);
-    INPUTGENERATOR::VectorMesonGenerator->set_pt_range(0., 10.);
+    INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("e", 0);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_rapidity_range(-1, 1);
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
-    INPUTGENERATOR::VectorMesonGenerator->set_upsilon_1s();
+    INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
   }
   // particle gun
+// if you run more than one of these Input::GUN_NUMBER > 1
+// add the settings for other with [1], next with [2]...
   if (Input::GUN)
   {
-    INPUTGENERATOR::Gun->AddParticle("pi-", 0, 1, 0);
-    INPUTGENERATOR::Gun->set_vtx(0, 0, 0);
+    INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
+    INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
   }
 
   //--------------

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -112,8 +112,8 @@ int Fun4All_G4_sPHENIX(
   // can only be set after InputInit() is called
 
   // Simple Input generator:
-// if you run more than one of these Input::SIMPLE_NUMBER > 1
-// add the settings for other with [1], next with [2]...
+  // if you run more than one of these Input::SIMPLE_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::SIMPLE)
   {
     INPUTGENERATOR::SimpleEventGenerator[0]->add_particles("pi-", 5);
@@ -125,8 +125,8 @@ int Fun4All_G4_sPHENIX(
     else
     {
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_function(PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform,
-                                                                             PHG4SimpleEventGenerator::Uniform);
+                                                                                PHG4SimpleEventGenerator::Uniform,
+                                                                                PHG4SimpleEventGenerator::Uniform);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_mean(0., 0., 0.);
       INPUTGENERATOR::SimpleEventGenerator[0]->set_vertex_distribution_width(0., 0., 5.);
     }
@@ -136,8 +136,8 @@ int Fun4All_G4_sPHENIX(
     INPUTGENERATOR::SimpleEventGenerator[0]->Embed(2);
   }
   // Upsilons
-// if you run more than one of these Input::UPSILON_NUMBER > 1
-// add the settings for other with [1], next with [2]...
+  // if you run more than one of these Input::UPSILON_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::UPSILON)
   {
     INPUTGENERATOR::VectorMesonGenerator[0]->add_decay_particles("e", 0);
@@ -147,8 +147,8 @@ int Fun4All_G4_sPHENIX(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
   }
   // particle gun
-// if you run more than one of these Input::GUN_NUMBER > 1
-// add the settings for other with [1], next with [2]...
+  // if you run more than one of these Input::GUN_NUMBER > 1
+  // add the settings for other with [1], next with [2]...
   if (Input::GUN)
   {
     INPUTGENERATOR::Gun[0]->AddParticle("pi-", 0, 1, 0);
@@ -496,7 +496,7 @@ int Fun4All_G4_sPHENIX(
     return 0;
   }
 
-// if we use a negative number of events we go back to the command line here
+  // if we use a negative number of events we go back to the command line here
   if (nEvents < 0)
   {
     return 0;
@@ -508,7 +508,6 @@ int Fun4All_G4_sPHENIX(
     cout << "it will run forever, so I just return without running anything" << endl;
     return 0;
   }
-
 
   se->skip(skip);
   se->run(nEvents);

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -4,8 +4,8 @@
 #include <GlobalVariables.C>
 
 #include <G4_BlackHole.C>
-#include <G4_CEmc_Spacal.C>
 #include <G4_CEmc_Albedo.C>
+#include <G4_CEmc_Spacal.C>
 #include <G4_EPD.C>
 #include <G4_FEMC.C>
 #include <G4_HcalIn_ref.C>

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -1,25 +1,25 @@
 #ifndef MACRO_G4SETUPSPHENIX_C
 #define MACRO_G4SETUPSPHENIX_C
 
-#include "GlobalVariables.C"
+#include <GlobalVariables.C>
 
-#include "G4_BlackHole.C"
-#include "G4_CEmc_Spacal.C"
-#include "G4_CEmc_Albedo.C"
-#include "G4_EPD.C"
-#include "G4_FEMC.C"
-#include "G4_HcalIn_ref.C"
-#include "G4_HcalOut_ref.C"
-#include "G4_Intt.C"
-#include "G4_Magnet.C"
-#include "G4_Micromegas.C"
-#include "G4_Mvtx.C"
-#include "G4_PSTOF.C"
-#include "G4_Pipe.C"
-#include "G4_PlugDoor.C"
-#include "G4_TPC.C"
-#include "G4_User.C"
-#include "G4_World.C"
+#include <G4_BlackHole.C>
+#include <G4_CEmc_Spacal.C>
+#include <G4_CEmc_Albedo.C>
+#include <G4_EPD.C>
+#include <G4_FEMC.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_Intt.C>
+#include <G4_Magnet.C>
+#include <G4_Micromegas.C>
+#include <G4_Mvtx.C>
+#include <G4_PSTOF.C>
+#include <G4_Pipe.C>
+#include <G4_PlugDoor.C>
+#include <G4_TPC.C>
+#include <G4_User.C>
+#include <G4_World.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 


### PR DESCRIPTION
This PR enables running multiple instances of every single particle generator (gun, simple and upsilon). That sadly needs a change in the Fun4All steering macros (add array index to generator when setting parameters). The tracking crashes when choosing different vertices for each of them though.
Replaces include "" by include <>. Together with a change in the ROOT_INCLUDE_PATH which now starts with ./, this enables local includes to be picked up - no matter where in the list of includes they show up. 
Moved some G4MAGNET settings to GlobalVars.C so it can be included in G4_Tracking.C (and G4_Magnet.C) which makes G4_Tracking.C loadable without previous loading of G4_Magnet.C