### PR TITLE
QA setup for new macros

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -2,6 +2,7 @@
 #define MACRO_G4CEMCSPACAL_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <g4detectors/PHG4CylinderCellReco.h>
 #include <g4detectors/PHG4CylinderGeom_Spacalv1.h>
@@ -21,6 +22,7 @@
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawClusterPositionCorrection.h>
 #include <caloreco/RawTowerCalibration.h>
+#include <qa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -34,6 +36,7 @@ R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
@@ -44,6 +47,7 @@ namespace Enable
   bool CEMC_TOWER = false;
   bool CEMC_CLUSTER = false;
   bool CEMC_EVAL = false;
+  bool CEMC_QA = false;
   int CEMC_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -471,4 +475,17 @@ void CEMC_Eval(const std::string &outputfile)
 
   return;
 }
+
+void CEMC_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::CEMC_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("CEMC");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
 #endif

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -3,6 +3,7 @@
 #define MACRO_G4HCALINREF_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <g4calo/HcalRawTowerBuilder.h>
 #include <g4calo/RawTowerDigitizer.h>
@@ -18,6 +19,7 @@
 #include <caloreco/RawClusterBuilderGraph.h>
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
+#include <qa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -25,6 +27,7 @@ R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 void HCalInner_SupportRing(PHG4Reco *g4Reco);
 
@@ -37,6 +40,7 @@ namespace Enable
   bool HCALIN_TOWER = false;
   bool HCALIN_CLUSTER = false;
   bool HCALIN_EVAL = false;
+  bool HCALIN_QA = false;
   int HCALIN_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -298,4 +302,17 @@ void HCALInner_Eval(const std::string &outputfile)
 
   return;
 }
+
+void HCALInner_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HCALIN_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("HCALIN");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
 #endif

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -2,6 +2,7 @@
 #define MACRO_G4HCALOUTREF_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <g4calo/HcalRawTowerBuilder.h>
 #include <g4calo/RawTowerDigitizer.h>
@@ -16,6 +17,7 @@
 #include <caloreco/RawClusterBuilderGraph.h>
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
+#include <qa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -23,6 +25,7 @@ R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
@@ -33,6 +36,7 @@ namespace Enable
   bool HCALOUT_TOWER = false;
   bool HCALOUT_CLUSTER = false;
   bool HCALOUT_EVAL = false;
+  bool HCALOUT_QA = false;
   int HCALOUT_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -224,4 +228,17 @@ void HCALOuter_Eval(const std::string &outputfile)
 
   return;
 }
+
+void HCALOuter_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HCALOUT_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeter *qa = new QAG4SimulationCalorimeter("HCALOUT");
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  return;
+}
+
 #endif

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -28,6 +28,8 @@
 #include <fun4all/Fun4AllNoSyncDstInputManager.h>
 #include <fun4all/Fun4AllServer.h>
 
+#include <set>
+
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libg4testbench.so)
 R__LOAD_LIBRARY(libPHPythia6.so)
@@ -50,22 +52,22 @@ namespace Input
   bool DZERO = false;
   int DZERO_NUMBER = 1;
   int DZERO_VERBOSITY = 0;
-  int DZERO_FirstEmbedId = 0;
+  std::set<int> DZERO_EmbedIds;
 
   bool GUN = false;
   int GUN_NUMBER = 1;
   int GUN_VERBOSITY = 0;
-  int GUN_FirstEmbedId = 0;
+  std::set<int> GUN_EmbedIds = 0;
 
   bool IONGUN = false;
   int IONGUN_NUMBER = 1;
   int IONGUN_VERBOSITY = 0;
-  int IONGUN_FirstEmbedId = 0;
+  std::set<int> IONGUN_EmbedIds = 0;
 
   bool PGEN = false;
   int PGEN_NUMBER = 1;
   int PGEN_VERBOSITY = 0;
-  int PGEN_FirstEmbedId = 0;
+  std::set<int> PGEN_EmbedIds = 0;
 
   bool SIMPLE = false;
   int SIMPLE_NUMBER = 1;
@@ -74,7 +76,7 @@ namespace Input
   bool UPSILON = false;
   int UPSILON_NUMBER = 1;
   int UPSILON_VERBOSITY = 0;
-  int UPSILON_FirstEmbedId = 0;
+  std::set<int> UPSILON_EmbedIds = 0;
 
   double PILEUPRATE = 0.;
   bool READHITS = false;
@@ -211,7 +213,7 @@ void InputInit()
       std::string name = "DZERO_" + std::to_string(i);
       PHG4ParticleGeneratorD0 *dzero = new PHG4ParticleGeneratorD0(name);
       dzero->Embed(Input::EmbedId);
-      if (i == 0) Input::DZERO_FirstEmbedId = Input::EmbedId;
+      Input::DZERO_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::DZeroMesonGenerator.push_back(dzero);
     }
@@ -223,7 +225,7 @@ void InputInit()
       std::string name = "GUN_" + std::to_string(i);
       PHG4ParticleGun *gun = new PHG4ParticleGun(name);
       gun->Embed(Input::EmbedId);
-      if (i == 0) Input::GUN_FirstEmbedId = Input::EmbedId;
+      Input::GUN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::Gun.push_back(gun);
     }
@@ -235,7 +237,7 @@ void InputInit()
       std::string name = "IONGUN_" + std::to_string(i);
       PHG4IonGun *iongun = new PHG4IonGun(name);
       iongun->Embed(Input::EmbedId);
-      if (i == 0) Input::IONGUN_FirstEmbedId = Input::EmbedId;
+      Input::IONGUN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::IonGun.push_back(iongun);
     }
@@ -247,6 +249,7 @@ void InputInit()
       std::string name = "PGEN_" + std::to_string(i);
       PHG4ParticleGenerator *pgen = new PHG4ParticleGenerator(name);
       pgen->Embed(Input::EmbedId);
