### PR TITLE
load libFermimotionAfterburner.so in G4_Input.C

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -38,6 +38,7 @@ R__LOAD_LIBRARY(libg4testbench.so)
 R__LOAD_LIBRARY(libPHPythia6.so)
 R__LOAD_LIBRARY(libPHPythia8.so)
 R__LOAD_LIBRARY(libPHSartre.so)
+R__LOAD_LIBRARY(libFermimotionAfterburner.so)
 
 namespace Input
 {


### PR DESCRIPTION
For the x8664 container this lib needs to be loaded