### PR TITLE
Eemc fix

### DIFF
--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -70,19 +70,23 @@ void EEMCSetup(PHG4Reco *g4Reco)
     eemc->SetAbsorberActive();
   }
 
-  /* path to central copy of calibrations repositry */
+  /* path to central copy of calibrations repository */
   ostringstream mapping_eemc;
 
   /* Use non-projective geometry */
   if (!G4EEMC::use_projective_geometry)
   {
     mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
-    eemc->SetTowerMappingFile(mapping_eemc.str());
+    eemc->set_string_param("mappingtower", mapping_eemc.str());
   }
 
   /* use projective geometry */
   else
   {
+    cout << "The projective version has serious problems with overlaps" << endl;
+    cout << "Do Not Use!" << endl;
+    cout << "If you insist, copy G4_EEMC.C locally and comment out this exit" << endl;
+    gSystem->Exit(1);
     ostringstream mapping_eemc_4x4construct;
 
     mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystals_v005.txt";
@@ -98,15 +102,6 @@ void EEMCSetup(PHG4Reco *g4Reco)
 
 void EEMC_Cells()
 {
-  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
-
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("EEMCCellReco");
-  hc->Detector("EEMC");
-  se->registerSubsystem(hc);
-
-  return;
 }
 
 void EEMC_Towers()

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -279,8 +279,7 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - 'electron' direction
   Enable::EEMC = true;
-  Enable::EEMC_CELL = Enable::EEMC && true;
-  Enable::EEMC_TOWER = Enable::EEMC_CELL && true;
+  Enable::EEMC_TOWER = Enable::EEMC && true;
   Enable::EEMC_CLUSTER = Enable::EEMC_TOWER && true;
   Enable::EEMC_EVAL = Enable::EEMC_CLUSTER && true;
 
@@ -362,8 +361,6 @@ int Fun4All_G4_EICDetector(
   if (Enable::FEMC_CELL) FEMC_Cells();
 
   if (Enable::FHCAL_CELL) FHCAL_Cells();
-
-  if (Enable::EEMC_CELL) EEMC_Cells();
 
   //-----------------------------
   // CEMC towering and clustering


### PR DESCRIPTION
This PR applies some cosmetic changes the G4_EEMC.C, it now exits if someone tries to enable the projective version. This version has serious overlap issues and should not be used in normal running. The cell reconstruction is obsolete for the eemc, the G4_EEMC.C macro contains an empty function so existing macros do not break. This function was removed from the Fun4All_G4_EICDetector.C