### PR TITLE
Acts objects in tracking

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -37,7 +37,6 @@
 #include <trackreco/PHActsSiliconSeeding.h>
 #include <trackreco/PHActsTracks.h>
 #include <trackreco/PHActsTrkFitter.h>
-#include <trackreco/PHActsTrkProp.h>
 #include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHActsVertexFinder.h>
 #include <trackreco/PHTpcResiduals.h>
@@ -194,20 +193,6 @@ void Tracking_Reco()
   // Tracking
   //------------
 
-  if(!G4TRACKING::use_Genfit)
-    {
-#if __cplusplus >= 201703L
-  
-      /// Always run PHActsSourceLinks first, to convert TrkrClusters 
-      /// to the Acts equivalent
-      PHActsSourceLinks* sl = new PHActsSourceLinks();
-      sl->Verbosity(verbosity);
-      sl->setMagField(G4MAGNET::magfield);
-      sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
-      se->registerSubsystem(sl);
-#endif  
-    }
-
   // Initial vertex finding
   //=================================
   if(G4TRACKING::use_acts_silicon_seeding && !G4TRACKING::use_Genfit)
@@ -220,8 +205,11 @@ void Tracking_Reco()
       
       if(G4TRACKING::use_acts_init_vertexing)
 	{
+
 	  PHActsInitialVertexFinder* init_vtx = new PHActsInitialVertexFinder();
 	  init_vtx->Verbosity(verbosity);
+	  init_vtx->setSvtxTrackMapName("SvtxSiliconTrackMap");
+	  init_vtx->setSvtxVertexMapName("SvtxVertexMap");
 	  se->registerSubsystem(init_vtx);
 	}
       else
@@ -469,11 +457,6 @@ void Tracking_Reco()
 
 #if __cplusplus >= 201703L
   
-
-    PHActsTracks* actsTracks = new PHActsTracks("PHActsTracks1");
-    actsTracks->Verbosity(verbosity);
-    se->registerSubsystem(actsTracks);
-
     PHActsTrkFitter* actsFit = new PHActsTrkFitter("PHActsFirstTrkFitter");
     actsFit->Verbosity(verbosity);
     actsFit->doTimeAnalysis(false);
@@ -489,14 +472,13 @@ void Tracking_Reco()
       se->registerSubsystem(residuals);
     }
 
-    PHActsVertexFinder *finder = new PHActsVertexFinder("PHActsVertexFinder");
+    PHActsInitialVertexFinder *finder = new PHActsInitialVertexFinder("PHActsVertexFinder");
     finder->Verbosity(verbosity);
+    finder->setSvtxTrackMapName("SvtxTrackMap");
+    finder->setSvtxVertexMapName("SvtxVertexMap");
+    /// Determines whether or not to reset track covariance matrix
+    finder->setInitialVertexer(false);
     se->registerSubsystem(finder);
-
-    PHActsTracks *actsTracks2 = new PHActsTracks("PHActsTracks2");
-    actsTracks2->Verbosity(verbosity);
-    actsTracks2->setSecondFit(true);
-    se->registerSubsystem(actsTracks2);
 
     PHActsTrkFitter* actsFit2 = new PHActsTrkFitter("PHActsSecondTrKFitter");
     actsFit2->Verbosity(verbosity);

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -472,12 +472,9 @@ void Tracking_Reco()
       se->registerSubsystem(residuals);
     }
 
-    PHActsInitialVertexFinder *finder = new PHActsInitialVertexFinder("PHActsVertexFinder");
+
+    PHActsVertexFinder *finder = new PHActsVertexFinder();
     finder->Verbosity(verbosity);
-    finder->setSvtxTrackMapName("SvtxTrackMap");
-    finder->setSvtxVertexMapName("SvtxVertexMap");
-    /// Determines whether or not to reset track covariance matrix
-    finder->setInitialVertexer(false);
     se->registerSubsystem(finder);
 
     PHActsTrkFitter* actsFit2 = new PHActsTrkFitter("PHActsSecondTrKFitter");

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -157,6 +157,26 @@ void TrackingInit()
     std::cout << "Cannot enable space charge correction if not using GenFit tracking chain" << std::endl;
     G4TPC::ENABLE_CORRECTIONS = false;
   }
