### PR TITLE
Revert "Added propagator to tracking reco sequence"

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -29,7 +29,6 @@
 #include <trackreco/PHTruthSiliconAssociation.h>
 #include <trackreco/PHTruthTrackSeeding.h>
 #include <trackreco/PHTruthVertexing.h>
-#include <trackreco/PHSimpleKFProp.h>
 
 #if __cplusplus >= 201703L
 #include <trackreco/ActsEvaluator.h>
@@ -288,21 +287,8 @@ void Tracking_Reco()
       hseeder->setSearchAngle(M_PI/8.,M_PI/8.); // radians (iter1, iter2)
       hseeder->setMinTrackSize(10,5); // (iter1, iter2)
       hseeder->setNThreads(1);
-      hseeder->Verbosity(verbosity);
+      hseeder->Verbosity(0);
       se->registerSubsystem(hseeder);
-
-      std::cout << "   Using intermediate vertex associator module " << std::endl;
-      PHTpcTrackSeedVertexAssoc *vtxassoc = new PHTpcTrackSeedVertexAssoc("PHTpcTrackSeedVertexAssoc_prePropagator");
-      vtxassoc->Verbosity(0);
-      se->registerSubsystem(vtxassoc);
-
-      std::cout << "   Using PHSimpleKFProp propagator " << std::endl;
-      PHSimpleKFProp* hprop = new PHSimpleKFProp("PHSimpleKFProp");
-      hprop->set_field_dir(G4MAGNET::magfield_rescale);
-      hprop->set_max_window(.04);
-      hprop->Verbosity(verbosity);
-      se->registerSubsystem(hprop);
-      
     }
     else
     {
@@ -318,22 +304,10 @@ void Tracking_Reco()
       seeder->set_field_dir(G4MAGNET::magfield_rescale);  // to get charge sign right
       seeder->Verbosity(verbosity);
       seeder->SetLayerRange(7, 55);
-      seeder->SetSearchWindow(0.01, 0.04);  // (eta width, phi width)
-      seeder->SetMinHitsPerCluster(0);
-      seeder->SetMinClustersPerTrack(5);
+      seeder->SetSearchWindow(0.01, 0.02);  // (eta width, phi width)
+      seeder->SetMinHitsPerCluster(2);
+      seeder->SetMinClustersPerTrack(20);
       se->registerSubsystem(seeder);
-
-      std::cout << "   Using intermediate vertex associator module " << std::endl;
-      PHTpcTrackSeedVertexAssoc *vtxassoc = new PHTpcTrackSeedVertexAssoc("PHTpcTrackSeedVertexAssoc_prePropagator");
-      vtxassoc->Verbosity(0);
-      se->registerSubsystem(vtxassoc);
-
-      std::cout << "   Using PHSimpleKFProp propagator " << std::endl;
-      PHSimpleKFProp* cprop = new PHSimpleKFProp("PHSimpleKFProp");
-      cprop->set_field_dir(G4MAGNET::magfield_rescale);
-      cprop->set_max_window(.04);
-      cprop->Verbosity(verbosity);
-      se->registerSubsystem(cprop);
     }
   }
 


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/macros#380

This PR should remove the propagator so we can get back on our feet again without disrupting the debugging of the propagator