### PR TITLE
Modify macros to build acts geometry before clustering

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -157,6 +157,26 @@ void TrackingInit()
     std::cout << "Cannot enable space charge correction if not using GenFit tracking chain" << std::endl;
     G4TPC::ENABLE_CORRECTIONS = false;
   }
+
+  /// Built the Acts geometry
+  Fun4AllServer* se = Fun4AllServer::instance();
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+  #if __cplusplus >= 201703L
+  /// Geometry must be built before any Acts modules
+  MakeActsGeometry* geom = new MakeActsGeometry();
+  geom->Verbosity(verbosity);
+  geom->setMagField(G4MAGNET::magfield);
+  geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
+  
+  /// Need a flip of the sign for constant field in tpc tracker
+  if(G4TRACKING::use_PHTpcTracker_seeding && 
+     G4MAGNET::magfield.find(".root") == std::string::npos)
+    {
+      geom->setMagFieldRescale(-1 * G4MAGNET::magfield_rescale);
+    }
+  se->registerSubsystem(geom);
+  #endif  
+
 }
 
 void Tracking_Reco()
@@ -177,18 +197,7 @@ void Tracking_Reco()
   if(!G4TRACKING::use_Genfit)
     {
 #if __cplusplus >= 201703L
-      /// Geometry must be built before any Acts modules
-      MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(verbosity);
-      geom->setMagField(G4MAGNET::magfield);
-      geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-
-      /// Need a flip of the sign for constant field in tpc tracker
-      if(G4TRACKING::use_PHTpcTracker_seeding 
-	 && G4MAGNET::magfield.find(".root") == std::string::npos)
-	geom->setMagFieldRescale(-1 * G4MAGNET::magfield_rescale);
-      se->registerSubsystem(geom);
-      
+  
       /// Always run PHActsSourceLinks first, to convert TrkrClusters 
       /// to the Acts equivalent
       PHActsSourceLinks* sl = new PHActsSourceLinks();
@@ -494,6 +503,7 @@ void Tracking_Reco()
     actsFit2->doTimeAnalysis(false);
     actsFit2->fitSiliconMMs(false);
     se->registerSubsystem(actsFit2);
+
 
 #endif
   }

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -410,6 +410,10 @@ int Fun4All_G4_sPHENIX(
   //--------------
   // SVTX tracking
   //--------------
+  if(Enable::TRACKING_TRACK)
+    {
+      TrackingInit();
+    }
   if (Enable::MVTX_CLUSTER) Mvtx_Clustering();
   if (Enable::INTT_CLUSTER) Intt_Clustering();
   if (Enable::TPC_CLUSTER) TPC_Clustering();
@@ -417,7 +421,6 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::TRACKING_TRACK)
   {
-    TrackingInit();
     Tracking_Reco();
   }
   //-----------------


### PR DESCRIPTION
This PR modifies the tracking macro and also the main Fun4All sPHENIX macro to build the Acts tracking geometry first before any of the tracking detector clustering. This allows to take advantage of a forthcoming coresoftware PR which gives the Svtx objects getters/setters for Acts objects.