### PR TITLE
Applying beam parameters (e.g. crossing angle) to detector simulation macros

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -94,7 +94,7 @@ namespace Input
     if (HepMCGen == nullptr)
     {
       std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
-      exit (1);
+      exit(1);
     }
     HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2020-001
 
@@ -118,20 +118,31 @@ namespace Input
     if (HepMCGen == nullptr)
     {
       std::cout << "ApplyEICBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
-      exit (1);
+      exit(1);
     }
 
     //25mrad x-ing as in EIC CDR
+    const double EIC_hadron_crossing_angle = 25e-3;
+
     HepMCGen->set_beam_direction_theta_phi(
-        25e-3,  // beamA_theta
-        0,      // beamA_phi
-        M_PI,   // beamB_theta
-        0       // beamB_phi
+        EIC_hadron_crossing_angle,  // beamA_theta
+        0,                          // beamA_phi
+        M_PI,                       // beamB_theta
+        0                           // beamB_phi
     );
     HepMCGen->set_beam_angular_divergence_hv(
         119e-6, 119e-6,  // proton beam divergence horizontal & vertical, as in EIC CDR Table 1.1
         211e-6, 152e-6   // electron beam divergence horizontal & vertical, as in EIC CDR Table 1.1
     );
+
+    // angular kick within a bunch as result of crab cavity
+    // using an naive assumption of transfer matrix from the cavity to IP,
+    // which is NOT yet validated with accelerator optics simulations!
+    const double z_hadron_cavity = 52e3;  // CDR Fig 3.3
+    const double z_e_cavity = 38e2;       // CDR Fig 3.2
+    HepMCGen->set_beam_angular_z_coefficient_hv(
+        -EIC_hadron_crossing_angle / 2. / z_hadron_cavity, 0,
+        -EIC_hadron_crossing_angle / 2. / z_e_cavity, 0);
 
     // calculate beam sigma width at IP  as in EIC CDR table 1.1
     const double sigma_p_h = sqrt(80 * 11.3e-7);

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -138,7 +138,7 @@ namespace Input
     // angular kick within a bunch as result of crab cavity
     // using an naive assumption of transfer matrix from the cavity to IP,
     // which is NOT yet validated with accelerator optics simulations!
-    const double z_hadron_cavity = 52e3;  // CDR Fig 3.3
+    const double z_hadron_cavity = 52e2;  // CDR Fig 3.3
     const double z_e_cavity = 38e2;       // CDR Fig 3.2
     HepMCGen->set_beam_angular_z_coefficient_hv(
         -EIC_hadron_crossing_angle / 2. / z_hadron_cavity, 0,

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -120,10 +120,16 @@ namespace Input
     }
     //INPUTMANAGER::HepMCInputManager->set_beam_direction_theta_phi(1e-3,0,M_PI - 1e-3,0); //2mrad x-ing of sPHENIX
 
-    HepMCGen->set_beam_direction_theta_phi(25e-3, 0, M_PI, 0);  //25mrad x-ing as in EIC CDR
+    //25mrad x-ing as in EIC CDR
+    HepMCGen->set_beam_direction_theta_phi(
+        25e-3,  // beamA_theta
+        0,      // beamA_phi
+        M_PI,   // beamB_theta
+        0       // beamB_phi
+    );
     HepMCGen->set_beam_angular_divergence_hv(
-        119e-6, 119e-6,   // proton beam as in EIC CDR Table 1.1
-        211e-6, 152e-6    // electron beam as in EIC CDR Table 1.1
+        119e-6, 119e-6,  // proton beam divergence horizontal & vertical, as in EIC CDR Table 1.1
+        211e-6, 152e-6   // electron beam divergence horizontal & vertical, as in EIC CDR Table 1.1
     );
 
     // calculate beam sigma width at IP  as in EIC CDR table 1.1
