### PR TITLE
Initial Vertexing

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -90,7 +90,8 @@ namespace G4TRACKING
   bool use_truth_si_matching = false;      // if true, associates silicon clusters using best truth track match to TPC seed tracks - for diagnostics only
   bool use_truth_track_seeding = false;    // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
-  bool use_acts_init_vertexing = true;    // if true runs acts silicon seeding+initial vertexing 
+  bool use_acts_silicon_seeding = true;   // if true runs acts silicon seeding
+  bool use_acts_init_vertexing = false;    // if true runs acts initial vertex finder, false runs truth vertexing
   bool use_phinit_vertexing = false && !use_acts_init_vertexing;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_rave_vertexing = true;          // Use Rave to find and fit for vertex after track fitting
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
@@ -198,18 +199,26 @@ void Tracking_Reco()
 
   // Initial vertex finding
   //=================================
-  if(G4TRACKING::use_acts_init_vertexing && !G4TRACKING::use_Genfit)
+  if(G4TRACKING::use_acts_silicon_seeding && !G4TRACKING::use_Genfit)
     {
       #if __cplusplus >= 201703L
 
       PHActsSiliconSeeding* silicon_Seeding = new PHActsSiliconSeeding();
       silicon_Seeding->Verbosity(verbosity);
       se->registerSubsystem(silicon_Seeding);
-
-      PHActsInitialVertexFinder* init_vtx = new PHActsInitialVertexFinder();
-      init_vtx->Verbosity(verbosity);
-      se->registerSubsystem(init_vtx);
-
+      
+      if(G4TRACKING::use_acts_init_vertexing)
+	{
+	  PHActsInitialVertexFinder* init_vtx = new PHActsInitialVertexFinder();
+	  init_vtx->Verbosity(verbosity);
+	  se->registerSubsystem(init_vtx);
+	}
+      else
+	{
+	  PHTruthVertexing *init_vtx = new PHTruthVertexing();
+	  init_vtx->Verbosity(verbosity);
+	  se->registerSubsystem(init_vtx);
+	}
       #endif
     }
   else if (G4TRACKING::use_phinit_vertexing)
@@ -441,7 +450,7 @@ void Tracking_Reco()
 #if __cplusplus >= 201703L
   
 
-    PHActsTracks* actsTracks = new PHActsTracks();
+    PHActsTracks* actsTracks = new PHActsTracks("PHActsTracks1");
     actsTracks->Verbosity(verbosity);
     se->registerSubsystem(actsTracks);
 
@@ -464,7 +473,7 @@ void Tracking_Reco()
     vtxer->Verbosity(verbosity);
     se->registerSubsystem(vtxer);
 
-    PHActsTracks *actsTracks2 = new PHActsTracks();
+    PHActsTracks *actsTracks2 = new PHActsTracks("PHActsTracks2");
     actsTracks2->Verbosity(verbosity);
     actsTracks2->setSecondFit(true);
     se->registerSubsystem(actsTracks2);
@@ -525,7 +534,7 @@ void Tracking_Eval(const std::string& outputfile)
   eval->do_gpoint_eval(false);
   eval->do_eval_light(true);
   eval->set_use_initial_vertex(G4TRACKING::g4eval_use_initial_vertex);
-  eval->scan_for_embedded(false);  // take all tracks if false - take only embedded tracks if true
+  eval->scan_for_embedded(true);  // take all tracks if false - take only embedded tracks if true
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -39,7 +39,6 @@
 #include <trackreco/PHActsTrkProp.h>
 #include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHActsVertexFinder.h>
-#include <trackreco/PHActsVertexFitter.h>
 #include <trackreco/PHTpcResiduals.h>
 #endif
 
@@ -207,9 +206,8 @@ void Tracking_Reco()
       silicon_Seeding->Verbosity(verbosity);
       se->registerSubsystem(silicon_Seeding);
 
-      PHTruthVertexing* init_vtx = new PHTruthVertexing("PHTruthVertexing");
+      PHActsInitialVertexFinder* init_vtx = new PHActsInitialVertexFinder();
       init_vtx->Verbosity(verbosity);
-      init_vtx->set_acts_silicon(true);
       se->registerSubsystem(init_vtx);
 
       #endif


### PR DESCRIPTION
After tuning and testing the initial vertexer, this PR adds it to the tracking macro with a flag. The truth vertexing is still run by default in this PR so as to not cause any possible issues to users currently working with the MDC data - tracking experts can continue testing it.