### PR TITLE
Fix forward calos

### DIFF
--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -169,19 +169,19 @@ void EEMC_Clusters()
 
   if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcTemplateClusterizer)
   {
-RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("EEMCRawClusterBuilderTemplate");
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EEMCRawClusterBuilderTemplate");
 
-  ClusterBuilder->Detector("EEMC");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem(ClusterBuilder);
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
   }
   else if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcGraphClusterizer)
   {
-RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
 
-  ClusterBuilder->Detector("EEMC");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem(ClusterBuilder);
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
   }
   else
   {

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -13,6 +13,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
 #include <fun4all/Fun4AllServer.h>
@@ -39,6 +40,16 @@ namespace G4EEMC
   int use_projective_geometry = 0;
   double Gdz = 18. + 0.0001;
   double Gz0 = -170.;
+  enum enu_Eemc_clusterizer
+  {
+    kEemcGraphClusterizer,
+    kEemcTemplateClusterizer
+  };
+  //default template clusterizer, as developed by Sasha Bazilevsky
+  enu_Eemc_clusterizer Eemc_clusterizer = kEemcTemplateClusterizer;
+  // graph clusterizer
+  //enu_Eemc_clusterizer Eemc_clusterizer = kEemcGraphClusterizer;
+
 }  // namespace G4EEMC
 
 void EEMCInit()
@@ -156,11 +167,27 @@ void EEMC_Clusters()
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
+  if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcTemplateClusterizer)
+  {
+RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("EEMCRawClusterBuilderTemplate");
+
   ClusterBuilder->Detector("EEMC");
   ClusterBuilder->Verbosity(verbosity);
   se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcGraphClusterizer)
+  {
+RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
 
+  ClusterBuilder->Detector("EEMC");
+  ClusterBuilder->Verbosity(verbosity);
+  se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "EEMC_Clusters - unknown clusterizer setting " << G4EEMC::Eemc_clusterizer << endl;
+    gSystem->Exit(1);
+  }
   return;
 }
 

--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -89,12 +89,6 @@ void FEMCSetup(PHG4Reco *g4Reco, const int absorberactive = 0)
 
 void FEMC_Cells()
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
-  hc->Detector("FEMC");
-  se->registerSubsystem(hc);
-
   return;
 }
 

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -85,14 +85,6 @@ void FEMCSetup(PHG4Reco *g4Reco)
 
 void FEMC_Cells()
 {
-  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
-
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
-  hc->Detector("FEMC");
-  se->registerSubsystem(hc);
-
   return;
 }
 

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -14,6 +14,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
 #include <fun4all/Fun4AllServer.h>
@@ -41,6 +42,15 @@ namespace G4FHCAL
   double Gz0 = 400.;
   double Gdz = 100.;
   double outer_radius = 262.;
+  enum enu_FHcal_clusterizer
+  {
+    kFHcalGraphClusterizer,
+    kFHcalTemplateClusterizer
+  };
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_FHcal_clusterizer FHcal_clusterizer = kFHcalTemplateClusterizer;
+  // graph clusterizer
+  //enu_FHcal_clusterizer FHcal_clusterizer = kFHcalGraphClusterizer;
 }  // namespace G4FHCAL
 
 void FHCALInit()
@@ -76,12 +86,6 @@ void FHCALSetup(PHG4Reco *g4Reco)
 
 void FHCAL_Cells(int verbosity = 0)
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FHCALCellReco");
-  hc->Detector("FHCAL");
-  se->registerSubsystem(hc);
-
   return;
 }
 
@@ -94,7 +98,6 @@ void FHCAL_Towers()
   ostringstream mapping_fhcal;
   mapping_fhcal << getenv("CALIBRATIONROOT")
                 << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
-  //mapping_fhcal << "towerMap_FHCAL_latest.txt";
 
   RawTowerBuilderByHitIndex *tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");
   tower_FHCAL->Detector("FHCAL");
@@ -148,11 +151,28 @@ void FHCAL_Clusters()
   int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
   Fun4AllServer *se = Fun4AllServer::instance();
 
+  if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
+RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("FHCALRawClusterBuilderTemplate");
+  ClusterBuilder->Detector("FHCAL");
+  ClusterBuilder->SetPlanarGeometry(); // has to be called after Detector()
+  ClusterBuilder->Verbosity(verbosity);
+  ClusterBuilder->set_threshold_energy(0.100);
+  se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
   RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
   ClusterBuilder->Detector("FHCAL");
   ClusterBuilder->Verbosity(verbosity);
   ClusterBuilder->set_threshold_energy(0.100);
   se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "FHCAL_Clusters - unknown clusterizer setting " << G4FHCAL::FHcal_clusterizer << endl;