+      Input::PGEN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::ParticleGenerator.push_back(pgen);
     }
@@ -258,7 +261,7 @@ void InputInit()
       std::string name = "EVTGENERATOR_" + std::to_string(i);
       PHG4SimpleEventGenerator *simple = new PHG4SimpleEventGenerator(name);
       simple->Embed(Input::EmbedId);
-      if (i == 0) Input::PGEN_FirstEmbedId = Input::EmbedId;
+      Input::PGEN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::SimpleEventGenerator.push_back(simple);
     }
@@ -270,7 +273,7 @@ void InputInit()
       std::string name = "UPSILON_" + std::to_string(i);
       PHG4ParticleGeneratorVectorMeson *upsilon = new PHG4ParticleGeneratorVectorMeson(name);
       upsilon->Embed(Input::EmbedId);
-      if (i == 0) Input::UPSILON_FirstEmbedId = Input::EmbedId;
+      Input::UPSILON_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
       INPUTGENERATOR::VectorMesonGenerator.push_back(upsilon);
     }

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -57,17 +57,17 @@ namespace Input
   bool GUN = false;
   int GUN_NUMBER = 1;
   int GUN_VERBOSITY = 0;
-  std::set<int> GUN_EmbedIds = 0;
+  std::set<int> GUN_EmbedIds;
 
   bool IONGUN = false;
   int IONGUN_NUMBER = 1;
   int IONGUN_VERBOSITY = 0;
-  std::set<int> IONGUN_EmbedIds = 0;
+  std::set<int> IONGUN_EmbedIds;
 
   bool PGEN = false;
   int PGEN_NUMBER = 1;
   int PGEN_VERBOSITY = 0;
-  std::set<int> PGEN_EmbedIds = 0;
+  std::set<int> PGEN_EmbedIds;
 
   bool SIMPLE = false;
   int SIMPLE_NUMBER = 1;
@@ -76,7 +76,7 @@ namespace Input
   bool UPSILON = false;
   int UPSILON_NUMBER = 1;
   int UPSILON_VERBOSITY = 0;
-  std::set<int> UPSILON_EmbedIds = 0;
+  std::set<int> UPSILON_EmbedIds;
 
   double PILEUPRATE = 0.;
   bool READHITS = false;

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -2,6 +2,7 @@
 #define MACRO_G4INTT_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <G4_Mvtx.C>
 
@@ -13,6 +14,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <intt/InttClusterizer.h>
+#include <qa_modules/QAG4SimulationIntt.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -21,6 +23,7 @@
 
 R__LOAD_LIBRARY(libg4intt.so)
 R__LOAD_LIBRARY(libintt.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
@@ -28,6 +31,7 @@ namespace Enable
   bool INTT_OVERLAPCHECK = false;
   bool INTT_CELL = false;
   bool INTT_CLUSTER = false;
+  bool INTT_QA = false;
   int INTT_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -186,4 +190,16 @@ void Intt_Clustering()
   }
   se->registerSubsystem(inttclusterizer);
 }
+
+
+void Intt_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::INTT_VERBOSITY);
+
+  Fun4AllServer* se = Fun4AllServer::instance();
+  QAG4SimulationIntt* qa = new QAG4SimulationIntt;
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+}
+
 #endif

--- a/common/G4_Jets.C
+++ b/common/G4_Jets.C
@@ -2,6 +2,7 @@
 #define MACRO_G4JETS_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <g4jets/ClusterJetInput.h>
 #include <g4jets/FastJetAlgo.h>
@@ -11,16 +12,19 @@
 #include <g4jets/TruthJetInput.h>
 
 #include <g4eval/JetEvaluator.h>
+#include <qa_modules/QAG4SimulationJet.h>
 
 #include <fun4all/Fun4AllServer.h>
 
 R__LOAD_LIBRARY(libg4jets.so)
 R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
   bool JETS = false;
   bool JETS_EVAL = false;
+  bool JETS_QA = false;
   int JETS_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -114,4 +118,40 @@ void Jet_Eval(const std::string &outfilename = "g4jets_eval.root")
 
   return;
 }
+
+
+void Jet_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::JETS_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  QAG4SimulationJet *calo_jet7 = new QAG4SimulationJet(
+      "AntiKt_Truth_r07");
+  calo_jet7->add_reco_jet("AntiKt_Tower_r07");
+  calo_jet7->add_reco_jet("AntiKt_Cluster_r07");
+  calo_jet7->add_reco_jet("AntiKt_Track_r07");
+  calo_jet7->Verbosity(verbosity);
+  se->registerSubsystem(calo_jet7);
+
+  QAG4SimulationJet *calo_jet4 = new QAG4SimulationJet(
+      "AntiKt_Truth_r04");
+  calo_jet4->add_reco_jet("AntiKt_Tower_r04");
+  calo_jet4->add_reco_jet("AntiKt_Cluster_r04");
+  calo_jet4->add_reco_jet("AntiKt_Track_r04");
+  calo_jet4->Verbosity(verbosity);
+  se->registerSubsystem(calo_jet4);
+
+  QAG4SimulationJet *calo_jet2 = new QAG4SimulationJet(
+      "AntiKt_Truth_r02");
+  calo_jet2->add_reco_jet("AntiKt_Tower_r02");
+  calo_jet2->add_reco_jet("AntiKt_Cluster_r02");
+  calo_jet2->add_reco_jet("AntiKt_Track_r02");
+  calo_jet2->Verbosity(verbosity);
+  se->registerSubsystem(calo_jet2);
+
+  return;
+}
+
+
 #endif

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -2,6 +2,7 @@
 #define MACRO_G4MVTX_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4mvtx/PHG4MvtxDefs.h>
