### PR TITLE
Move `ShowerCompress()` to after evaluator and QA calls

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -399,8 +399,6 @@ int Fun4All_G4_sPHENIX(
   if (Enable::FEMC_TOWER) FEMC_Towers();
   if (Enable::FEMC_CLUSTER) FEMC_Clusters();
 
-  if (Enable::DSTOUT_COMPRESS) ShowerCompress();
-
   //--------------
   // SVTX tracking
   //--------------
@@ -516,7 +514,11 @@ int Fun4All_G4_sPHENIX(
   {
     string FullOutFile = DstOut::OutputDir + "/" + DstOut::OutputFile;
     Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
-    if (Enable::DSTOUT_COMPRESS) DstCompress(out);
+    if (Enable::DSTOUT_COMPRESS)
+      {
+        ShowerCompress();
+        DstCompress(out);
+      }
     se->registerOutputManager(out);
   }
   //-----------------


### PR DESCRIPTION
`ShowerCompress()` drop the calorimeter G4hits and G4Cells for a compact DST output. However, in the current call order, the hits are dropped before evaluator and the QA modules, both of which uses hits for check purposes. 

This problem show up in HF MDC1 production jobs where Geant4 QA plots for calorimeters are all empty:
https://github.com/sPHENIX-Collaboration/MDC1/pull/6  

Suggest change the order so hits remain in memory for the evaluator and the QA modules to dig on. Meanwhile, this carry the calorimeter hits in memory through the tracking stage and it may impact the overall memory foot print of the jobs, only when the DST compression is enabled. 

