### PR TITLE
Added hybrid TPC seeding

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -91,7 +91,7 @@ namespace G4TRACKING
   bool use_truth_si_matching = false;      // if true, associates silicon clusters using best truth track match to TPC seed tracks - for diagnostics only
   bool use_truth_track_seeding = false;    // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
-  bool use_acts_init_vertexing = false;    // if true runs acts silicon seeding+initial vertexing 
+  bool use_acts_init_vertexing = true;    // if true runs acts silicon seeding+initial vertexing 
   bool use_phinit_vertexing = false && !use_acts_init_vertexing;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_rave_vertexing = true;          // Use Rave to find and fit for vertex after track fitting
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples


### PR DESCRIPTION
Alters G4_Tracking.C to include the option to use the PHHybridSeeding module, which contains the STAR seeding core and the ALICE simplified KF.

Now that there are more than two TPC seeding options, there also needed to be a guard against nonsensical configurations. If both PHTpcTracker and PHHybridSeeding are selected, it issues a warning and reverts to the default behavior (i.e. using PHCASeeding).