### PR TITLE
Fix track associations to calorimeters

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -263,12 +263,6 @@ void Tracking_Reco()
 
     se->registerSubsystem(kalman);
 
-    //------------------
-    // Track Projections
-    //------------------
-    PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
-    projection->Verbosity(verbosity);
-    se->registerSubsystem(projection);
   }
   
   // Acts tracking chain (starts from TPC track seeds)
@@ -401,6 +395,13 @@ void Tracking_Reco()
 	}
 #endif
     }
+
+  //------------------
+  // Track Projections
+  //------------------
+  PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
+  projection->Verbosity(verbosity);
+  se->registerSubsystem(projection);
   
   return;
 }


### PR DESCRIPTION
PHGenFitTrackProjection was inside the Genfit tracking section, so when Acts tracking was run, the associations to the calorimeters were not being made. Moved it to the end of Tracking_reco() so that it will be run for either Genfit or Acts tracking.