@@ -12,6 +13,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <mvtx/MvtxClusterizer.h>
+#include <qa_modules/QAG4SimulationMvtx.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -20,6 +22,7 @@
 
 R__LOAD_LIBRARY(libg4mvtx.so)
 R__LOAD_LIBRARY(libmvtx.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
@@ -27,6 +30,7 @@ namespace Enable
   bool MVTX_OVERLAPCHECK = false;
   bool MVTX_CELL = false;
   bool MVTX_CLUSTER = false;
+  bool MVTX_QA = false;
   bool MVTX_ABSORBER = false;
   bool MVTX_SERVICE = true;
   int MVTX_VERBOSITY = 0;
@@ -236,6 +240,16 @@ void Mvtx_Clustering()
   MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
+}
+
+void Mvtx_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::MVTX_VERBOSITY);
+
+  Fun4AllServer* se = Fun4AllServer::instance();
+  QAG4SimulationMvtx* qa = new QAG4SimulationMvtx;
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
 }
 
 #endif

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -2,6 +2,7 @@
 #define MACRO_G4TPC_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <G4_Intt.C>
 #include <G4_Mvtx.C>
@@ -17,11 +18,13 @@
 
 #include <tpc/TpcClusterizer.h>
 #include <tpc/TpcSpaceChargeCorrection.h>
+#include <qa_modules/QAG4SimulationTpc.h>
 
 #include <fun4all/Fun4AllServer.h>
 
 R__LOAD_LIBRARY(libg4tpc.so)
 R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
@@ -30,6 +33,7 @@ namespace Enable
   bool TPC_OVERLAPCHECK = false;
   bool TPC_CELL = false;
   bool TPC_CLUSTER = false;
+  bool TPC_QA = false;
 
   bool TPC_ENDCAP = true;
 
@@ -218,4 +222,17 @@ void TPC_Clustering()
   }
 
 }
+
+
+void TPC_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::TPC_VERBOSITY);
+
+  Fun4AllServer* se = Fun4AllServer::instance();
+  QAG4SimulationTpc * qa =  new QAG4SimulationTpc;
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+}
+
+
 #endif

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -17,6 +17,7 @@
 #include <trackreco/PHGenFitTrackProjection.h>
 #include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHGenFitTrkProp.h>
+#include <trackreco/PHRaveVertexing.h>
 #include <trackreco/PHHoughSeeding.h>
 #include <trackreco/PHInitZVertexing.h>
 #include <trackreco/PHMicromegasTpcTrackMatching.h>

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -2,6 +2,7 @@
 #define MACRO_G4TRACKING_C
 
 #include <GlobalVariables.C>
+#include <QA.C>
 
 #include <G4_Intt.C>
 #include <G4_Micromegas.C>
@@ -42,23 +43,29 @@
 
 #include <phtpctracker/PHTpcTracker.h>
 
