### PR TITLE
Multiple inputmanagers

### DIFF
--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -59,7 +59,9 @@ int Fun4All_G4_EICDetector(
   // about the number of layers used for the cell reco code
   //
   //Input::READHITS = true;
-  INPUTREADHITS::filename = inputFile;
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::filelist[0] = inputFile;
 
   // Or:
   // Use one or more particle generators
@@ -145,6 +147,11 @@ int Fun4All_G4_EICDetector(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
   }
   // particle gun
   // if you run more than one of these Input::GUN_NUMBER > 1

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -61,7 +61,7 @@ int Fun4All_G4_EICDetector(
   //Input::READHITS = true;
   INPUTREADHITS::filename[0] = inputFile;
   // if you use a filelist
-  // INPUTREADHITS::filelist[0] = inputFile;
+  // INPUTREADHITS::listfile[0] = inputFile;
 
   // Or:
   // Use one or more particle generators
@@ -69,7 +69,10 @@ int Fun4All_G4_EICDetector(
   // all other options only play a role if it is active
   // In case embedding into a production output, please double check your G4Setup_EICDetector.C and G4_*.C consistent with those in the production macro folder
   //  Input::EMBED = true;
-  INPUTEMBED::filename = embed_input_file;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  //INPUTEMBED::listfile[0] = embed_input_file;
+
   // Use Pythia 8
   //  Input::PYTHIA8 = true;
 

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -68,7 +68,7 @@ int Fun4All_G4_fsPHENIX(
   Input::READHITS = false;
   INPUTREADHITS::filename[0] = inputFile;
   // if you use a filelist
-  // INPUTREADHITS::filelist[0] = inputFile;
+  // INPUTREADHITS::listfile[0] = inputFile;
   // Or:
   // Use particle generator
   // And
@@ -77,7 +77,9 @@ int Fun4All_G4_fsPHENIX(
   // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
 
   //  Input::EMBED = true;
-  INPUTEMBED::filename = embed_input_file;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  //INPUTEMBED::listfile[0] = embed_input_file;
 
   Input::SIMPLE = true;
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -66,8 +66,9 @@ int Fun4All_G4_fsPHENIX(
   // the simulations step completely. The G4Setup macro is only loaded to get information
   // about the number of layers used for the cell reco code
   Input::READHITS = false;
-  INPUTREADHITS::filename = inputFile;
-
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::filelist[0] = inputFile;
   // Or:
   // Use particle generator
   // And
@@ -144,6 +145,11 @@ int Fun4All_G4_fsPHENIX(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
   }
   // particle gun
   // if you run more than one of these Input::GUN_NUMBER > 1

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -81,7 +81,7 @@ int Fun4All_G4_sPHENIX(
   //  Input::EMBED = true;
   INPUTEMBED::filename[0] = embed_input_file;
   // if you use a filelist
-  INPUTEMBED::listfile[0] = embed_input_file;
+  //INPUTEMBED::listfile[0] = embed_input_file;
 
   Input::SIMPLE = true;
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -71,7 +71,7 @@ int Fun4All_G4_sPHENIX(
   //  Input::READHITS = true;
   INPUTREADHITS::filename[0] = inputFile;
   // if you use a filelist
-  // INPUTREADHITS::filelist[0] = inputFile;
+  // INPUTREADHITS::listfile[0] = inputFile;
   // Or:
   // Use particle generator
   // And
@@ -79,7 +79,9 @@ int Fun4All_G4_sPHENIX(
   // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
   // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   //  Input::EMBED = true;
-  INPUTEMBED::filename = embed_input_file;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  INPUTEMBED::listfile[0] = embed_input_file;
 
   Input::SIMPLE = true;
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -69,8 +69,9 @@ int Fun4All_G4_sPHENIX(
   // the simulations step completely. The G4Setup macro is only loaded to get information
   // about the number of layers used for the cell reco code
   //  Input::READHITS = true;
-  INPUTREADHITS::filename = inputFile;
-
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::filelist[0] = inputFile;
   // Or:
   // Use particle generator
   // And
@@ -153,6 +154,11 @@ int Fun4All_G4_sPHENIX(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
   }
   // particle gun
   // if you run more than one of these Input::GUN_NUMBER > 1


### PR DESCRIPTION
This PR makes it possible to read more than one input file (also for embedding). This requires a small change in our Fun4All macros where the respective filename(s) are now maps and therefore need an index. Existing macros can be adapted easily by appending [0] to the filename. The index is not terribly important, it is used when naming the input manager (and since it is a map you cannot have duplicate indices. I will merge this once the mdc1-5 rebuild is finished