### PR TITLE
initialize magnet in MagnetInit() not in G4MAGNET namespace

### DIFF
--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -26,6 +26,14 @@ namespace G4MAGNET
 
 void MagnetInit()
 {
+  if (!isfinite(G4MAGNET::magfield_rescale))
+  {
+    G4MAGNET::magfield_rescale = 1.;
+  }
+  if (G4MAGNET::magfield.empty())
+  {
+    G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
+  }
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MAGNET::magnet_outer_cryostat_wall_radius + G4MAGNET::magnet_outer_cryostat_wall_thickness);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4MAGNET::magnet_length / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4MAGNET::magnet_length / 2.);

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -55,7 +55,10 @@ namespace TRACKING
 
 namespace G4MAGNET
 {
-  double magfield_rescale = 1;
-  string magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
+  // initialize to garbage values - the override is done in the respective
+  // MagnetInit() functions. If used standalone (without the G4_Magnet include)
+  // like in the tracking - those need to be set in the Fun4All macro
+  double magfield_rescale = NAN;
+  string magfield;
 }  // namespace G4MAGNET
 #endif


### PR DESCRIPTION
The previous implementation which initialized the sPHENIX default for the G4MAGNET namespace in GlobalVariables.C ran into problems when other magnets try to overwrite those. The solution is to initialize the variables to some garbage (NAN and empty string) and then set them in MagnetInit() if there were not set.
If other macros use this without going through the magnet - they need to set those variables