### PR TITLE
Fix magnet

### DIFF
--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -24,7 +24,7 @@ namespace G4MAGNET
   double magnet_length = 379.;
 }  // namespace G4MAGNET
 
-void MagnetInit()
+void MagnetFieldInit()
 {
   if (!isfinite(G4MAGNET::magfield_rescale))
   {
@@ -34,6 +34,11 @@ void MagnetInit()
   {
     G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sPHENIX.2d.root");
   }
+}
+
+void MagnetInit()
+{
+  MagnetFieldInit();
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MAGNET::magnet_outer_cryostat_wall_radius + G4MAGNET::magnet_outer_cryostat_wall_thickness);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4MAGNET::magnet_length / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4MAGNET::magnet_length / 2.);

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -60,104 +60,29 @@ void G4Init()
   }
 
   // load detector/material macros and execute Init() function
-  if (Enable::PIPE)
-  {
-    PipeInit();
-  }
-
-  if (Enable::PLUGDOOR)
-  {
-    PlugDoorInit();
-  }
-
-  if (Enable::EGEM)
-  {
-    EGEM_Init();
-  }
-  if (Enable::FGEM)
-  {
-    FGEM_Init();
-  }
-  if (Enable::FST)
-  {
-    FST_Init();
-  }
-  if (Enable::BARREL)
-  {
-    BarrelInit();
-  }
-  if (Enable::MVTX)
-  {
-    MvtxInit();
-  }
-  if (Enable::TPC)
-  {
-    TPCInit();
-  }
-  if (Enable::TRACKING)
-  {
-    TrackingInit();
-  }
-
+  if (Enable::PIPE) PipeInit();
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::EGEM) EGEM_Init();
+  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FST) FST_Init();
+  if (Enable::BARREL) BarrelInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::TPC) TPCInit();
+  if (Enable::TRACKING) TrackingInit();
   if (Enable::BBC) BbcInit();
-
-  if (Enable::CEMC)
-  {
-    CEmcInit(72);  // make it 2*2*2*3*3 so we can try other combinations
-  }
-
-  if (Enable::HCALIN)
-  {
-    HCalInnerInit(1);
-  }
-
-  if (Enable::MAGNET)
-  {
-    MagnetInit();
-  }
-  if (Enable::HCALOUT)
-  {
-    HCalOuterInit();
-  }
-
-  if (Enable::FEMC)
-  {
-    FEMCInit();
-  }
-
-  if (Enable::FHCAL)
-  {
-    FHCALInit();
-  }
-
-  if (Enable::EEMC)
-  {
-    EEMCInit();
-  }
-
-  if (Enable::DIRC)
-  {
-    DIRCInit();
-  }
-
-  if (Enable::RICH)
-  {
-    RICHInit();
-  }
-
-  if (Enable::AEROGEL)
-  {
-    AerogelInit();
-  }
-  if (Enable::USER)
-  {
-    UserInit();
-  }
-
-  if (Enable::BLACKHOLE)
-  {
-    BlackHoleInit();
-  }
+  if (Enable::CEMC) CEmcInit(72);  // make it 2*2*2*3*3 so we can try other combinations
+  if (Enable::HCALIN) HCalInnerInit(1);
+  if (Enable::MAGNET) MagnetInit();
+  MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::FEMC) FEMCInit();
+  if (Enable::FHCAL) FHCALInit();
+  if (Enable::EEMC) EEMCInit();
+  if (Enable::DIRC) DIRCInit();
+  if (Enable::RICH) RICHInit();
+  if (Enable::AEROGEL) AerogelInit();
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
 }
 
 int G4Setup()
@@ -203,132 +128,42 @@ int G4Setup()
   }
   g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
 
+// the radius is an older protection against overlaps, it is not
+// clear how well this works nowadays but it doesn't hurt either
   double radius = 0.;
 
-  //----------------------------------------
-  // PIPE
-  if (Enable::PIPE)
-  {
-    radius = Pipe(g4Reco, radius);
-  }
-  //----------------------------------------
-
-  if (Enable::EGEM)
-  {
-    EGEMSetup(g4Reco);
-  }
-
-  if (Enable::FGEM)
-  {
-    FGEMSetup(g4Reco);
-  }
-  if (Enable::FST)
-  {
-    FSTSetup(g4Reco);
-  }
-  if (Enable::BARREL)
-  {
-    Barrel(g4Reco, radius);
-  }
-  if (Enable::MVTX)
-  {
-    radius = Mvtx(g4Reco, radius);
-  }
-  if (Enable::TPC)
-  {
-    radius = TPC(g4Reco, radius);
-  }
-
-  //----------------------------------------
-  // BBC
-
+  if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  if (Enable::EGEM) EGEMSetup(g4Reco);
+  if (Enable::FGEM) FGEMSetup(g4Reco);
+  if (Enable::FST) FSTSetup(g4Reco);
+  if (Enable::BARREL) Barrel(g4Reco, radius);
+  if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
+  if (Enable::TPC) radius = TPC(g4Reco, radius);
   if (Enable::BBC) Bbc(g4Reco);
