### PR TITLE
Add Acts track-to-calo projection

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -36,6 +36,7 @@
 #include <trackreco/PHActsVertexFinder.h>
 #include <trackreco/PHActsVertexFitter.h>
 #include <trackreco/PHTpcResiduals.h>
+#include <trackreco/PHActsTrackProjection.h>
 #endif
 
 #include <trackbase/TrkrHitTruthAssoc.h>
@@ -269,6 +270,13 @@ void Tracking_Reco()
 
     se->registerSubsystem(kalman);
 
+    //------------------
+    // Track Projections
+    //------------------
+    PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
+    projection->Verbosity(verbosity);
+    se->registerSubsystem(projection);
+    
   }
   
   // Acts tracking chain (starts from TPC track seeds)
@@ -367,47 +375,44 @@ void Tracking_Reco()
 #if __cplusplus >= 201703L
       /// Geometry must be built before any Acts modules
       MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(0);
+      geom->Verbosity(verbosity);
       geom->setMagField(G4MAGNET::magfield);
       geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(geom);
       
       /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
       PHActsSourceLinks* sl = new PHActsSourceLinks();
-      sl->Verbosity(0);
+      sl->Verbosity(verbosity);
       sl->setMagField(G4MAGNET::magfield);
       sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(sl);
       
       PHActsTracks* actsTracks = new PHActsTracks();
-      actsTracks->Verbosity(0);
+      actsTracks->Verbosity(verbosity);
       se->registerSubsystem(actsTracks);
       
       PHActsTrkFitter* actsFit = new PHActsTrkFitter();
-      actsFit->Verbosity(0);
+      actsFit->Verbosity(verbosity);
       actsFit->doTimeAnalysis(false);
       /// If running with distortions, fit only the silicon+MMs first
       actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
       se->registerSubsystem(actsFit);
       
-
       if(G4TRACKING::SC_CALIBMODE)
 	{
 	  /// run tpc residual determination with silicon+MM track fit
 	  PHTpcResiduals *residuals = new PHTpcResiduals();
-	  residuals->Verbosity(0);
+	  residuals->Verbosity(verbosity);
 	  se->registerSubsystem(residuals);
-
 	}
+
+      PHActsTrackProjection* actsProj = new PHActsTrackProjection();
+      actsProj->Verbosity(verbosity);
+      se->registerSubsystem(actsProj);
 #endif
     }
 
-  //------------------
-  // Track Projections
-  //------------------
-  PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
-  projection->Verbosity(verbosity);
-  se->registerSubsystem(projection);
+ 
   
   return;
 }


### PR DESCRIPTION
This PR puts the acts track-to-calo projection module in the acts tracking chain and the previous GenFit track-to-calo projection module in the GenFit tracking chain. This PR depends on the corresponding coresoftware [PR](https://github.com/sPHENIX-Collaboration/coresoftware/pull/980). 