+    gSystem->Exit(1);
+  }
 
   return;
 }

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -153,20 +153,20 @@ void FHCAL_Clusters()
 
   if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
   {
-RawClusterBuilderTemplate* ClusterBuilder = new RawClusterBuilderTemplate("FHCALRawClusterBuilderTemplate");
-  ClusterBuilder->Detector("FHCAL");
-  ClusterBuilder->SetPlanarGeometry(); // has to be called after Detector()
-  ClusterBuilder->Verbosity(verbosity);
-  ClusterBuilder->set_threshold_energy(0.100);
-  se->registerSubsystem(ClusterBuilder);
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("FHCALRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->SetPlanarGeometry();  // has to be called after Detector()
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
   }
   else if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
   {
-  RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
-  ClusterBuilder->Detector("FHCAL");
-  ClusterBuilder->Verbosity(verbosity);
-  ClusterBuilder->set_threshold_energy(0.100);
-  se->registerSubsystem(ClusterBuilder);
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
   }
   else
   {

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -272,7 +272,7 @@ void HCALInner_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALIN");
-    ClusterBuilder->SetCylindricalGeometry(); // has to be called after Detector()
+    ClusterBuilder->SetCylindricalGeometry();  // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -272,7 +272,7 @@ void HCALInner_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALIN");
-    ClusterBuilder->SetCylindricalGeometry();
+    ClusterBuilder->SetCylindricalGeometry(); // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -196,7 +196,7 @@ void HCALOuter_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalOutRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALOUT");
-    ClusterBuilder->SetCylindricalGeometry(); // has to be called after Detector()
+    ClusterBuilder->SetCylindricalGeometry();  // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -196,7 +196,7 @@ void HCALOuter_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalOutRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALOUT");
-    ClusterBuilder->SetCylindricalGeometry();
+    ClusterBuilder->SetCylindricalGeometry(); // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -265,15 +265,13 @@ int Fun4All_G4_EICDetector(
 
   Enable::FEMC = true;
   //  Enable::FEMC_ABSORBER = true;
-  Enable::FEMC_CELL = Enable::FEMC && true;
-  Enable::FEMC_TOWER = Enable::FEMC_CELL && true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
 
   Enable::FHCAL = true;
   //  Enable::FHCAL_ABSORBER = true;
-  Enable::FHCAL_CELL = Enable::FHCAL && true;
-  Enable::FHCAL_TOWER = Enable::FHCAL_CELL && true;
+  Enable::FHCAL_TOWER = Enable::FHCAL && true;
   Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
   Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && true;
 
@@ -357,10 +355,6 @@ int Fun4All_G4_EICDetector(
   if (Enable::HCALIN_CELL) HCALInner_Cells();
 
   if (Enable::HCALOUT_CELL) HCALOuter_Cells();
-
-  if (Enable::FEMC_CELL) FEMC_Cells();
-
-  if (Enable::FHCAL_CELL) FHCAL_Cells();
 
   //-----------------------------
   // CEMC towering and clustering

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -276,14 +276,12 @@ int Fun4All_G4_fsPHENIX(
 
   Enable::FEMC = true;
   Enable::FEMC_ABSORBER = true;
-  Enable::FEMC_CELL = Enable::FEMC && true;
-  Enable::FEMC_TOWER = Enable::FEMC_CELL && true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
 
   Enable::FHCAL = true;
   Enable::FHCAL_ABSORBER = true;
-  Enable::FHCAL_CELL = Enable::FHCAL && true;
-  Enable::FHCAL_TOWER = Enable::FHCAL_CELL && true;
+  Enable::FHCAL_TOWER = Enable::FHCAL && true;
   Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
   Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && true;
 
@@ -351,9 +349,6 @@ int Fun4All_G4_fsPHENIX(
   if (Enable::HCALIN_CELL) HCALInner_Cells();
 
   if (Enable::HCALOUT_CELL) HCALOuter_Cells();
-
-  if (Enable::FEMC_CELL) FEMC_Cells();
-  if (Enable::FHCAL_CELL) FHCAL_Cells();
 
   //-----------------------------
   // CEMC towering and clustering

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -278,8 +278,7 @@ int Fun4All_G4_sPHENIX(
   // forward EMC
   //Enable::FEMC = true;
   Enable::FEMC_ABSORBER = true;
-  Enable::FEMC_CELL = Enable::FEMC && true;
-  Enable::FEMC_TOWER = Enable::FEMC_CELL && true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER and Enable::QA && true;
 
@@ -365,8 +364,6 @@ int Fun4All_G4_sPHENIX(
   if (Enable::HCALIN_CELL) HCALInner_Cells();
 
   if (Enable::HCALOUT_CELL) HCALOuter_Cells();
-
-  if (Enable::FEMC_CELL) FEMC_Cells();
 
   //-----------------------------
   // CEMC towering and clustering


### PR DESCRIPTION
This PR adds the use of the template clusterizer for the eemc and the fhcal. It removes the obsolete call reco for the forward calos (they go directly from g4hits to towers). The functions themselves and the enable is still in place so we don't break existing macros