@@ -139,15 +145,15 @@ namespace Input
     const double collision_sigma_t = collision_sigma_z / 29.9792;  // speed of light in cm/ns
 
     HepMCGen->set_vertex_distribution_width(
-        sigma_p_h * sigma_e_h / sqrt(sigma_p_h * sigma_p_h + sigma_e_h * sigma_e_h),
-        sigma_p_v * sigma_e_v / sqrt(sigma_p_v * sigma_p_v + sigma_e_v * sigma_e_v),
-        collision_sigma_z,
-        collision_sigma_t);
+        sigma_p_h * sigma_e_h / sqrt(sigma_p_h * sigma_p_h + sigma_e_h * sigma_e_h),  //x
+        sigma_p_v * sigma_e_v / sqrt(sigma_p_v * sigma_p_v + sigma_e_v * sigma_e_v),  //y
+        collision_sigma_z,                                                            //z
+        collision_sigma_t);                                                           //t
     HepMCGen->set_vertex_distribution_function(
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus);
+        PHHepMCGenHelper::Gaus,   //x
+        PHHepMCGenHelper::Gaus,   //y
+        PHHepMCGenHelper::Gaus,   //z
+        PHHepMCGenHelper::Gaus);  //t
   }
 }  // namespace Input
 

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -94,6 +94,7 @@ namespace Input
     if (HepMCGen == nullptr)
     {
       std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
+      exit (1);
     }
     HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2020-001
 
@@ -117,8 +118,8 @@ namespace Input
     if (HepMCGen == nullptr)
     {
       std::cout << "ApplyEICBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
+      exit (1);
     }
-    //INPUTMANAGER::HepMCInputManager->set_beam_direction_theta_phi(1e-3,0,M_PI - 1e-3,0); //2mrad x-ing of sPHENIX
 
     //25mrad x-ing as in EIC CDR
     HepMCGen->set_beam_direction_theta_phi(

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -109,7 +109,7 @@ namespace Input
         PHHepMCGenHelper::Gaus);
   }
 
-  //! apply EIC beam parameter to any HepMC generator,
+  //! apply EIC beam parameter to any HepMC generator following EIC CDR,
   //! including in-time collision's space time shift, beam crossing angle and angular divergence
   //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, PHSartre, ReadEICFiles
   void ApplyEICBeamParameter(PHHepMCGenHelper *HepMCGen)

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -18,10 +18,10 @@
 
 #include <fermimotionafterburner/FermimotionAfterburner.h>
 
-#include <phhepmc/PHHepMCGenHelper.h>
 #include <phhepmc/Fun4AllHepMCInputManager.h>
 #include <phhepmc/Fun4AllHepMCPileupInputManager.h>
 #include <phhepmc/HepMCFlowAfterBurner.h>
+#include <phhepmc/PHHepMCGenHelper.h>
 
 #include <phsartre/PHSartre.h>
 #include <phsartre/PHSartreParticleTrigger.h>
@@ -90,18 +90,18 @@ namespace Input
   //! apply EIC beam parameter to any HepMC generator,
   //! including in-time collision's space time shift, beam crossing angle and angular divergence
   //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, PHSartre, ReadEICFiles
-  void ApplyEICBeamParameter(PHHepMCGenHelper * HepMCGen)
+  void ApplyEICBeamParameter(PHHepMCGenHelper *HepMCGen)
   {
     if (HepMCGen == nullptr)
     {
-      std::cout << "ApplyEICBeamParameter(): Fatal Error - null input pointer HepMCGen"<<std::endl;
+      std::cout << "ApplyEICBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
     }
     //INPUTMANAGER::HepMCInputManager->set_beam_direction_theta_phi(1e-3,0,M_PI - 1e-3,0); //2mrad x-ing of sPHENIX
 
-    HepMCGen->set_beam_direction_theta_phi(25e-3,0,M_PI ,0); //25mrad x-ing as in EIC CDR
+    HepMCGen->set_beam_direction_theta_phi(25e-3, 0, M_PI, 0);  //25mrad x-ing as in EIC CDR
     HepMCGen->set_beam_angular_divergence_hv(
-        119-6, 119e-6, // EIC CDR Table 1.1
-        211e-6, 152e-6 // EIC CDR Table 1.1
+        119 - 6, 119e-6,  // EIC CDR Table 1.1
+        211e-6, 152e-6    // EIC CDR Table 1.1
     );
 
     // calculate beam sigma width at IP  as in EIC CDR table 1.1
@@ -113,22 +113,20 @@ namespace Input
     const double sigma_e_l = 2;
 
     // combine two beam gives the collision sigma in z
-    const double collision_sigma_z = sqrt(sigma_p_l*sigma_p_l+sigma_e_l*sigma_e_l)/2;
-    const double collision_sigma_t = collision_sigma_z / 29.9792; // speed of light in cm/ns
+    const double collision_sigma_z = sqrt(sigma_p_l * sigma_p_l + sigma_e_l * sigma_e_l) / 2;
+    const double collision_sigma_t = collision_sigma_z / 29.9792;  // speed of light in cm/ns
 
     HepMCGen->set_vertex_distribution_width(
-        sigma_p_h*sigma_e_h / sqrt(sigma_p_h*sigma_p_h+sigma_e_h*sigma_e_h),
-        sigma_p_v*sigma_e_v / sqrt(sigma_p_v*sigma_p_v+sigma_e_v*sigma_e_v),
+        sigma_p_h * sigma_e_h / sqrt(sigma_p_h * sigma_p_h + sigma_e_h * sigma_e_h),
+        sigma_p_v * sigma_e_v / sqrt(sigma_p_v * sigma_p_v + sigma_e_v * sigma_e_v),
         collision_sigma_z,
-        collision_sigma_t );
+        collision_sigma_t);
     HepMCGen->set_vertex_distribution_function(
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus);
   }