+#include <qa_modules/QAG4SimulationTracking.h>
+#include <qa_modules/QAG4SimulationUpsilon.h>
+#include <qa_modules/QAG4SimulationVertex.h>
+
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libPHTpcTracker.so)
+R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace Enable
 {
   bool TRACKING_TRACK = false;
   bool TRACKING_EVAL = false;
   int TRACKING_VERBOSITY = 0;
+  bool TRACKING_QA = false;
 }  // namespace Enable
 
 namespace G4TRACKING
 {
   // Space Charge calibration flag
-  bool SC_CALIBMODE = true;  // this is anded with G4TPC::ENABLE_DISTORTIONS in TrackingInit()
+  bool SC_CALIBMODE = true;        // this is anded with G4TPC::ENABLE_DISTORTIONS in TrackingInit()
   double SC_COLLISIONRATE = 50e3;  // leave at 50 KHz for now, scaling of distortion map not implemented yet
-  
+
   // Tracking reconstruction setup parameters and flags
   //=====================================
 
@@ -132,11 +139,11 @@ void TrackingInit()
   G4TRACKING::SC_CALIBMODE = G4TPC::ENABLE_DISTORTIONS && G4TRACKING::SC_CALIBMODE;
 
   // Genfit does final vertexing, Acts does not
-  if(G4TRACKING::use_Genfit)
-    G4TRACKING::g4eval_use_initial_vertex = false;    
+  if (G4TRACKING::use_Genfit)
+    G4TRACKING::g4eval_use_initial_vertex = false;
 
   // For now the TpcSpaceChargeCorrection module only works with the GenFit tracking chain
-  if(G4TPC::ENABLE_CORRECTIONS && !G4TRACKING::use_Genfit)
+  if (G4TPC::ENABLE_CORRECTIONS && !G4TRACKING::use_Genfit)
   {
     std::cout << "Cannot enable space charge correction if not using GenFit tracking chain" << std::endl;
     G4TPC::ENABLE_CORRECTIONS = false;
@@ -268,139 +275,136 @@ void Tracking_Reco()
     kalman->set_use_truth_vertex(false);
 
     se->registerSubsystem(kalman);
-
   }
-  
+
   // Acts tracking chain (starts from TPC track seeds)
   //===================================
   if (!G4TRACKING::use_truth_track_seeding && !G4TRACKING::use_Genfit)
+  {
+    std::cout << "   Using normal Acts matching chain for silicon and MM's " << std::endl;
+
+    // Silicon cluster matching to TPC track seeds
+    if (G4TRACKING::use_truth_si_matching)
     {
-      std::cout << "   Using normal Acts matching chain for silicon and MM's " << std::endl;
-      
-      // Silicon cluster matching to TPC track seeds
-      if (G4TRACKING::use_truth_si_matching)
-	{
-	  std::cout << "      Using truth Si matching " << std::endl;
-	  // use truth particle matching in TPC to assign clusters in silicon to TPC tracks from CA seeder
-	  // intended only for diagnostics
-	  PHTruthSiliconAssociation* silicon_assoc = new PHTruthSiliconAssociation();
-	  silicon_assoc->Verbosity(0);
-	  se->registerSubsystem(silicon_assoc);
-	}
-      else
-	{
-	  std::cout << "      Using stub matching for Si matching " << std::endl;
-	  
-	  // The normal silicon association methods
-	  // start with a complete TPC track seed from one of the CA seeders
-	  
-	  // use truth information to assemble silicon clusters into track stubs for now
-	  PHSiliconTruthTrackSeeding* silicon_seeding = new PHSiliconTruthTrackSeeding();
-	  silicon_seeding->Verbosity(0);
-	  se->registerSubsystem(silicon_seeding);
-	  
-	  // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
-	  PHSiliconTpcTrackMatching *silicon_match = new PHSiliconTpcTrackMatching();
-	  silicon_match ->Verbosity(0);
-	  if(!G4TRACKING::use_PHTpcTracker_seeding)
-	    silicon_match->set_seeder(true);    // module defaults to PHCASeeding, use true for PHTpcTracker seeding
-	  silicon_match->set_field(G4MAGNET::magfield);
-	  silicon_match->set_field_dir(G4MAGNET::magfield_rescale);
-	  silicon_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
-	  if(G4TRACKING::SC_CALIBMODE)
-	    {
-	      silicon_match->set_collision_rate(G4TRACKING::SC_COLLISIONRATE);
-	      // search windows for initial matching with distortions
-	      // tuned values are 0.04 and 0.008 in distorted events
-	      silicon_match->set_phi_search_window(0.04);  
-	      silicon_match->set_eta_search_window(0.008); 
-	    }
-	  else
-	    {
-	      // after distortion corrections and rerunning clustering, default tuned values are 0.02 and 0.004 in low occupancy events
-	      silicon_match->set_phi_search_window(0.02);  
-	      silicon_match->set_eta_search_window(0.004); 
-	    }
-	  silicon_match->set_test_windows_printout(false);  // used for tuning search windows only
-	  se->registerSubsystem(silicon_match);
-	}	  
-      
-      // Associate Micromegas clusters with the tracks
-      if(G4MICROMEGAS::n_micromegas_layer > 0)
-	{
-	  std::cout << "      Using Micromegas matching " << std::endl;
-	  
-	  // Match TPC track stubs from CA seeder to clusters in the micromegas layers
-	  PHMicromegasTpcTrackMatching *mm_match = new PHMicromegasTpcTrackMatching();
-	  mm_match ->Verbosity(0);
-	  mm_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
-	  if(G4TRACKING::SC_CALIBMODE)
-	    {
-	      // calibration pass with distorted tracks
-	      mm_match->set_collision_rate(G4TRACKING::SC_COLLISIONRATE);
-	      // configuration is potentially with different search windows
-	      mm_match-> set_rphi_search_window_lyr1(0.2);
-	      mm_match-> set_rphi_search_window_lyr2(13.0);
-	      mm_match-> set_z_search_window_lyr1(26.0);
-	      mm_match-> set_z_search_window_lyr2(0.2);
-	    }
-	  else
-	    {
-	      // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
-	      mm_match-> set_rphi_search_window_lyr1(0.2);
-	      mm_match-> set_rphi_search_window_lyr2(13.0);
-	      mm_match-> set_z_search_window_lyr1(26.0);
-	      mm_match-> set_z_search_window_lyr2(0.2);
-	    }
-	  mm_match->set_min_tpc_layer(38);   // layer in TPC to start projection fit
-	  mm_match->set_test_windows_printout(false);   // used for tuning search windows only
-	  se->registerSubsystem(mm_match);
-	}
+      std::cout << "      Using truth Si matching " << std::endl;
+      // use truth particle matching in TPC to assign clusters in silicon to TPC tracks from CA seeder
+      // intended only for diagnostics
+      PHTruthSiliconAssociation* silicon_assoc = new PHTruthSiliconAssociation();
+      silicon_assoc->Verbosity(0);
+      se->registerSubsystem(silicon_assoc);
     }
-  
+    else
+    {
+      std::cout << "      Using stub matching for Si matching " << std::endl;
+
+      // The normal silicon association methods
+      // start with a complete TPC track seed from one of the CA seeders
+
+      // use truth information to assemble silicon clusters into track stubs for now
+      PHSiliconTruthTrackSeeding* silicon_seeding = new PHSiliconTruthTrackSeeding();
+      silicon_seeding->Verbosity(0);
+      se->registerSubsystem(silicon_seeding);
+
+      // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
+      PHSiliconTpcTrackMatching* silicon_match = new PHSiliconTpcTrackMatching();
+      silicon_match->Verbosity(0);
+      if (!G4TRACKING::use_PHTpcTracker_seeding)
+        silicon_match->set_seeder(true);  // module defaults to PHCASeeding, use true for PHTpcTracker seeding
+      silicon_match->set_field(G4MAGNET::magfield);
+      silicon_match->set_field_dir(G4MAGNET::magfield_rescale);
+      silicon_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
+      if (G4TRACKING::SC_CALIBMODE)
+      {
+        silicon_match->set_collision_rate(G4TRACKING::SC_COLLISIONRATE);
+        // search windows for initial matching with distortions
+        // tuned values are 0.04 and 0.008 in distorted events
+        silicon_match->set_phi_search_window(0.04);
+        silicon_match->set_eta_search_window(0.008);
+      }
+      else
+      {
+        // after distortion corrections and rerunning clustering, default tuned values are 0.02 and 0.004 in low occupancy events
+        silicon_match->set_phi_search_window(0.02);
+        silicon_match->set_eta_search_window(0.004);
+      }
+      silicon_match->set_test_windows_printout(false);  // used for tuning search windows only
+      se->registerSubsystem(silicon_match);
+    }
+
+    // Associate Micromegas clusters with the tracks
+    if (G4MICROMEGAS::n_micromegas_layer > 0)
+    {
+      std::cout << "      Using Micromegas matching " << std::endl;
+
+      // Match TPC track stubs from CA seeder to clusters in the micromegas layers
+      PHMicromegasTpcTrackMatching* mm_match = new PHMicromegasTpcTrackMatching();
+      mm_match->Verbosity(0);
+      mm_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
+      if (G4TRACKING::SC_CALIBMODE)
+      {
+        // calibration pass with distorted tracks
+        mm_match->set_collision_rate(G4TRACKING::SC_COLLISIONRATE);
+        // configuration is potentially with different search windows
+        mm_match->set_rphi_search_window_lyr1(0.2);
+        mm_match->set_rphi_search_window_lyr2(13.0);
+        mm_match->set_z_search_window_lyr1(26.0);
+        mm_match->set_z_search_window_lyr2(0.2);
+      }
+      else
+      {
+        // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
+        mm_match->set_rphi_search_window_lyr1(0.2);
+        mm_match->set_rphi_search_window_lyr2(13.0);
+        mm_match->set_z_search_window_lyr1(26.0);
+        mm_match->set_z_search_window_lyr2(0.2);
+      }
+      mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
+      mm_match->set_test_windows_printout(false);  // used for tuning search windows only
+      se->registerSubsystem(mm_match);
+    }
+  }
+
   // Final fitting of tracks using Acts Kalman Filter
   //=================================
-  if(!G4TRACKING::use_Genfit)
-    {
-      std::cout << "   Using Acts track fitting " << std::endl;
-      
+  if (!G4TRACKING::use_Genfit)
+  {
+    std::cout << "   Using Acts track fitting " << std::endl;
+
 #if __cplusplus >= 201703L
-      /// Geometry must be built before any Acts modules
-      MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(0);
-      geom->setMagField(G4MAGNET::magfield);
-      geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-      se->registerSubsystem(geom);
-      
-      /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
-      PHActsSourceLinks* sl = new PHActsSourceLinks();
-      sl->Verbosity(0);
-      sl->setMagField(G4MAGNET::magfield);
-      sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
-      se->registerSubsystem(sl);
-      
-      PHActsTracks* actsTracks = new PHActsTracks();
-      actsTracks->Verbosity(0);
-      se->registerSubsystem(actsTracks);
-      
-      PHActsTrkFitter* actsFit = new PHActsTrkFitter();
-      actsFit->Verbosity(0);
-      actsFit->doTimeAnalysis(false);
-      /// If running with distortions, fit only the silicon+MMs first
-      actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-      se->registerSubsystem(actsFit);
-      
+    /// Geometry must be built before any Acts modules
+    MakeActsGeometry* geom = new MakeActsGeometry();
+    geom->Verbosity(0);
+    geom->setMagField(G4MAGNET::magfield);
+    geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
+    se->registerSubsystem(geom);
 
-      if(G4TRACKING::SC_CALIBMODE)
-	{
-	  /// run tpc residual determination with silicon+MM track fit
-	  PHTpcResiduals *residuals = new PHTpcResiduals();
-	  residuals->Verbosity(0);
-	  se->registerSubsystem(residuals);
+    /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
+    PHActsSourceLinks* sl = new PHActsSourceLinks();
+    sl->Verbosity(0);
+    sl->setMagField(G4MAGNET::magfield);
+    sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
+    se->registerSubsystem(sl);
 
-	}
-#endif
+    PHActsTracks* actsTracks = new PHActsTracks();
+    actsTracks->Verbosity(0);
+    se->registerSubsystem(actsTracks);
+
+    PHActsTrkFitter* actsFit = new PHActsTrkFitter();
+    actsFit->Verbosity(0);
+    actsFit->doTimeAnalysis(false);
+    /// If running with distortions, fit only the silicon+MMs first
+    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+    se->registerSubsystem(actsFit);
+
+    if (G4TRACKING::SC_CALIBMODE)
+    {
+      /// run tpc residual determination with silicon+MM track fit
+      PHTpcResiduals* residuals = new PHTpcResiduals();
+      residuals->Verbosity(0);
+      se->registerSubsystem(residuals);
     }
+#endif
+  }
 
   //------------------
   // Track Projections
@@ -408,7 +412,7 @@ void Tracking_Reco()
   PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
   projection->Verbosity(verbosity);
   se->registerSubsystem(projection);
-  
+
   return;
 }
 
@@ -441,34 +445,67 @@ void Tracking_Eval(const std::string& outputfile)
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 
-  if(!G4TRACKING::use_Genfit && !G4TRACKING::SC_CALIBMODE)
+  if (!G4TRACKING::use_Genfit && !G4TRACKING::SC_CALIBMODE)
   {
 #if __cplusplus >= 201703L
-    if(G4TRACKING::use_acts_evaluator)
-      {
-	ActsEvaluator *actsEval = new ActsEvaluator(outputfile+"_acts.root", eval);
-	actsEval->Verbosity(0);
-	actsEval->setEvalCKF(false);
-	se->registerSubsystem(actsEval);
-      }
+    if (G4TRACKING::use_acts_evaluator)
+    {
+      ActsEvaluator* actsEval = new ActsEvaluator(outputfile + "_acts.root", eval);
+      actsEval->Verbosity(0);
+      actsEval->setEvalCKF(false);
+      se->registerSubsystem(actsEval);
+    }
 #endif
   }
 
- if (G4TRACKING::use_primary_vertex)
-   {
-      // make a second evaluator that records tracks fitted with primary vertex included
-      // good for analysis of prompt tracks, particularly if Mvtx is not present
-      SvtxEvaluator* evalp;
-      evalp = new SvtxEvaluator("SVTXEVALUATOR", outputfile + "_primary_eval.root", "PrimaryTrackMap", G4MVTX::n_maps_layer, G4INTT::n_intt_layer, G4TPC::n_gas_layer);
-      evalp->do_cluster_eval(true);
-      evalp->do_g4hit_eval(true);
-      evalp->do_hit_eval(false);
-      evalp->do_gpoint_eval(false);
-      evalp->scan_for_embedded(true);  // take all tracks if false - take only embedded tracks if true
-      evalp->Verbosity(verbosity);
-      se->registerSubsystem(evalp);
-    }
-  
+  if (G4TRACKING::use_primary_vertex)
+  {
+    // make a second evaluator that records tracks fitted with primary vertex included
+    // good for analysis of prompt tracks, particularly if Mvtx is not present
+    SvtxEvaluator* evalp;
+    evalp = new SvtxEvaluator("SVTXEVALUATOR", outputfile + "_primary_eval.root", "PrimaryTrackMap", G4MVTX::n_maps_layer, G4INTT::n_intt_layer, G4TPC::n_gas_layer);
+    evalp->do_cluster_eval(true);
+    evalp->do_g4hit_eval(true);
+    evalp->do_hit_eval(false);
+    evalp->do_gpoint_eval(false);
+    evalp->scan_for_embedded(true);  // take all tracks if false - take only embedded tracks if true
+    evalp->Verbosity(verbosity);
+    se->registerSubsystem(evalp);
+  }
+
   return;
 }
