### PR TITLE
fix second track fit vertex node access

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -468,6 +468,7 @@ void Tracking_Reco()
 
     PHActsTracks *actsTracks2 = new PHActsTracks();
     actsTracks2->Verbosity(verbosity);
+    actsTracks2->setSecondFit(true);
     se->registerSubsystem(actsTracks2);
 
     PHActsTrkFitter* actsFit2 = new PHActsTrkFitter("PHActsSecondTrKFitter");


### PR DESCRIPTION
This PR adds a flag to the second track fit pass so that the correct vertex node is picked up while leaving the Acts vertex writing to the `SvtxVertexMapActs` so that the QA can function with Acts and Rave.