+
+  /// Built the Acts geometry
+  Fun4AllServer* se = Fun4AllServer::instance();
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+  #if __cplusplus >= 201703L
+  /// Geometry must be built before any Acts modules
+  MakeActsGeometry* geom = new MakeActsGeometry();
+  geom->Verbosity(verbosity);
+  geom->setMagField(G4MAGNET::magfield);
+  geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
+  
+  /// Need a flip of the sign for constant field in tpc tracker
+  if(G4TRACKING::use_PHTpcTracker_seeding && 
+     G4MAGNET::magfield.find(".root") == std::string::npos)
+    {
+      geom->setMagFieldRescale(-1 * G4MAGNET::magfield_rescale);
+    }
+  se->registerSubsystem(geom);
+  #endif  
+
 }
 
 void Tracking_Reco()
@@ -177,18 +197,7 @@ void Tracking_Reco()
   if(!G4TRACKING::use_Genfit)
     {
 #if __cplusplus >= 201703L
-      /// Geometry must be built before any Acts modules
-      MakeActsGeometry* geom = new MakeActsGeometry();
-      geom->Verbosity(verbosity);
-      geom->setMagField(G4MAGNET::magfield);
-      geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-
-      /// Need a flip of the sign for constant field in tpc tracker
-      if(G4TRACKING::use_PHTpcTracker_seeding 
-	 && G4MAGNET::magfield.find(".root") == std::string::npos)
-	geom->setMagFieldRescale(-1 * G4MAGNET::magfield_rescale);
-      se->registerSubsystem(geom);
-      
+  
       /// Always run PHActsSourceLinks first, to convert TrkrClusters 
       /// to the Acts equivalent
       PHActsSourceLinks* sl = new PHActsSourceLinks();
@@ -494,6 +503,7 @@ void Tracking_Reco()
     actsFit2->doTimeAnalysis(false);
     actsFit2->fitSiliconMMs(false);
     se->registerSubsystem(actsFit2);
+
 
 #endif
   }

--- a/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
+++ b/detectors/fsPHENIX/Fun4All_G4_fsPHENIX.C
@@ -403,13 +403,17 @@ int Fun4All_G4_fsPHENIX(
   //--------------
   // SVTX tracking
   //--------------
+  if (Enable::TRACKING_TRACK)
+  {
+    TrackingInit();
+  }
+
   if (Enable::MVTX_CLUSTER) Mvtx_Clustering();
   if (Enable::INTT_CLUSTER) Intt_Clustering();
   if (Enable::TPC_CLUSTER) TPC_Clustering();
 
   if (Enable::TRACKING_TRACK)
   {
-    TrackingInit();
     Tracking_Reco();
   }
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -410,6 +410,10 @@ int Fun4All_G4_sPHENIX(
   //--------------
   // SVTX tracking
   //--------------
+  if(Enable::TRACKING_TRACK)
+    {
+      TrackingInit();
+    }
   if (Enable::MVTX_CLUSTER) Mvtx_Clustering();
   if (Enable::INTT_CLUSTER) Intt_Clustering();
   if (Enable::TPC_CLUSTER) TPC_Clustering();
@@ -417,7 +421,6 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::TRACKING_TRACK)
   {
-    TrackingInit();
     Tracking_Reco();
   }
   //-----------------


### PR DESCRIPTION
This PR implements the necessary changes to run the Acts tracking in the new Acts-Svtx object scheme. It removes the need for `PHActsSourceLinks` and `PHActsTracks`. 

This PR should not be merged until the corresponding coresoftware PR is merged. Note also that the default `Fun4All` macro has been changed in this PR, to accommodate the fact that the Acts geometry must be built before any of the clustering is performed.