### PR TITLE
Tpc distortion correction

### DIFF
--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -4,6 +4,7 @@
 #include <g4detectors/PHG4BbcSubsystem.h>
 
 #include <g4bbc/BbcVertexFastSimReco.h>
+#include <g4main/PHG4Reco.h>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -16,6 +16,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <tpc/TpcClusterizer.h>
+#include <tpc/TpcSpaceChargeCorrection.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -51,6 +52,14 @@ namespace G4TPC
     PHG4TpcElectronDrift::COORD_PHI|
     PHG4TpcElectronDrift::COORD_R|
     PHG4TpcElectronDrift::COORD_Z;
+
+  // distortion corrections
+  bool ENABLE_CORRECTIONS = false;
+  std::string correction_filename = "fluct_average.rev3.1side.3d.file0.h_negz.real_B1.4_E-400.0.ross_phi1_sphenix_phislice_lookup_r26xp40xz40.distortion_map.hist.root";
+  unsigned int correction_coordinates =
+    TpcSpaceChargeCorrection::COORD_PHI|
+    TpcSpaceChargeCorrection::COORD_R|
+    TpcSpaceChargeCorrection::COORD_Z;
 
 }  // namespace G4TPC
 
@@ -195,8 +204,18 @@ void TPC_Clustering()
 
   // For the Tpc
   //==========
-  TpcClusterizer* tpcclusterizer = new TpcClusterizer();
+  auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(verbosity);
   se->registerSubsystem(tpcclusterizer);
+
+  // space charge correction
+  if( G4TPC::ENABLE_CORRECTIONS )
+  {
+    auto tpcSpaceChargeCorrection = new TpcSpaceChargeCorrection;
+    tpcSpaceChargeCorrection->set_distortion_filename( G4TPC::correction_filename );
+    tpcSpaceChargeCorrection->set_coordinates( G4TPC::correction_coordinates );
+    se->registerSubsystem(tpcSpaceChargeCorrection);
+  }
+
 }
 #endif

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -135,6 +135,12 @@ void TrackingInit()
   if(G4TRACKING::use_Genfit)
     G4TRACKING::g4eval_use_initial_vertex = false;    
 
+  // For now the TpcSpaceChargeCorrection module only works with the GenFit tracking chain
+  if(G4TPC::ENABLE_CORRECTIONS && !G4TRACKING::use_Genfit)
+  {
+    std::cout << "Cannot enable space charge correction if not using GenFit tracking chain" << std::endl;
+    G4TPC::ENABLE_CORRECTIONS = false;
+  }
 }
 
 void Tracking_Reco()


### PR DESCRIPTION
This PR adds the TpcSpaceChargeCorrection module to the GenFit tracking chain. 
For now, the module will make Acts tracking fail because of the inability to assign clusters to the right surface once they have been moved in "r". So the G4_Tracking automatically disable the module if not running GenFit chain.
Also: fixed missing include in G4_Bbc.C

Question: 
Default filenames for G4TPC::distortion_filename and G4TPC::reconstruction_filename are local name:
  std::string distortion_filename = "fluct_average.rev3.1side.3d.file0.h_negz.real_B1.4_E-400.0.ross_phi1_sphenix_phislice_lookup_r26xp40xz40.distortion_map.hist.root";
  std::string correction_filename = "fluct_average.rev3.1side.3d.file0.h_negz.real_B1.4_E-400.0.ross_phi1_sphenix_phislice_lookup_r26xp40xz40.distortion_map.hist.root";
Should we not
- move the corresponding file to an official place (e.g. in $CALIBRATIONROOT)
- use the full path name in the macro (does full path understand env. variables ?), or make sure that the code looks in the official path if the file is not found in working directory ? 
This way, just turning on the flag would "magically" work.
