### PR TITLE
Remove tstring

### DIFF
--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -41,7 +41,7 @@ void BarrelInit()
   if ((G4BARREL::SETTING::BARRELV1 ? 1 : 0) +
       (G4BARREL::SETTING::BARRELV2 ? 1 : 0) +
       (G4BARREL::SETTING::BARRELV3 ? 1 : 0) +
-      (G4BARREL::SETTING::BARRELV4 ? 1 : 0))
+      (G4BARREL::SETTING::BARRELV4 ? 1 : 0) > 1)
   {
     cout << "use only G4BARREL::SETTING::BARRELV1=true or G4BARREL::SETTING::BARRELV2=true or G4BARREL::SETTING::BARRELV3=true or G4BARREL::SETTING::BARRELV4=true" << endl;
 

--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -15,8 +15,8 @@
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4mvtx.so)
 
-int make_barrel_pixel_layer(string name, PHG4Reco *g4Reco, 
-                      double radius, double halflength, double tSilicon);
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon);
 
 //---------------------------------------------------------------------//
 namespace Enable
@@ -24,12 +24,33 @@ namespace Enable
   bool BARREL = false;
   bool BARREL_ABSORBER = false;
 }  // namespace Enable
+
+namespace G4BARREL
+{
+  namespace SETTING
+  {
+    bool BARRELV1 = false;
+    bool BARRELV2 = false;
+    bool BARRELV3 = false;
+    bool BARRELV4 = false;
+  }  // namespace SETTING
+}  // namespace G4BARREL
 //---------------------------------------------------------------------//
 void BarrelInit()
 {
+  if ((G4BARREL::SETTING::BARRELV1 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV2 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV3 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV4 ? 1 : 0))
+  {
+    cout << "use only G4BARREL::SETTING::BARRELV1=true or G4BARREL::SETTING::BARRELV2=true or G4BARREL::SETTING::BARRELV3=true or G4BARREL::SETTING::BARRELV4=true" << endl;
+
+    gSystem->Exit(1);
+  }
 }
+
 //---------------------------------------------------------------------//
-double Barrel(PHG4Reco* g4Reco, double radius, TString specialSetting = "")
+double Barrel(PHG4Reco *g4Reco, double radius)
 {
   const bool AbsorberActive = Enable::ABSORBER || Enable::BARREL_ABSORBER;
 
@@ -40,27 +61,33 @@ double Barrel(PHG4Reco* g4Reco, double radius, TString specialSetting = "")
   const float um = 0.0001;  //convert um to cm
 
   // Different Barrel versions documented in arXiv:2009.0288
-  double r[6]           = { 3.64, 4.81, 5.98, 16.0, 22.0, -1};  //cm
-  double halfLength[6]  = { 20, 20, 25, 25, 25, 25};   //cm
-  double tSilicon[6]    = { 100*um, 100*um, 100*um, 100*um, 100*um, 100*um};
+  double r[6] = {3.64, 4.81, 5.98, 16.0, 22.0, -1};  //cm
+  double halfLength[6] = {20, 20, 25, 25, 25, 25};   //cm
+  double tSilicon[6] = {100 * um, 100 * um, 100 * um, 100 * um, 100 * um, 100 * um};
 
-  if (specialSetting.Contains("BARRELV1") || specialSetting.Contains("BARRELV2")){
-    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50*um;
-  } else if (specialSetting.Contains("BARRELV3")){
-    for (Int_t i = 0; i < 5; i++) tSilicon[i] = 35*um;
-  } else if (specialSetting.Contains("BARRELV4")){
-    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50*um;
-    nLayer  = 6;
-    r[3]    = 9.2;
-    r[4]    = 17.;
-    r[5]    = 27.;
+  if (G4BARREL::SETTING::BARRELV1 || G4BARREL::SETTING::BARRELV2)
+  {
+    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
   }
-  
+  else if (G4BARREL::SETTING::BARRELV3)
+  {
+    for (Int_t i = 0; i < 5; i++) tSilicon[i] = 35 * um;
+  }
+  else if (G4BARREL::SETTING::BARRELV4)
+  {
+    for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
+    nLayer = 6;
+    r[3] = 9.2;
+    r[4] = 17.;
+    r[5] = 27.;
+  }
+
   double max_bh_radius = 0.;
-  for (int i = 0; i < nLayer; i++){
-    make_barrel_pixel_layer(Form("BARREL_%d", i), g4Reco, r[i],  halfLength[i], tSilicon[i]); 
-    max_bh_radius = r[i]+1.5;
-//     std::cout << "done with barrel layer intialization at "<< r[i] << std::endl;
+  for (int i = 0; i < nLayer; i++)
+  {
+    make_barrel_pixel_layer(Form("BARREL_%d", i), g4Reco, r[i], halfLength[i], tSilicon[i]);
+    max_bh_radius = r[i] + 1.5;
+    //     std::cout << "done with barrel layer intialization at "<< r[i] << std::endl;
   }
 
   // update now that we know the outer radius
@@ -68,13 +95,12 @@ double Barrel(PHG4Reco* g4Reco, double radius, TString specialSetting = "")
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer - 1]);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer - 1]);
   return max_bh_radius;
