### PR TITLE
remove final IVF

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -443,7 +443,7 @@ void Tracking_Reco()
 #if __cplusplus >= 201703L
   
 
-    PHActsTracks* actsTracks = new PHActsTracks();
+    PHActsTracks* actsTracks = new PHActsTracks("PHActsTracks1");
     actsTracks->Verbosity(verbosity);
     se->registerSubsystem(actsTracks);
 
@@ -462,11 +462,7 @@ void Tracking_Reco()
       se->registerSubsystem(residuals);
     }
 
-    PHActsVertexFinder* vtxer = new PHActsVertexFinder();
-    vtxer->Verbosity(verbosity);
-    se->registerSubsystem(vtxer);
-
-    PHActsTracks *actsTracks2 = new PHActsTracks();
+    PHActsTracks *actsTracks2 = new PHActsTracks("PHActsTracks2");
     actsTracks2->Verbosity(verbosity);
     actsTracks2->setSecondFit(true);
     se->registerSubsystem(actsTracks2);


### PR DESCRIPTION
After discussion in the impromptu tracking meeting today, we agreed that we should remove the final vertexer since it hasn't been tuned for AuAu yet and has only been robustly looked at in low multiplicity. This PR removes the module from the main tracking macro.

We should run a Jenkins QA job with the updated macro to ensure that none of the performance changes significantly. I did some local tests and didn't see anything, but the QA has a knack for finding things 😄 