### PR TITLE
Make acts silicon seeding default

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -89,7 +89,7 @@ namespace G4TRACKING
   bool use_truth_si_matching = false;      // if true, associates silicon clusters using best truth track match to TPC seed tracks - for diagnostics only
   bool use_truth_track_seeding = false;    // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
-  bool use_acts_init_vertexing = false;    // if true runs acts silicon seeding+initial vertexing 
+  bool use_acts_init_vertexing = true;    // if true runs acts silicon seeding+initial vertexing 
   bool use_phinit_vertexing = false && !use_acts_init_vertexing;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_rave_vertexing = true;          // Use Rave to find and fit for vertex after track fitting
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples


### PR DESCRIPTION
After discussion in the tracking meeting today, it was agreed upon that the acts silicon seeder should be made default so that we completely remove our dependence on truth information in the track reconstruction.