+
+void Tracking_QA()
+{
+  int verbosity = std::max(Enable::QA_VERBOSITY, Enable::TRACKING_VERBOSITY);
+
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer* se = Fun4AllServer::instance();
+
+  QAG4SimulationTracking* qa = new QAG4SimulationTracking();
+  //  qa->addEmbeddingID(2);
+  qa->Verbosity(verbosity);
+  se->registerSubsystem(qa);
+
+  QAG4SimulationVertex* qa2 = new QAG4SimulationVertex();
+  // qa2->addEmbeddingID(2);
+  qa2->Verbosity(verbosity);
+  se->registerSubsystem(qa2);
+
+  if (Input::UPSILON)
+  {
+    QAG4SimulationUpsilon* qa = new QAG4SimulationUpsilon();
+
+    for (int i = 0; i < Input::UPSILON_NUMBER; ++i)
+    {
+      qa->addEmbeddingID(Input::UPSILON_FirstEmbedId + i);
+    }
+    se->registerSubsystem(qa);
+  }
+}
+
 #endif

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -17,10 +17,10 @@
 #include <trackreco/PHGenFitTrackProjection.h>
 #include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHGenFitTrkProp.h>
-#include <trackreco/PHRaveVertexing.h>
 #include <trackreco/PHHoughSeeding.h>
 #include <trackreco/PHInitZVertexing.h>
 #include <trackreco/PHMicromegasTpcTrackMatching.h>
