### PR TITLE
replace G4double by double

### DIFF
--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -129,8 +129,8 @@ double Pipe(PHG4Reco* g4Reco, double radius)
 
   PHG4ConeSubsystem* cone = nullptr;
 
-  G4double cone_position = 0.5 * G4PIPE::be_pipe_length + G4PIPE::al_pipe_length + 0.5 * G4PIPE::al_pipe_cone_length;
-  G4double ext_position = 0.5 * G4PIPE::be_pipe_length + G4PIPE::al_pipe_length + G4PIPE::al_pipe_cone_length + 0.5 * G4PIPE::al_pipe_ext_length + no_overlapp;
+  double cone_position = 0.5 * G4PIPE::be_pipe_length + G4PIPE::al_pipe_length + 0.5 * G4PIPE::al_pipe_cone_length;
+  double ext_position = 0.5 * G4PIPE::be_pipe_length + G4PIPE::al_pipe_length + G4PIPE::al_pipe_cone_length + 0.5 * G4PIPE::al_pipe_ext_length + no_overlapp;
 
   /* north aluminum pipe (conical part) */
   cone = new PHG4ConeSubsystem("N_AL_PIPE_CONE", 6);


### PR DESCRIPTION
This PR replaces G4double in the macro. A change in the includes removed G4Types.hh and the use of G4double made it barf. Please do not use G4 typedefed variables