### PR TITLE
ActsEvaluator Flag

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -81,7 +81,7 @@ namespace G4TRACKING
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
   bool use_init_vertexing = false;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
-
+  bool use_acts_evaluator = false;         // Turn to true for an acts evaluator which outputs acts specific information in a tuple
   int init_vertexing_min_zvtx_tracks = 2;  // PHInitZvertexing parameter for reducing spurious vertices, use 2 for Pythia8 events, 5 for large multiplicity events
                                            //default seed is PHTpcTracker
 
@@ -360,7 +360,7 @@ void Tracking_Reco()
   
   // Final fitting of tracks using Acts Kalman Filter
   //=================================
-  if(!G4TRACKING::use_Genfit && !G4TRACKING::SC_CALIBMODE)
+  if(!G4TRACKING::use_Genfit)
     {
       std::cout << "   Using Acts track fitting " << std::endl;
       
@@ -437,10 +437,13 @@ void Tracking_Eval(const std::string& outputfile)
   if(!G4TRACKING::use_Genfit && !G4TRACKING::SC_CALIBMODE)
   {
 #if __cplusplus >= 201703L
-      ActsEvaluator *actsEval = new ActsEvaluator(outputfile+"_acts.root", eval);
-      actsEval->Verbosity(0);
-      actsEval->setEvalCKF(false);
-      se->registerSubsystem(actsEval);
+    if(use_acts_evaluator)
+      {
+	ActsEvaluator *actsEval = new ActsEvaluator(outputfile+"_acts.root", eval);
+	actsEval->Verbosity(0);
+	actsEval->setEvalCKF(false);
+	se->registerSubsystem(actsEval);
+      }
 #endif
   }
 

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -437,7 +437,7 @@ void Tracking_Eval(const std::string& outputfile)
   if(!G4TRACKING::use_Genfit && !G4TRACKING::SC_CALIBMODE)
   {
 #if __cplusplus >= 201703L
-    if(use_acts_evaluator)
+    if(G4TRACKING::use_acts_evaluator)
       {
 	ActsEvaluator *actsEval = new ActsEvaluator(outputfile+"_acts.root", eval);
 	actsEval->Verbosity(0);


### PR DESCRIPTION
This PR adds a flag for running the ActsEvaluator. It also removes the SC flag for running the acts track fitting chain so that it can be run either with or without space charge distortions.