+#include <trackreco/PHRaveVertexing.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
 #include <trackreco/PHSiliconTruthTrackSeeding.h>
 #include <trackreco/PHTrackSeeding.h>
@@ -413,10 +413,10 @@ void Tracking_Reco()
   if (G4TRACKING::use_rave_vertexing)
   {
     PHRaveVertexing* rave = new PHRaveVertexing();
-//    rave->set_vertexing_method("kalman-smoothing:1");
+    //    rave->set_vertexing_method("kalman-smoothing:1");
     rave->set_over_write_svtxvertexmap(false);
     rave->set_svtxvertexmaprefit_node_name("SvtxVertexMapRave");
-//    rave->Verbosity(0);
+    //    rave->Verbosity(0);
     se->registerSubsystem(rave);
   }
 
@@ -510,25 +510,22 @@ void Tracking_QA()
   qa2->Verbosity(verbosity);
   se->registerSubsystem(qa2);
 
-
   if (G4TRACKING::use_rave_vertexing)
   {
-
     QAG4SimulationVertex* qav = new QAG4SimulationVertex();
     // qav->addEmbeddingID(2);
     qav->Verbosity(verbosity);
     qav->setVertexMapName("SvtxVertexMapRave");
     se->registerSubsystem(qav);
-
   }
 
   if (Input::UPSILON)
   {
     QAG4SimulationUpsilon* qa = new QAG4SimulationUpsilon();
 
-    for (int i = 0; i < Input::UPSILON_NUMBER; ++i)
+    for (int id : Input::UPSILON_EmbedIds)
     {
-      qa->addEmbeddingID(Input::UPSILON_FirstEmbedId + i);
+      qa->addEmbeddingID(id);
     }
     se->registerSubsystem(qa);
   }

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -87,6 +87,7 @@ namespace G4TRACKING
   bool use_truth_track_seeding = false;    // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
   bool use_init_vertexing = false;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
+  bool use_rave_vertexing = true;          // Use Rave to find and fit for vertex after track fitting
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
   bool use_acts_evaluator = false;         // Turn to true for an acts evaluator which outputs acts specific information in a tuple
   int init_vertexing_min_zvtx_tracks = 2;  // PHInitZvertexing parameter for reducing spurious vertices, use 2 for Pythia8 events, 5 for large multiplicity events
@@ -406,6 +407,18 @@ void Tracking_Reco()
 #endif
   }
 
+  // Final vertex finding and fitting with RAVE
+  //=================================
+  if (G4TRACKING::use_rave_vertexing)
+  {
+    PHRaveVertexing* rave = new PHRaveVertexing();
+//    rave->set_vertexing_method("kalman-smoothing:1");
+    rave->set_over_write_svtxvertexmap(false);
+    rave->set_svtxvertexmaprefit_node_name("SvtxVertexMapRave");
+//    rave->Verbosity(0);
+    se->registerSubsystem(rave);
+  }
+
   //------------------
   // Track Projections
   //------------------
@@ -495,6 +508,18 @@ void Tracking_QA()
   // qa2->addEmbeddingID(2);
   qa2->Verbosity(verbosity);
   se->registerSubsystem(qa2);