-
-
 
 }  // namespace Input
 

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -87,6 +87,28 @@ namespace Input
   int VERBOSITY = 0;
   int EmbedId = 1;
 
+  //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+  //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, PHSartre, ReadEICFiles
+  void ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen)
+  {
+    if (HepMCGen == nullptr)
+    {
+      std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
+    }
+    HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2020-001
+
+    HepMCGen->set_vertex_distribution_width(
+        100e-4,         // approximation from past RICH data
+        100e-4,         // approximation from past RICH data
+        7,              // sPH-TRG-2020-001. Fig 3.2
+        20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+    HepMCGen->set_vertex_distribution_function(
+        PHHepMCGenHelper::Gaus,
+        PHHepMCGenHelper::Gaus,
+        PHHepMCGenHelper::Gaus,
+        PHHepMCGenHelper::Gaus);
+  }
+
   //! apply EIC beam parameter to any HepMC generator,
   //! including in-time collision's space time shift, beam crossing angle and angular divergence
   //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, PHSartre, ReadEICFiles
@@ -127,7 +149,6 @@ namespace Input
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus);
   }
-
 }  // namespace Input
 
 namespace INPUTHEPMC

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -122,8 +122,8 @@ namespace Input
 
     HepMCGen->set_beam_direction_theta_phi(25e-3, 0, M_PI, 0);  //25mrad x-ing as in EIC CDR
     HepMCGen->set_beam_angular_divergence_hv(
-        119 - 6, 119e-6,  // EIC CDR Table 1.1
-        211e-6, 152e-6    // EIC CDR Table 1.1
+        119e-6, 119e-6,   // proton beam as in EIC CDR Table 1.1
+        211e-6, 152e-6    // electron beam as in EIC CDR Table 1.1
     );
 
     // calculate beam sigma width at IP  as in EIC CDR table 1.1

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -168,6 +168,20 @@ int Fun4All_G4_EICDetector(
   if (Input::PYTHIA6)
   {
     INPUTGENERATOR::Pythia6->set_config_file(string(getenv("CALIBRATIONROOT")) + "/Generators/phpythia6_ep.cfg");
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia6);
+  }
+  // pythia8
+  if (Input::PYTHIA8)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Pythia8);
+  }
+  // Sartre
+  if (Input::SARTRE)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::Sartre);
   }
 
   //--------------
@@ -177,10 +191,13 @@ int Fun4All_G4_EICDetector(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 30, 0);  //optional collision smear in space, time
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTMANAGER::HepMCInputManager);
+    // optional overriding beam parameters
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 30, 0);  //optional collision smear in space, time
                                                                                             //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
+    // INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     //! embedding ID for the event
     //! positive ID is the embedded event of interest, e.g. jetty event from pythia
     //! negative IDs are backgrounds, .e.g out of time pile up collisions

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -162,6 +162,19 @@ int Fun4All_G4_fsPHENIX(
     INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
   }
 
+  // pythia6
+  if (Input::PYTHIA6)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia6);
+  }
+  // pythia8
+  if (Input::PYTHIA8)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia8);
+  }
+
   //--------------
   // Set Input Manager specific options
   //--------------
