### PR TITLE
updated flags to handle new distortions from Henry

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -138,7 +138,7 @@ void TrackingInit()
   }
 
   // SC_CALIBMODE makes no sense if distortions are not present
-  G4TRACKING::SC_CALIBMODE = G4TPC::ENABLE_DISTORTIONS && G4TRACKING::SC_CALIBMODE;
+  G4TRACKING::SC_CALIBMODE = (G4TPC::ENABLE_STATIC_DISTORTIONS || G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS ) && G4TRACKING::SC_CALIBMODE;
 
   // Genfit does final vertexing, Acts does not
   if (G4TRACKING::use_Genfit)


### PR DESCRIPTION
This pull request updates the flags in G4_TPC and G4_Tracking needed to accomodate latest distortion code from Henry.
The latter can deal with either static and per-event distortion maps (or both at the same time) and thus the configuration flags must support both configuration.