+
+
+  if (G4TRACKING::use_rave_vertexing)
+  {
+
+    QAG4SimulationVertex* qav = new QAG4SimulationVertex();
+    // qav->addEmbeddingID(2);
+    qav->Verbosity(verbosity);
+    qav->setVertexMapName("SvtxVertexMapRave");
+    se->registerSubsystem(qav);
+
+  }
 
   if (Input::UPSILON)
   {

--- a/common/QA.C
+++ b/common/QA.C
@@ -12,7 +12,7 @@ namespace Enable
 {
   // if you want this to run by default, initialize this to true
   // Otherwise you have to use Enable::USER = true; in your macro
-  bool QA = true;
+  bool QA = false;
   int QA_VERBOSITY = 0;
 }  // namespace Enable
 

--- a/common/QA.C
+++ b/common/QA.C
@@ -32,7 +32,7 @@ void QA_G4CaloTracking()
 }
 
 // run this after se->run() to output QA histogram file for all QA modules
-void QA_EndRun(const std::string& qaOutputFileName)
+void QA_Output(const std::string& qaOutputFileName)
 {
   Fun4AllServer* se = Fun4AllServer::instance();
   QAHistManagerDef::saveQARootFile(qaOutputFileName);

--- a/common/QA.C
+++ b/common/QA.C
@@ -1,0 +1,42 @@
+#ifndef MACRO_QA_C
+#define MACRO_QA_C
+
+#include <fun4all/Fun4AllServer.h>
+#include <qa_modules/QAG4SimulationCalorimeterSum.h>
+#include <qa_modules/QAHistManagerDef.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libqa_modules.so)
+
+namespace Enable
+{
+  // if you want this to run by default, initialize this to true
+  // Otherwise you have to use Enable::USER = true; in your macro
+  bool QA = true;
+  int QA_VERBOSITY = 0;
+}  // namespace Enable
+
+namespace QA
+{
+  //  int myparam = 0;
+}  // namespace QA
+
+// QA moduel combining tracking and calorimeters
+void QA_G4CaloTracking()
+{
+  Fun4AllServer* se = Fun4AllServer::instance();
+  QAG4SimulationCalorimeterSum* calo_qa = new QAG4SimulationCalorimeterSum();
+  calo_qa->Verbosity(Enable::QA_VERBOSITY);
+  se->registerSubsystem(calo_qa);
+  return;
+}
+
+// run this after se->run() to output QA histogram file for all QA modules
+void QA_EndRun(const std::string& qaOutputFileName)
+{
+  Fun4AllServer* se = Fun4AllServer::instance();
+  QAHistManagerDef::saveQARootFile(qaOutputFileName);
+  return;
+}
+
+#endif

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -16,6 +16,7 @@
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>
 #include <G4_Tracking.C>
+#include <QA.C>
 #include <G4_User.C>
 
 #include <fun4all/Fun4AllDstOutputManager.h>
@@ -300,6 +301,9 @@ int Fun4All_G4_sPHENIX(
   //Enable::BLACKHOLE_SAVEHITS = false; // turn off saving of bh hits
   //BlackHoleGeometry::visible = true;
 
+  // disable QA which otherwise run by default
+  //Enable::QA = false;
+
   // run user provided code (from local G4_User.C)
   //Enable::USER = true;
 
@@ -456,6 +460,12 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::USER) UserAnalysisInit();
 
+  //----------------------
+  // Standard QAs
+  //----------------------
+
+  if (Enable::TRACKING_TRACK and Enable::QA) QA_G4CaloTracking();
+
   //--------------
   // Set up Input Managers
   //--------------
@@ -508,6 +518,12 @@ int Fun4All_G4_sPHENIX(
 
   se->skip(skip);
   se->run(nEvents);
+
+  //-----
+  // QA output
+  //-----
+
+  if (Enable::QA) QA_EndRun(outputroot + "_qa.root");
 
   //-----
   // Exit

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -246,6 +246,7 @@ int Fun4All_G4_sPHENIX(
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
+  Enable::CEMC_QA = Enable::CEMC_CLUSTER && true;
 
   Enable::HCALIN = true;
   Enable::HCALIN_ABSORBER = true;
@@ -253,6 +254,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
   Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
+  Enable::HCALIN_QA = Enable::HCALIN_CLUSTER && true;
 
   Enable::MAGNET = true;
   Enable::MAGNET_ABSORBER = true;
@@ -263,6 +265,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
   Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
+  Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER && true;
 
   // forward EMC
   //Enable::FEMC = true;
@@ -464,7 +467,14 @@ int Fun4All_G4_sPHENIX(
   // Standard QAs
   //----------------------
 
-  if (Enable::TRACKING_TRACK and Enable::QA) QA_G4CaloTracking();
+
+  if (Enable::CEMC_QA and Enable::QA) CEMC_Eval(outputroot + "_g4cemc_eval.root");
+
+  if (Enable::HCALIN_QA and Enable::QA) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
+
+  if (Enable::HCALOUT_QA and Enable::QA) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
+
+  if (Enable::TRACKING_TRACK and Enable::CEMC_QA and Enable::HCALIN_QA and Enable::HCALOUT_QA  and Enable::QA) QA_G4CaloTracking();
 
   //--------------
   // Set up Input Managers

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -40,10 +40,10 @@ int Fun4All_G4_sPHENIX(
     const string &outdir = ".")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(1);
+  se->Verbosity(0);
 
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
-  PHRandomSeed::Verbosity(0);
+  PHRandomSeed::Verbosity(1);
 
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -16,8 +16,8 @@
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>
 #include <G4_Tracking.C>
-#include <QA.C>
 #include <G4_User.C>
+#include <QA.C>
 
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllOutputManager.h>
@@ -40,10 +40,10 @@ int Fun4All_G4_sPHENIX(
     const string &outdir = ".")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(0);
+  se->Verbosity(1);
 
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
-  PHRandomSeed::Verbosity(1);
+  PHRandomSeed::Verbosity(0);
 
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();
@@ -204,13 +204,17 @@ int Fun4All_G4_sPHENIX(
   //======================
   // What to run
   //======================
+
+  // QA, main switch
+  Enable::QA = true;
+
   // Global options (enabled for all enables subsystems - if implemented)
   //  Enable::ABSORBER = true;
   //  Enable::OVERLAPCHECK = true;
   //  Enable::VERBOSITY = 1;
 
   // Enable::BBC = true;
-  Enable::BBCFAKE = true; // Smeared vtx and t0, use if you don't want real BBC in simulation
+  Enable::BBCFAKE = true;  // Smeared vtx and t0, use if you don't want real BBC in simulation
 
   Enable::PIPE = true;
   Enable::PIPE_ABSORBER = true;
@@ -219,15 +223,18 @@ int Fun4All_G4_sPHENIX(
   Enable::MVTX = true;
   Enable::MVTX_CELL = Enable::MVTX && true;
   Enable::MVTX_CLUSTER = Enable::MVTX_CELL && true;
+  Enable::MVTX_QA = Enable::MVTX_CLUSTER and Enable::QA && true;
 
   Enable::INTT = true;
   Enable::INTT_CELL = Enable::INTT && true;
   Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
+  Enable::INTT_QA = Enable::INTT_CLUSTER and Enable::QA && true;
 
   Enable::TPC = true;
   Enable::TPC_ABSORBER = true;
   Enable::TPC_CELL = Enable::TPC && true;
   Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
+  Enable::TPC_QA = Enable::TPC_CLUSTER and Enable::QA && true;
 
   //Enable::MICROMEGAS = true;
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
@@ -235,6 +242,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::TRACKING_TRACK = true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
+  Enable::TRACKING_QA = Enable::TRACKING_TRACK and Enable::QA && true;
 
   //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
   //  into the tracking, cannot run together with CEMC
@@ -246,7 +254,7 @@ int Fun4All_G4_sPHENIX(
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
-  Enable::CEMC_QA = Enable::CEMC_CLUSTER && true;
+  Enable::CEMC_QA = Enable::CEMC_CLUSTER and Enable::QA && true;
 
   Enable::HCALIN = true;
   Enable::HCALIN_ABSORBER = true;
@@ -254,7 +262,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
   Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
-  Enable::HCALIN_QA = Enable::HCALIN_CLUSTER && true;
+  Enable::HCALIN_QA = Enable::HCALIN_CLUSTER and Enable::QA && true;
 
   Enable::MAGNET = true;
   Enable::MAGNET_ABSORBER = true;
@@ -265,7 +273,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
   Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
-  Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER && true;
+  Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER and Enable::QA && true;
 
   // forward EMC
   //Enable::FEMC = true;
@@ -273,7 +281,7 @@ int Fun4All_G4_sPHENIX(
   Enable::FEMC_CELL = Enable::FEMC && true;
   Enable::FEMC_TOWER = Enable::FEMC_CELL && true;
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
-  Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
+  Enable::FEMC_EVAL = Enable::FEMC_CLUSTER and Enable::QA && true;
 
   Enable::EPD = false;
 
@@ -288,6 +296,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::JETS = true;
   Enable::JETS_EVAL = Enable::JETS && true;
+  Enable::JETS_QA = Enable::JETS and Enable::QA && true;
 
   // HI Jet Reco for p+Au / Au+Au collisions (default is false for
   // single particle / p+p-only simulations, or for p+Au / Au+Au
@@ -303,9 +312,6 @@ int Fun4All_G4_sPHENIX(
   Enable::BLACKHOLE = true;
   //Enable::BLACKHOLE_SAVEHITS = false; // turn off saving of bh hits
   //BlackHoleGeometry::visible = true;
-
-  // disable QA which otherwise run by default
-  //Enable::QA = false;
 
   // run user provided code (from local G4_User.C)
   //Enable::USER = true;
@@ -467,14 +473,18 @@ int Fun4All_G4_sPHENIX(
   // Standard QAs
   //----------------------
 
+  if (Enable::CEMC_QA) CEMC_QA();
+  if (Enable::HCALIN_QA) HCALInner_QA();
+  if (Enable::HCALOUT_QA) HCALOuter_QA();
 
-  if (Enable::CEMC_QA and Enable::QA) CEMC_Eval(outputroot + "_g4cemc_eval.root");
+  if (Enable::JETS_QA) Jet_QA();
 
-  if (Enable::HCALIN_QA and Enable::QA) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
+  if (Enable::MVTX_QA) Mvtx_QA();
+  if (Enable::INTT_QA) Intt_QA();
+  if (Enable::TPC_QA) TPC_QA();
+  if (Enable::TRACKING_QA) Tracking_QA();
 
-  if (Enable::HCALOUT_QA and Enable::QA) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
-
-  if (Enable::TRACKING_TRACK and Enable::CEMC_QA and Enable::HCALIN_QA and Enable::HCALOUT_QA  and Enable::QA) QA_G4CaloTracking();
+  if (Enable::TRACKING_QA and Enable::CEMC_QA and Enable::HCALIN_QA and Enable::HCALOUT_QA) QA_G4CaloTracking();
 
   //--------------
   // Set up Input Managers
@@ -533,7 +543,7 @@ int Fun4All_G4_sPHENIX(
   // QA output
   //-----
 
-  if (Enable::QA) QA_EndRun(outputroot + "_qa.root");
+  if (Enable::QA) QA_Output(outputroot + "_qa.root");
 
   //-----
   // Exit


### PR DESCRIPTION
This is the first of several steps to rebuild the standardized QA capability under the new macro setup [ #262 ]

QA modules are integrated in the common macros, part of each of the detector setup and jet/track reconstruction macros. They can be enabled/disabled in the main Fun4All macro like an eval step, which default to be enabled. Suggest enable these QA modules in the coming productions too. 

Next steps include introduce its jobs in Jenkins CI and build a new QA plot archival. 