-  
 }
 //---------------------------------------------------------------------//
 //-----------------------------------------------------------------------------------//
-int make_barrel_pixel_layer(string name, PHG4Reco *g4Reco, 
-                      double radius, double halflength, double tSilicon){
-
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon)
+{
   //---------------------------------
   //build barrel layer
   //---------------------------------
@@ -87,17 +113,18 @@ int make_barrel_pixel_layer(string name, PHG4Reco *g4Reco,
                                  "Support1", "Support_Gap", "Support2"};
   string material[nSubLayer] = {"G4_Si", "G4_Al", "G4_KAPTON", "G4_WATER",
                                 "G4_GRAPHITE", "G4_AIR", "G4_GRAPHITE"};
-  double thickness[nSubLayer] = {tSilicon , 15 * um, 20 * um, 100 * um,
+  double thickness[nSubLayer] = {tSilicon, 15 * um, 20 * um, 100 * um,
                                  50 * um, 1, 50 * um};
 
   double max_bh_radius = 0.;
-  PHG4CylinderSubsystem* cyl;
+  PHG4CylinderSubsystem *cyl;
   cout << "started to create cylinder layer: " << name << endl;
-  
+
   double currRadius = radius;
-//   cout << currRadius << endl;
-  for (int l = 0; l < nSubLayer; l++) {
-    cyl = new PHG4CylinderSubsystem(name + "_" + layerName[l],l);
+  //   cout << currRadius << endl;
+  for (int l = 0; l < nSubLayer; l++)
+  {
+    cyl = new PHG4CylinderSubsystem(name + "_" + layerName[l], l);
     cyl->SuperDetector(name);
     cyl->set_double_param("radius", currRadius);
     cyl->set_double_param("length", 2.0 * halflength);
@@ -106,13 +133,12 @@ int make_barrel_pixel_layer(string name, PHG4Reco *g4Reco,
     if (l == 0) cyl->SetActive();  //only the Silicon Sensor is active
     cyl->OverlapCheck(true);
     g4Reco->registerSubsystem(cyl);
-    currRadius = currRadius+thickness[l];
+    currRadius = currRadius + thickness[l];
   }
 
   return 0;
 }
 
 //-----------------------------------------------------------------------------------//
-
 
 #endif

--- a/common/G4_FGEM_fsPHENIX.C
+++ b/common/G4_FGEM_fsPHENIX.C
@@ -267,7 +267,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -277,7 +277,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -299,7 +299,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -309,7 +309,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -319,7 +319,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -51,15 +51,41 @@ namespace G4FHCAL
   enu_FHcal_clusterizer FHcal_clusterizer = kFHcalTemplateClusterizer;
   // graph clusterizer
   //enu_FHcal_clusterizer FHcal_clusterizer = kFHcalGraphClusterizer;
+  namespace SETTING
+  {
+    bool FullEtaAcc = false;
+    bool HC2x = false;
+    bool HC4x = false;
+    bool towercalib1 = false;
+    bool towercalibSiPM = false;
+    bool towercalibHCALIN = false;
+    bool towercalib3 = false;
+  }  // namespace SETTING
 }  // namespace G4FHCAL
 
 void FHCALInit()
 {
+  // simple way to check if only 1 of the settings is true
+  if ((G4FHCAL::SETTING::FullEtaAcc ? 1 : 0) + (G4FHCAL::SETTING::HC4x ? 1 : 0) + (G4FHCAL::SETTING::HC2x ? 1 : 0) > 1)
+  {
+    cout << "use only  G4FHCAL::SETTING::FullEtaAcc=true or G4FHCAL::SETTING::HC2x=true or G4FHCAL::SETTING::HC4x=true" << endl;
+    gSystem->Exit(1);
+  }
+  if ((G4FHCAL::SETTING::towercalib1 ? 1 : 0) + (G4FHCAL::SETTING::towercalibSiPM ? 1 : 0) +
+          (G4FHCAL::SETTING::towercalibHCALIN ? 1 : 0) + (G4FHCAL::SETTING::towercalib3 ? 1 : 0) >
+      1)
+  {
+    cout << "use only G4FHCAL::SETTING::towercalib1 = true or G4FHCAL::SETTING::towercalibSiPM = true"
+         << " or G4FHCAL::SETTING::towercalibHCALIN = true or G4FHCAL::SETTING::towercalib3 = true" << endl;
+    gSystem->Exit(1);
+  }
+
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FHCAL::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FHCAL::Gz0 + G4FHCAL::Gdz / 2.);
 }
 
-void FHCALSetup(PHG4Reco *g4Reco, TString specialSetting = ""){
+void FHCALSetup(PHG4Reco *g4Reco)
+{
   const bool AbsorberActive = Enable::ABSORBER || Enable::FHCAL_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FHCAL_OVERLAPCHECK;
   Fun4AllServer *se = Fun4AllServer::instance();
@@ -71,16 +97,16 @@ void FHCALSetup(PHG4Reco *g4Reco, TString specialSetting = ""){
 
   // Switch to desired calo setup
   // full HCal Fe-Scint with nominal acceptance
-  if (specialSetting.Contains("FullEtaAcc"))
+  if (G4FHCAL::SETTING::FullEtaAcc)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
   // full HCal Fe-Scint with nominal acceptance doubled granularity
-  else if (specialSetting.Contains("HC2x"))
+  else if (G4FHCAL::SETTING::HC2x)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
   // full HCal Fe-Scint with nominal acceptance four times granularity
-  else if (specialSetting.Contains("HC4x"))
+  else if (G4FHCAL::SETTING::HC2x)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
   // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
-  else 
+  else
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
 
   hhcal->SetTowerMappingFile(mapping_fhcal.str());
@@ -96,7 +122,7 @@ void FHCAL_Cells(int verbosity = 0)
   return;
 }
 
-void FHCAL_Towers( TString specialSetting = "")
+void FHCAL_Towers()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
 
@@ -106,28 +132,29 @@ void FHCAL_Towers( TString specialSetting = "")
 
   // Switch to desired calo setup
   // full HCal Fe-Scint with nominal acceptance
-  if (specialSetting.Contains("FullEtaAcc"))
+  if (G4FHCAL::SETTING::FullEtaAcc)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
   // full HCal Fe-Scint with nominal acceptance doubled granularity
-  else if (specialSetting.Contains("HC2x"))
+  else if (G4FHCAL::SETTING::HC2x)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
   // full HCal Fe-Scint with nominal acceptance four times granularity
-  else if (specialSetting.Contains("HC4x"))
+  else if (G4FHCAL::SETTING::HC4x)
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
   // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
-  else 
+  else
     mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
-                
+
   RawTowerBuilderByHitIndex *tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");
   tower_FHCAL->Detector("FHCAL");
   tower_FHCAL->set_sim_tower_node_prefix("SIM");
   tower_FHCAL->GeometryTableFile(mapping_fhcal.str());
 
   se->registerSubsystem(tower_FHCAL);
-  
+
   // enable usage of different tower calibrations for systematic studies
-  if(specialSetting.Contains("towercalib1")){
-    cout << "1: using " << specialSetting.Data() << " for FHCAL towers" << endl;
+  if (G4FHCAL::SETTING::towercalib1)
+  {
+    cout << "1: using towercalib1 for FHCAL towers" << endl;
     const double FHCAL_photoelectron_per_GeV = 500;
     RawTowerDigitizer *TowerDigitizer_FHCAL = new RawTowerDigitizer("FHCALRawTowerDigitizer");
 
@@ -136,29 +163,31 @@ void FHCAL_Towers( TString specialSetting = "")
     TowerDigitizer_FHCAL->set_raw_tower_node_prefix("RAW");
     TowerDigitizer_FHCAL->set_digi_algorithm(RawTowerDigitizer::kSiPM_photon_digitization);
     TowerDigitizer_FHCAL->set_pedstal_central_ADC(0);
-    TowerDigitizer_FHCAL->set_pedstal_width_ADC(8);// eRD1 test beam setting
-    TowerDigitizer_FHCAL->set_photonelec_ADC(1);//not simulating ADC discretization error
-    TowerDigitizer_FHCAL->set_photonelec_yield_visible_GeV( FHCAL_photoelectron_per_GeV );
-    TowerDigitizer_FHCAL->set_zero_suppression_ADC(16); // eRD1 test beam setting
+    TowerDigitizer_FHCAL->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+    TowerDigitizer_FHCAL->set_photonelec_ADC(1);     //not simulating ADC discretization error
+    TowerDigitizer_FHCAL->set_photonelec_yield_visible_GeV(FHCAL_photoelectron_per_GeV);
+    TowerDigitizer_FHCAL->set_zero_suppression_ADC(16);  // eRD1 test beam setting
 
-    se->registerSubsystem( TowerDigitizer_FHCAL );
+    se->registerSubsystem(TowerDigitizer_FHCAL);
 
     RawTowerCalibration *TowerCalibration_FHCAL = new RawTowerCalibration("FHCALRawTowerCalibration");
     TowerCalibration_FHCAL->Detector("FHCAL");
     TowerCalibration_FHCAL->Verbosity(verbosity);
     TowerCalibration_FHCAL->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-    TowerCalibration_FHCAL->set_calib_const_GeV_ADC( 1. / FHCAL_photoelectron_per_GeV );
-    TowerCalibration_FHCAL->set_pedstal_ADC( 0 );
+    TowerCalibration_FHCAL->set_calib_const_GeV_ADC(1. / FHCAL_photoelectron_per_GeV);
+    TowerCalibration_FHCAL->set_pedstal_ADC(0);
 
-    se->registerSubsystem( TowerCalibration_FHCAL );
-  } else if(specialSetting.Contains("towercalibSiPM")){
+    se->registerSubsystem(TowerCalibration_FHCAL);
+  }
+  else if (G4FHCAL::SETTING::towercalibSiPM)
+  {
     //from https://sphenix-collaboration.github.io/doxygen/d4/d58/Fun4All__G4__Prototype4_8C_source.html
-    const double sampling_fraction =0.019441;    //  +/-  0.019441 from 0 Degree indenting 12 GeV electron showers
+    const double sampling_fraction = 0.019441;     //  +/-  0.019441 from 0 Degree indenting 12 GeV electron showers
     const double photoelectron_per_GeV = 500;      //500 photon per total GeV deposition
     const double ADC_per_photoelectron_HG = 3.8;   // From Sean Stoll, Mar 29
     const double ADC_per_photoelectron_LG = 0.24;  // From Sean Stoll, Mar 29
 
-    cout << "2: using " << specialSetting.Data() << " for FHCAL towers" << endl;
+    cout << "2: using towercalibSiPM for FHCAL towers" << endl;
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
     TowerDigitizer->Detector("FHCAL");
     TowerDigitizer->set_raw_tower_node_prefix("RAW");
@@ -170,7 +199,6 @@ void FHCAL_Towers( TString specialSetting = "")
     TowerDigitizer->set_zero_suppression_ADC(-1000);  // no-zero suppression
     se->registerSubsystem(TowerDigitizer);
 
-
     RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
     TowerCalibration->Detector("FHCAL");
     TowerCalibration->set_raw_tower_node_prefix("RAW");
@@ -179,7 +207,9 @@ void FHCAL_Towers( TString specialSetting = "")
     TowerCalibration->set_pedstal_ADC(0);
     TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
     se->registerSubsystem(TowerCalibration);
-  } else if(specialSetting.Contains("towercalibHCALIN")){
+  }
+  else if (G4FHCAL::SETTING::towercalibHCALIN)
+  {
     const double visible_sample_fraction_HCALIN = 7.19505e-02;  // 1.34152e-02
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
     TowerDigitizer->Detector("FHCAL");
@@ -200,12 +230,14 @@ void FHCAL_Towers( TString specialSetting = "")
     TowerCalibration->set_pedstal_ADC(0);
     TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
     se->registerSubsystem(TowerCalibration);
-  } else if(specialSetting.Contains("towercalib3")){
-    cout << "3: using " << specialSetting.Data() << " for FHCAL towers" << endl;
+  }
+  else if (G4FHCAL::SETTING::towercalib3)
+  {
+    cout << "3: using towercalib3 for FHCAL towers" << endl;
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
     TowerDigitizer->Detector("FHCAL");
     TowerDigitizer->set_pedstal_central_ADC(0);
-    TowerDigitizer->set_pedstal_width_ADC(8);// eRD1 test beam setting
+    TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
     TowerDigitizer->Verbosity(verbosity);
     TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
     se->registerSubsystem(TowerDigitizer);
@@ -217,7 +249,9 @@ void FHCAL_Towers( TString specialSetting = "")
     TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
     TowerCalibration->set_pedstal_ADC(0);
     se->registerSubsystem(TowerCalibration);
-  } else {
+  }
+  else
+  {
     cout << "def: using default for FHCAL towers" << endl;
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
     TowerDigitizer->Detector("FHCAL");

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -11,21 +11,47 @@
 
 R__LOAD_LIBRARY(libg4detectors.so)
 
-int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
-                          double Rmax,double tSilicon);
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax, double tSilicon);
 //-----------------------------------------------------------------------------------//
 namespace Enable
 {
   static bool FST = false;
 }
+
+namespace G4FST
+{
+  namespace SETTING
+  {
+    bool FSTV1 = false;
+    bool FSTV2 = false;
+    bool FSTV3 = false;
+    bool FSTV41 = false;
+    bool FSTV42 = false;
+    bool FSTV4 = false;
+  }  // namespace SETTING
+}  // namespace G4FST
+
 //-----------------------------------------------------------------------------------//
 void FST_Init()
 {
+  if ((G4FST::SETTING::FSTV1 ? 1 : 0) +
+          (G4FST::SETTING::FSTV2 ? 1 : 0) +
+          (G4FST::SETTING::FSTV3 ? 1 : 0) +
+          (G4FST::SETTING::FSTV4 ? 1 : 0) +
+          (G4FST::SETTING::FSTV41 ? 1 : 0) +
+          (G4FST::SETTING::FSTV42 ? 1 : 0) >
+      1)
+  {
+    cout << "use only G4FST::SETTING::FSTV1=true or G4FST::SETTING::FSTV2=true or G4FST::SETTING::FSTV13 = true or G4FST::SETTING::FSTV3=true or G4FST::SETTING::FSTV4=true or G4FST::SETTING::FSTV41=true or G4FST::SETTING::FSTV42=true" << endl;
+    gSystem->Exit(1);
+  }
+
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 44.);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 282.);
 }
 //-----------------------------------------------------------------------------------//
-void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245, TString specialSetting = "")
+void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
 {
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;
@@ -33,57 +59,69 @@ void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245, TString specialSet
 
   //Design from Xuan Li @LANL
   // Different FST version documented in arXiv:2009.0288
-  if ( specialSetting.Contains("FSTV1")){ // version 1
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    25, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  36, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 50*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 50*um);
-  } if ( specialSetting.Contains("FSTV2")){ // version 2
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    30, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  35, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 50*um);
-    make_LANL_FST_station("FST_4", g4Reco, 270, 6.5,  45, 50*um);
-  } if ( specialSetting.Contains("FSTV3")){ // version 3
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    25, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  36, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 100*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 100*um);
-  } if ( specialSetting.Contains("FSTV41")){ // version 4.1
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    25, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  36, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 50*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 100*um);
-    make_LANL_FST_station("FST_5", g4Reco, 270, 15,   45, 100*um);
-  } if ( specialSetting.Contains("FSTV42")){ // version 4.1
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    25, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  36, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 100*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 100*um);
-    make_LANL_FST_station("FST_5", g4Reco, 270, 15,   45, 100*um);
-  } if ( specialSetting.Contains("FSTV4")){ // version 4
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    25, 50*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  36, 50*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 50*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 50*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 50*um);
-    make_LANL_FST_station("FST_5", g4Reco, 270, 15,   45, 50*um);
-  } else { // Version 0 
-    make_LANL_FST_station("FST_0", g4Reco, 35,  4,    30, 100*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 53,  4.5,  35, 100*um);
-    make_LANL_FST_station("FST_2", g4Reco, 77,  5,    36, 100*um);
-    make_LANL_FST_station("FST_3", g4Reco, 101, 6,    38.5, 100*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5,  45, 100*um);
-  } 
-  
+  if (G4FST::SETTING::FSTV1)
+  {                                                              // version 1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+  }
+  if (G4FST::SETTING::FSTV2)
+  {                                                              // version 2
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 270, 6.5, 45, 50 * um);
+  }
+  if (G4FST::SETTING::FSTV3)
+  {                                                              // version 3
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
+  if (G4FST::SETTING::FSTV41)
+  {                                                              // version 4.1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  if (G4FST::SETTING::FSTV42)
+  {                                                              // version 4.1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  if (G4FST::SETTING::FSTV4)
+  {                                                              // version 4
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 50 * um);
+  }
+  else
+  {                                                               // Version 0
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 100 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 100 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 100 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
 }
 //-----------------------------------------------------------------------------------//
-int make_LANL_FST_station(string name, PHG4Reco *g4Reco,
-			  double zpos, double Rmin, double Rmax,double tSilicon) //silicon thickness
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco,
+                          double zpos, double Rmin, double Rmax, double tSilicon)  //silicon thickness
 {
   //  cout
   //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "


### PR DESCRIPTION
This PR removes the recently introduce TString interfaces. Options and settings should be set via namespaces. That maybe clunky and we can change this if there is a better idea but there should only be one way to set stuff up. Besides checking for substrings without any naming convention will lead to problems later on if options strings are not unique (or one is a substring of another otion)