### PR TITLE
Updated FST and forward GEM configurations.

### DIFF
--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -30,6 +30,7 @@ namespace G4FST
     bool FSTV41 = false;
     bool FSTV42 = false;
     bool FSTV4 = false;
+    bool FST_MVTX_TPC = false;
   }  // namespace SETTING
 }  // namespace G4FST
 
@@ -42,14 +43,15 @@ void FST_Init()
           (G4FST::SETTING::FSTV3 ? 1 : 0) +
           (G4FST::SETTING::FSTV4 ? 1 : 0) +
           (G4FST::SETTING::FSTV41 ? 1 : 0) +
-          (G4FST::SETTING::FSTV42 ? 1 : 0) >
+          (G4FST::SETTING::FSTV42 ? 1 : 0) +
+          (G4FST::SETTING::FST_MVTX_TPC ? 1 : 0) >
       1)
   {
-    cout << "use only G4FST::SETTING::FSTV0=true or G4FST::SETTING::FSTV1=true or G4FST::SETTING::FSTV2=true or G4FST::SETTING::FSTV3=true or G4FST::SETTING::FSTV4=true or G4FST::SETTING::FSTV41=true or G4FST::SETTING::FSTV42=true" << endl;
+    cout << "use only G4FST::SETTING::FSTV0=true or G4FST::SETTING::FSTV1=true or G4FST::SETTING::FSTV2=true or G4FST::SETTING::FSTV3=true or G4FST::SETTING::FSTV4=true or G4FST::SETTING::FSTV41=true or G4FST::SETTING::FSTV42=true or G4FST::SETTING::FST_MVTX_TPC=true" << endl;
     gSystem->Exit(1);
   }
 
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 44.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 45.);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 282.);
 }
 //-----------------------------------------------------------------------------------//
@@ -95,7 +97,7 @@ void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
     make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
   }
   else if (G4FST::SETTING::FSTV42)
-  {                                                              // version 4.1
+  {                                                              // version 4.2
     make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
     make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
     make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
@@ -111,6 +113,15 @@ void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
     make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
     make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
     make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FST_MVTX_TPC)
+  {                                                              // mvtx_tpc version (based on version 4)
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 19.5, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 19.5, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 19.5, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 7.5, 19.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 9.5, 45, 50 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 280, 16, 45, 50 * um);
   }
   else
   {                                                               // Version 0

--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -19,6 +19,7 @@ namespace Enable
   bool EGEM = false;
   bool EGEM_FULL = true;
   bool FGEM = false;
+  bool FGEM_ORIG = false;
 }  // namespace Enable
 
 void EGEM_Init()
@@ -66,10 +67,19 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   double zpos;
   PHG4SectorSubsystem *gem;
 
+  if(Enable::FGEM_ORIG){
+  	make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 1.95, N_Sector);
+  	make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 3.20, N_Sector);
+  }
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_2";
-  etamax = 2;
+  if(Enable::FGEM_ORIG){
+  	etamax = 3.3;
+  }
+  else{
+	etamax = 2;
+  }
   etamin = min_eta;
   zpos = 134.0;
 
@@ -90,7 +100,7 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_3";
-  etamax = 2;
+  etamax = 3.3;
   etamin = min_eta;
   zpos = 157.0;
 