@@ -169,15 +182,14 @@ int Fun4All_G4_fsPHENIX(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
-                                                                                           //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCInputManager);
+
+    // optional overriding beam parameters
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
+    //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
-    //! embedding ID for the event
-    //! positive ID is the embedded event of interest, e.g. jetty event from pythia
-    //! negative IDs are backgrounds, .e.g out of time pile up collisions
-    //! Usually, ID = 0 means the primary Au+Au collision background
-    //INPUTMANAGER::HepMCInputManager->set_embedding_id(Input::EmbedID);
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     if (Input::PILEUPRATE > 0)
     {
       // Copy vertex settings from foreground hepmc input
@@ -185,6 +197,11 @@ int Fun4All_G4_fsPHENIX(
       // and then modify the ones you want to be different
       // INPUTMANAGER::HepMCPileupInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);
     }
+  }
+  if (Input::PILEUPRATE > 0)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCPileupInputManager);
   }
 
   // register all input generators with Fun4All

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -171,6 +171,19 @@ int Fun4All_G4_sPHENIX(
     INPUTGENERATOR::Gun[0]->set_vtx(0, 0, 0);
   }
 
+  // pythia6
+  if (Input::PYTHIA6)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia6);
+  }
+  // pythia8
+  if (Input::PYTHIA8)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia8);
+  }
+
   //--------------
   // Set Input Manager specific options
   //--------------
@@ -178,10 +191,14 @@ int Fun4All_G4_sPHENIX(
 
   if (Input::HEPMC)
   {
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
-                                                                                           //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCInputManager);
+
+    // optional overriding beam parameters
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_width(100e-4, 100e-4, 8, 0);  //optional collision smear in space, time
+    //    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_mean(0,0,0,0);//optional collision central position shift in space, time
     // //optional choice of vertex distribution function in space, time
-    INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
+    //INPUTMANAGER::HepMCInputManager->set_vertex_distribution_function(PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus);
     //! embedding ID for the event
     //! positive ID is the embedded event of interest, e.g. jetty event from pythia
     //! negative IDs are backgrounds, .e.g out of time pile up collisions
@@ -194,6 +211,11 @@ int Fun4All_G4_sPHENIX(
       // and then modify the ones you want to be different
       // INPUTMANAGER::HepMCPileupInputManager->set_vertex_distribution_width(100e-4,100e-4,8,0);
     }
+  }
+  if (Input::PILEUPRATE > 0)
+  {
+    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCPileupInputManager);
   }
   // register all input generators with Fun4All
   InputRegister();
@@ -489,7 +511,7 @@ int Fun4All_G4_sPHENIX(
   if (Enable::KFPARTICLE && Input::UPSILON) KFParticle_Upsilon_Reco();
   if (Enable::KFPARTICLE && Input::DZERO) KFParticle_D0_Reco();
   //if (Enable::KFPARTICLE && Input::LAMBDAC) KFParticle_Lambdac_Reco();
-     
+
   //----------------------
   // Standard QAs
   //----------------------
@@ -523,10 +545,10 @@ int Fun4All_G4_sPHENIX(
     string FullOutFile = DstOut::OutputDir + "/" + DstOut::OutputFile;
     Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", FullOutFile);
     if (Enable::DSTOUT_COMPRESS)
-      {
-        ShowerCompress();
-        DstCompress(out);
-      }
+    {
+      ShowerCompress();
+      DstCompress(out);
+    }
     se->registerOutputManager(out);
   }
   //-----------------


### PR DESCRIPTION
Following https://github.com/sPHENIX-Collaboration/coresoftware/pull/1087 , this pull request apply the beam parameters by default to the detector simulation macros. This is applied toany HepMC-based generator, e.g. `Fun4AllHepMCInputManager`, `Fun4AllHepMCPileupInputManager`, `PHPythia8`, `PHPythia6`, `PHSartre`, `ReadEICFiles`

Two functions defines the parameters: 

* `Input::ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen)` applies the 2mrad sPHENIX beam crossing as defined in sPH-TRG-2020-001
* `Input::ApplyEICBeamParameter(PHHepMCGenHelper *HepMCGen)` applies the 25mrad beam crossing and beam parameters as defined in EIC CDR

Users are allowed to override these beam parameters in the main macro by commenting out or adding more parameter calls following interface defined in [`PHHepMCGenHelper`](https://sphenix-collaboration.github.io/doxygen/dd/d2a/classPHHepMCGenHelper.html)

Given it changes behavior of of all event based simulation, this pull request is put in draft state. Help in cross checking the beam parameter calculation will be appreciated. 
