### PR TITLE
KFParticle macro added

### DIFF
--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -1,0 +1,166 @@
+#ifndef MACRO_G4KFPARTICLE_C
+#define MACRO_G4KFPARTICLE_C
+
+#include <GlobalVariables.C>
+
+#include <kfparticle_sphenix/KFParticle_sPHENIX.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libkfparticle_sphenix.so)
+
+namespace Enable
+{
+  bool KFPARTICLE = false;
+  bool KFPARTICLE_SAVE_NTUPLE = false;
+  bool KFPARTICLE_APPEND_TO_DST = true;
+  bool KFPARTICLE_TRUTH_MATCH = false;
+  bool KFPARTICLE_DETECTOR_INFO = false;
+  int KFPARTICLE_VERBOSITY = 0;
+  std::string KFPARTICLE_TRACKMAP = "SvtxTrackMap";
+  std::string KFPARTICLE_VERTEXMAP = "SvtxVertexMap";
+}  // namespace Enable
+
+namespace KFParticleBaseCut
+{
+  float minTrackPT = 0.5; // GeV
+  float maxTrackchi2nDoF = 2;
+  float minTrackIPchi2 = 15; // IP = DCA of track with vertex
+  float maxVertexchi2nDoF = 2;
+  float maxTrackTrackDCA = 0.05; // cm
+  float minMotherPT = 0; // GeV
+}  // namespace KFParticleBaseCut
+
+void KFParticleInit() {} //I guess this line isnt needed
+
+void KFParticle_Upsilon_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "Upsilon";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(2);
+  daughterList[0] = make_pair("electron", +1);
+  daughterList[1] = make_pair("electron", -1);
+  kfparticle->getChargeConjugate(false);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(0); // Upsilon decays are prompt, tracks are more likely to point to vertex
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(7);
+  kfparticle->setMaximumMass(11);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+void KFParticle_D0_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "D0";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(2);
+  daughterList[0] = make_pair("kaon", -1);
+  daughterList[1] = make_pair("pion", +1);
+  kfparticle->getChargeConjugate(true);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(1.750);
+  kfparticle->setMaximumMass(1.950);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+void KFParticle_Lambdac_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "Lambdac";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(3);
+  daughterList[0] = make_pair("proton", +1);
+  daughterList[1] = make_pair("kaon", -1);
+  daughterList[2] = make_pair("pion", +1);
+  kfparticle->getChargeConjugate(true);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(2.150);
+  kfparticle->setMaximumMass(2.400);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+#endif

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -12,6 +12,7 @@
 #include <G4_HIJetReco.C>
 #include <G4_Input.C>
 #include <G4_Jets.C>
+#include <G4_KFParticle.C>
 #include <G4_ParticleFlow.C>
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>
@@ -91,10 +92,16 @@ int Fun4All_G4_sPHENIX(
   //  Input::GUN_NUMBER = 3; // if you need 3 of them
   // Input::GUN_VERBOSITY = 1;
 
+  //D0 generator
+  //Input::DZERO = false;
+  //Input::DZERO_VERBOSITY = 0;
+  //Lambda_c generator //Not ready yet
+  //Input::LAMBDAC = false;
+  //Input::LAMBDAC_VERBOSITY = 0;
   // Upsilon generator
-  //  Input::UPSILON = true;
-  // Input::UPSILON_NUMBER = 3; // if you need 3 of them
-  // Input::UPSILON_VERBOSITY = 0;
+  //Input::UPSILON = true;
+  //Input::UPSILON_NUMBER = 3; // if you need 3 of them
+  //Input::UPSILON_VERBOSITY = 0;
 
   //  Input::HEPMC = true;
   INPUTHEPMC::filename = inputFile;
@@ -190,7 +197,7 @@ int Fun4All_G4_sPHENIX(
   // Write the DST
   //======================
 
-  //  Enable::DSTOUT = true;
+  //Enable::DSTOUT = true;
   Enable::DSTOUT_COMPRESS = false;
   DstOut::OutputDir = outdir;
   DstOut::OutputFile = outputFile;
@@ -466,6 +473,17 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::USER) UserAnalysisInit();
 
+  //======================
+  // Run KFParticle on evt
+  //======================
+  Enable::KFPARTICLE = false;
+  Enable::KFPARTICLE_VERBOSITY = 0;
+  //Enable::KFPARTICLE_TRUTH_MATCH = true;
+  //Enable::KFPARTICLE_SAVE_NTUPLE = true;
+  if (Enable::KFPARTICLE && Input::UPSILON) KFParticle_Upsilon_Reco();
+  if (Enable::KFPARTICLE && Input::DZERO) KFParticle_D0_Reco();
+  //if (Enable::KFPARTICLE && Input::LAMBDAC) KFParticle_Lambdac_Reco();
+     
   //----------------------
   // Standard QAs
   //----------------------

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -296,7 +296,11 @@ int Fun4All_G4_sPHENIX(
   Enable::PLUGDOOR_ABSORBER = true;
 
   Enable::GLOBAL_RECO = true;
-  //  Enable::GLOBAL_FASTSIM = true;
+  //Enable::GLOBAL_FASTSIM = true;
+  //Enable::KFPARTICLE = true;
+  //Enable::KFPARTICLE_VERBOSITY = 1;
+  //Enable::KFPARTICLE_TRUTH_MATCH = true;
+  //Enable::KFPARTICLE_SAVE_NTUPLE = true;
 
   Enable::CALOTRIGGER = Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER && false;
 
@@ -476,10 +480,6 @@ int Fun4All_G4_sPHENIX(
   //======================
   // Run KFParticle on evt
   //======================
-  Enable::KFPARTICLE = false;
-  Enable::KFPARTICLE_VERBOSITY = 0;
-  //Enable::KFPARTICLE_TRUTH_MATCH = true;
-  //Enable::KFPARTICLE_SAVE_NTUPLE = true;
   if (Enable::KFPARTICLE && Input::UPSILON) KFParticle_Upsilon_Reco();
   if (Enable::KFPARTICLE && Input::DZERO) KFParticle_D0_Reco();
   //if (Enable::KFPARTICLE && Input::LAMBDAC) KFParticle_Lambdac_Reco();


### PR DESCRIPTION
This PR adds the KFParticle macro to perform Upsilon, D0 and Lc reco

The three reconstructions were tested and work without crashing although the Lc generator is still a work in progress. This will appear in a later PR to core software.

There are some base cuts which are realistic but might be tight for code testing so they can be loosened (or set to effectively no cut). The nTuple output is disabled by default while the DST output is enabled. Truth matching is also disabled by default, only enable it if you know there are truth variables. KFParticle will exit your run rather than skip the event if this is the case