--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -33,6 +33,7 @@ namespace Enable
 namespace G4TRACKING
 {
   bool DISPLACED_VERTEX = false;
+  bool PROJECTION_EEMC = false;
   bool PROJECTION_CEMC = false;
   bool PROJECTION_FEMC = false;
   bool PROJECTION_FHCAL = false;
@@ -143,10 +144,16 @@ void Tracking_Reco()
   //-------------------------
   // FGEM
   //-------------------------
-  if (Enable::FGEM)
+  if (Enable::FGEM || Enable::FGEM_ORIG)
   {
+    int first_gem(0);
+    if (Enable::FGEM_ORIG){
+      first_gem = 0;
+    }else{
+      first_gem = 2;
+    }
     // GEM2, 70um azimuthal resolution, 1cm radial strips
-    for (int i = 2; i < 5; i++)
+    for (int i = first_gem; i < 5; i++)
     {
       kalman->add_phg4hits(Form("G4HIT_FGEM_%d", i),          //      const std::string& phg4hitsNames,
                            PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
@@ -162,7 +169,7 @@ void Tracking_Reco()
   //-------------------------
   if (Enable::FST)
   {
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < 6; i++)
     {
       kalman->add_phg4hits(Form("G4HIT_FST_%d", i),           //      const std::string& phg4hitsNames,
                            PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
@@ -192,15 +199,22 @@ void Tracking_Reco()
   //-------------------------
   // CEMC
   //-------------------------
-
   if (Enable::CEMC && G4TRACKING::PROJECTION_CEMC)
   {
     kalman->add_state_name("CEMC");
   }
-  se->registerSubsystem(kalman);
+  //-------------------------
+  // EEMC
+  //-------------------------
+  if (Enable::EEMC && G4TRACKING::PROJECTION_EEMC)
+  {
+    kalman->add_state_name("EEMC");
+  }
 
+  se->registerSubsystem(kalman);
   return;
 }
+
 
 //-----------------------------------------------------------------------------//
 
@@ -216,6 +230,7 @@ void Tracking_Eval(const std::string &outputfile)
   //----------------
   // Fast Tracking evaluation
   //----------------
+
 
   PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
   fast_sim_eval->set_trackmapname(TRACKING::TrackNodeName);

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -225,11 +225,15 @@ int Fun4All_G4_EICDetector(
   // EIC beam pipe extension beyond the Be-section:
   //G4PIPE::use_forward_pipes = true;
 
+  // gems
   Enable::EGEM = true;
   Enable::FGEM = true;
+  Enable::FGEM_ORIG = false; //5 forward gems; cannot be used with FST
   // barrel tracker
   Enable::BARREL = false;
-  Enable::FST = false;
+  // fst
+  Enable::FST = true;
+  G4FST::SETTING::FST_MVTX_TPC = true;
   // mvtx/tpc tracker
   Enable::MVTX = true;
   Enable::TPC = true;
@@ -239,6 +243,7 @@ int Fun4All_G4_EICDetector(
   Enable::TRACKING_EVAL = Enable::TRACKING && true;
   G4TRACKING::DISPLACED_VERTEX = false;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
+  G4TRACKING::PROJECTION_EEMC = false;
   G4TRACKING::PROJECTION_CEMC = false;
   G4TRACKING::PROJECTION_FEMC = false;
   G4TRACKING::PROJECTION_FHCAL = false;

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -48,7 +48,7 @@ void G4Init()
 {
   // First some check for subsystems which do not go together
 
-  if (Enable::TPC && Enable::FST)
+  if (Enable::TPC && Enable::FST && !G4FST::SETTING::FST_MVTX_TPC)
   {
     cout << "TPC and FST cannot be enabled together" << endl;
     gSystem->Exit(1);
@@ -59,11 +59,17 @@ void G4Init()
     gSystem->Exit(1);
   }
 
+  if(Enable::FGEM_ORIG && Enable::FST)
+  {
+    cout << "FST cannot be enabled with 5 FGEM setup" << endl;
+    gSystem->Exit(1);
+  }
+
   // load detector/material macros and execute Init() function
   if (Enable::PIPE) PipeInit();
   if (Enable::PLUGDOOR) PlugDoorInit();
   if (Enable::EGEM) EGEM_Init();
-  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEM_Init();
   if (Enable::FST) FST_Init();
   if (Enable::BARREL) BarrelInit();
   if (Enable::MVTX) MvtxInit();
@@ -134,7 +140,7 @@ int G4Setup()
 
   if (Enable::PIPE) radius = Pipe(g4Reco, radius);
   if (Enable::EGEM) EGEMSetup(g4Reco);
-  if (Enable::FGEM) FGEMSetup(g4Reco);
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEMSetup(g4Reco);
   if (Enable::FST) FSTSetup(g4Reco);
   if (Enable::BARREL) Barrel(g4Reco, radius);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);


### PR DESCRIPTION
This PR updates the current default EICDetector with an FST compatible with the TPC+MVTX+3 forward gems. The inner 4 FST disks are made smaller to fit inside the TPC inner field cage. The outer-most disk is moved to z=208cm to avoid a conflict with the last forward GEM. The inner radius of the second is decreased since no FST disk is nearby.

<img width="563" alt="fst_fgem" src="https://user-images.githubusercontent.com/8701169/111036605-04becb80-83ee-11eb-9897-de499878504d.png">


In addition, an option for a 5 FGEM setting is created with an Enable::FGEM_ORIG option, which can only be enabled if the FST is removed.

<img width="596" alt="original_fgem_full" src="https://user-images.githubusercontent.com/8701169/111036672-6121eb00-83ee-11eb-9e31-991152fca4a6.png">


Lastly, track projection to the EEMC is also added.