### PR TITLE
Acts vertexing

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -368,24 +368,24 @@ void Tracking_Reco()
 #if __cplusplus >= 201703L
       /// Geometry must be built before any Acts modules
       MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(0);
+      geom->Verbosity(verbosity);
       geom->setMagField(G4MAGNET::magfield);
       geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(geom);
       
       /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
       PHActsSourceLinks* sl = new PHActsSourceLinks();
-      sl->Verbosity(0);
+      sl->Verbosity(verbosity);
       sl->setMagField(G4MAGNET::magfield);
       sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
       se->registerSubsystem(sl);
       
       PHActsTracks* actsTracks = new PHActsTracks();
-      actsTracks->Verbosity(0);
+      actsTracks->Verbosity(verbosity);
       se->registerSubsystem(actsTracks);
       
       PHActsTrkFitter* actsFit = new PHActsTrkFitter();
-      actsFit->Verbosity(0);
+      actsFit->Verbosity(verbosity);
       actsFit->doTimeAnalysis(false);
       /// If running with distortions, fit only the silicon+MMs first
       actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
@@ -396,7 +396,7 @@ void Tracking_Reco()
 	{
 	  /// run tpc residual determination with silicon+MM track fit
 	  PHTpcResiduals *residuals = new PHTpcResiduals();
-	  residuals->Verbosity(0);
+	  residuals->Verbosity(verbosity);
 	  se->registerSubsystem(residuals);
 
 	}
@@ -404,7 +404,7 @@ void Tracking_Reco()
       if(G4TRACKING::use_acts_vertexing)
 	{
 	  PHActsVertexFinder *vtxer = new PHActsVertexFinder();
-	  vtxer->Verbosity(0);
+	  vtxer->Verbosity(verbosity);
 	  se->registerSubsystem(vtxer);
 	}
 

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -81,6 +81,7 @@ namespace G4TRACKING
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
   bool use_init_vertexing = false;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
+  bool use_acts_vertexing = true;          // Turn to true for acts final vertexing tool
   bool use_acts_evaluator = false;         // Turn to true for an acts evaluator which outputs acts specific information in a tuple
   int init_vertexing_min_zvtx_tracks = 2;  // PHInitZvertexing parameter for reducing spurious vertices, use 2 for Pythia8 events, 5 for large multiplicity events
                                            //default seed is PHTpcTracker
@@ -399,6 +400,15 @@ void Tracking_Reco()
 	  se->registerSubsystem(residuals);
 
 	}
+
+      if(G4TRACKING::use_acts_vertexing)
+	{
+	  PHActsVertexFinder *vtxer = new PHActsVertexFinder();
+	  vtxer->Verbosity(0);
+	  se->registerSubsystem(vtxer);
+	}
+
+
 #endif
     }
 

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -81,7 +81,6 @@ namespace G4TRACKING
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
   bool use_init_vertexing = false;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
-  bool use_acts_vertexing = true;          // Turn to true for acts final vertexing tool
   bool use_acts_evaluator = false;         // Turn to true for an acts evaluator which outputs acts specific information in a tuple
   int init_vertexing_min_zvtx_tracks = 2;  // PHInitZvertexing parameter for reducing spurious vertices, use 2 for Pythia8 events, 5 for large multiplicity events
                                            //default seed is PHTpcTracker
@@ -398,15 +397,12 @@ void Tracking_Reco()
 	  PHTpcResiduals *residuals = new PHTpcResiduals();
 	  residuals->Verbosity(verbosity);
 	  se->registerSubsystem(residuals);
-
 	}
-
-      if(G4TRACKING::use_acts_vertexing)
-	{
-	  PHActsVertexFinder *vtxer = new PHActsVertexFinder();
-	  vtxer->Verbosity(verbosity);
-	  se->registerSubsystem(vtxer);
-	}
+    
+      PHActsVertexFinder *vtxer = new PHActsVertexFinder();
+      vtxer->Verbosity(verbosity);
+      se->registerSubsystem(vtxer);
+	
 
 
 #endif


### PR DESCRIPTION
This PR adds the acts vertex finding module to the acts tracking chain. It does not overwrite the `SvtxVertexMap` and instead creates a new map on the node tree.