### PR TITLE
Revert "Add Acts track-to-calo projection"

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -36,7 +36,6 @@
 #include <trackreco/PHActsVertexFinder.h>
 #include <trackreco/PHActsVertexFitter.h>
 #include <trackreco/PHTpcResiduals.h>
-#include <trackreco/PHActsTrackProjection.h>
 #endif
 
 #include <trackbase/TrkrHitTruthAssoc.h>
@@ -270,13 +269,6 @@ void Tracking_Reco()
 
     se->registerSubsystem(kalman);
 
-    //------------------
-    // Track Projections
-    //------------------
-    PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
-    projection->Verbosity(verbosity);
-    se->registerSubsystem(projection);
-    
   }
   
   // Acts tracking chain (starts from TPC track seeds)
@@ -375,44 +367,47 @@ void Tracking_Reco()
 #if __cplusplus >= 201703L
       /// Geometry must be built before any Acts modules
       MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(verbosity);
+      geom->Verbosity(0);
       geom->setMagField(G4MAGNET::magfield);
       geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(geom);
       
       /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
       PHActsSourceLinks* sl = new PHActsSourceLinks();
-      sl->Verbosity(verbosity);
+      sl->Verbosity(0);
       sl->setMagField(G4MAGNET::magfield);
       sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(sl);
       
       PHActsTracks* actsTracks = new PHActsTracks();
-      actsTracks->Verbosity(verbosity);
+      actsTracks->Verbosity(0);
       se->registerSubsystem(actsTracks);
       
       PHActsTrkFitter* actsFit = new PHActsTrkFitter();
-      actsFit->Verbosity(verbosity);
+      actsFit->Verbosity(0);
       actsFit->doTimeAnalysis(false);
       /// If running with distortions, fit only the silicon+MMs first
       actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
       se->registerSubsystem(actsFit);
       
+
       if(G4TRACKING::SC_CALIBMODE)
 	{
 	  /// run tpc residual determination with silicon+MM track fit
 	  PHTpcResiduals *residuals = new PHTpcResiduals();
-	  residuals->Verbosity(verbosity);
+	  residuals->Verbosity(0);
 	  se->registerSubsystem(residuals);
-	}
 
-      PHActsTrackProjection* actsProj = new PHActsTrackProjection();
-      actsProj->Verbosity(verbosity);
-      se->registerSubsystem(actsProj);
+	}
 #endif
     }
 
- 
+  //------------------
+  // Track Projections
+  //------------------
+  PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
+  projection->Verbosity(verbosity);
+  se->registerSubsystem(projection);
   
   return;
 }


### PR DESCRIPTION
This PR reverts the previous PR. It seems Jenkins found a bug in Acts in the way that Acts handles a particular error. Rather than returning an error, Acts just throws an exception which causes the code to crash. I've reported the bug and we will have to update versions once the developers fix things.

In the meantime, we'll revert this and just continue to use the GenFit track projection module.

Reverts sPHENIX-Collaboration/macros#334