-
-  //----------------------------------------
-  // CEMC
-  //
-  if (Enable::CEMC)
-  {
-    radius = CEmc(g4Reco, radius);
-  }
-
-  //----------------------------------------
-  // HCALIN
-
-  if (Enable::HCALIN)
-  {
-    radius = HCalInner(g4Reco, radius, 4);
-  }
-  //----------------------------------------
-  // MAGNET
-
-  if (Enable::MAGNET)
-  {
-    radius = Magnet(g4Reco, radius);
-  }
-  //----------------------------------------
-  // HCALOUT
-
-  if (Enable::HCALOUT)
-  {
-    radius = HCalOuter(g4Reco, radius, 4);
-  }
-  //----------------------------------------
-  // FEMC
-
-  if (Enable::FEMC)
-  {
-    FEMCSetup(g4Reco);
-  }
-
-  //----------------------------------------
-  // FHCAL
-
-  if (Enable::FHCAL)
-  {
-    FHCALSetup(g4Reco);
-  }
-  //----------------------------------------
-  // EEMC
-
-  if (Enable::EEMC)
-  {
-    EEMCSetup(g4Reco);
-  }
+  if (Enable::CEMC) radius = CEmc(g4Reco, radius);
+  if (Enable::HCALIN) radius = HCalInner(g4Reco, radius, 4);
+  if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
+  if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
+  if (Enable::FEMC) FEMCSetup(g4Reco);
+  if (Enable::FHCAL) FHCALSetup(g4Reco);
+  if (Enable::EEMC) EEMCSetup(g4Reco);
 
   //----------------------------------------
   // PID
 
-  if (Enable::DIRC)
-  {
-    DIRCSetup(g4Reco);
-  }
+  if (Enable::DIRC) DIRCSetup(g4Reco);
+  if (Enable::RICH) RICHSetup(g4Reco);
+  if (Enable::AEROGEL) AerogelSetup(g4Reco);
 
-  if (Enable::RICH)
-  {
-    RICHSetup(g4Reco);
-  }
-
-  if (Enable::AEROGEL)
-  {
-    AerogelSetup(g4Reco);
-  }
   //----------------------------------------
   // sPHENIX forward flux return door
-  if (Enable::PLUGDOOR)
-  {
-    PlugDoor(g4Reco);
-  }
-  if (Enable::USER)
-  {
-    UserDetector(g4Reco);
+  if (Enable::PLUGDOOR) PlugDoor(g4Reco);
+
+  if (Enable::USER) UserDetector(g4Reco);
   }
   //----------------------------------------
   // BLACKHOLE if enabled, needs info from all previous sub detectors for dimensions
-  if (Enable::BLACKHOLE)
-  {
-    BlackHole(g4Reco, radius);
-  }
+  if (Enable::BLACKHOLE) BlackHole(g4Reco, radius);
 
   PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
   g4Reco->registerSubsystem(truth);

--- a/detectors/fsPHENIX/G4Setup_fsPHENIX.C
+++ b/detectors/fsPHENIX/G4Setup_fsPHENIX.C
@@ -50,6 +50,8 @@ void G4Init()
   if (Enable::CEMC) CEmcInit();
   if (Enable::HCALIN) HCalInnerInit();
   if (Enable::MAGNET) MagnetInit();
+// We want the field - even if the magnet volume is disabled
+  MagnetFieldInit();
   if (Enable::HCALOUT) HCalOuterInit();
   if (Enable::FGEM) FGEM_Init();
   if (Enable::FEMC) FEMCInit();

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -75,6 +75,8 @@ void G4Init()
   {
     MagnetInit();
   }
+// We want the field - even if the magnet volume is disabled
+  MagnetFieldInit();
   if (Enable::HCALOUT)
   {
     HCalOuterInit();


### PR DESCRIPTION
This PR fixes an unwanted side effect of the change of the initialization of the magnet fieldmap and scale factor. If the magnet is disabled in the Fun4All macro, those values were not initialized anymore leading to a crash. Now the those values are initialized in G4Setup no matter if the magnet volume is enabled or not