### PR TITLE
Fix fsPHENIX loading order of G4_Tracking

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -76,10 +76,10 @@ namespace Input
   int SIMPLE_NUMBER = 1;
   int SIMPLE_VERBOSITY = 0;
 
-  bool UPSILON = false;
+//  bool UPSILON = false; // moved to GlobalVariables.C, as used in downstream vairables
   int UPSILON_NUMBER = 1;
   int UPSILON_VERBOSITY = 0;
-  std::set<int> UPSILON_EmbedIds;
+//  std::set<int> UPSILON_EmbedIds; // moved to GlobalVariables.C, as used in downstream vairables
 
   double PILEUPRATE = 0.;
   bool READHITS = false;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -2,6 +2,7 @@
 #define MACRO_GLOBALVARIABLES_C
 
 #include <g4decayer/EDecayType.hh>
+#include <set>
 
 double no_overlapp = 0.0001;
 
@@ -12,6 +13,9 @@ namespace Input
   bool HEPMC = false;
   bool EMBED = false;
   bool READEIC = false;
+
+  bool UPSILON = false;
+  std::set<int> UPSILON_EmbedIds;
 }  // namespace Input
 
 namespace DstOut

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -11,6 +11,7 @@
 #include <G4_FwdJets.C>
 #include <G4_Global.C>
 #include <G4_Input.C>
+#include <G4_Tracking.C>
 #include <G4_Jets.C>
 #include <G4_Production.C>
 #include <G4_User.C>

--- a/detectors/fsPHENIX/G4Setup_fsPHENIX.C
+++ b/detectors/fsPHENIX/G4Setup_fsPHENIX.C
@@ -17,7 +17,6 @@
 #include <G4_Piston.C>
 #include <G4_PlugDoor_fsPHENIX.C>
 #include <G4_TPC.C>
-#include <G4_Tracking.C>
 #include <G4_User.C>
 #include <G4_World.C>
 


### PR DESCRIPTION
Following the example of the sPHENIX macro, fixing the loading order of G4_Tracking in fsPHENIX setup. Currently it fails while looking for variables from G4_Input