### PR TITLE
Latest FST and Barrel designs

### DIFF
--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -1,3 +1,11 @@
+/*---------------------------------------------------------------------*
+ * Barrel tracker designed by LANL EIC team                            *
+ * See technical notes for details: arXiv:2009.02888                   *
+ * Contact Ping and Xuan @LANL for questions:                          *
+ *   Xuan: xuanli@lanl.gov                                             *
+ *   Ping: cpwong@lanl.gov                                             *
+ *---------------------------------------------------------------------*/
+
 #ifndef MACRO_G4BARRELEIC_C
 #define MACRO_G4BARRELEIC_C
 
@@ -14,78 +22,178 @@
 
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4mvtx.so)
+
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon, double tAirgap);
+
 //---------------------------------------------------------------------//
 namespace Enable
 {
   bool BARREL = false;
   bool BARREL_ABSORBER = false;
 }  // namespace Enable
+
+namespace G4BARREL
+{
+  namespace SETTING
+  {
+    bool BARRELV0 = false;
+    bool BARRELV1 = false;
+    bool BARRELV2 = false;
+    bool BARRELV3 = false;
+    bool BARRELV4 = false;
+    bool BARRELV5 = false;
+    bool BARRELV6 = false;
+  }  // namespace SETTING
+}  // namespace G4BARREL
 //---------------------------------------------------------------------//
 void BarrelInit()
 {
+  //check barrel setting
+  if ((G4BARREL::SETTING::BARRELV0 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV1 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV2 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV3 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV4 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV5 ? 1 : 0) +
+      (G4BARREL::SETTING::BARRELV6 ? 1 : 0) > 1)
+    {
+      cout << "use only ";
+      for (int i=0;i<7;i++) {
+	if (i==0) cout<<"G4BARREL::SETTING::BARRELV"<<i<<"=true ";
+	else cout<<" or G4BARREL::SETTING::BARRELV"<<i<<"=true ";
+      }
+
+      gSystem->Exit(1);
+    }
 }
+
 //---------------------------------------------------------------------//
-double Barrel(PHG4Reco* g4Reco, double radius)
+double Barrel(PHG4Reco *g4Reco, double radius)
 {
   const bool AbsorberActive = Enable::ABSORBER || Enable::BARREL_ABSORBER;
+  double max_bh_radius = 0.;
 
   //---------------------------------
   //build barrel detector
   //---------------------------------
-  const int nLayer = 5;
-  const int nSubLayer = 7;
+  int nLayer = 5;
   const float um = 0.0001;  //convert um to cm
 
-  double r[nLayer] = {3.64, 4.81, 5.98, 16.0, 22.0};  //cm
-  double halfLength[nLayer] = {20, 20, 25, 25, 25};   //cm
+  // Different Barrel versions documented in arXiv:2009.02888
+  double r[6] = {3.64, 4.81, 5.98, 16.0, 22.0, -1};  //cm
+  double halfLength[6] = {20, 20, 25, 25, 25, 25};   //cm
+  double tSilicon[6] = {100 * um, 100 * um, 100 * um, 100 * um, 100 * um, 100 * um};
+  double tAirgap[6] = {0.9, 0.9, 1, 1, 1, 1};
+  
+  if (G4BARREL::SETTING::BARRELV1 || G4BARREL::SETTING::BARRELV2)
+    {
+      for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
+    }
+  else if (G4BARREL::SETTING::BARRELV3)
+    {
+      for (Int_t i = 0; i < 5; i++) tSilicon[i] = 35 * um;
+    }
+  else if (G4BARREL::SETTING::BARRELV4)
+    {
+      for (Int_t i = 0; i < 3; i++) tSilicon[i] = 50 * um;
+      nLayer = 6;
+      r[3] = 9.2;
+      r[4] = 17.;
+      r[5] = 27.;
+    }
+
+  if (G4BARREL::SETTING::BARRELV5 ||G4BARREL::SETTING::BARRELV6)
+    {
+      int nLayer1 = 3;   //barrel 1
+      int nLayer2 = 2;   //barrel 2
+      if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC
+
+      int my_nLayer[2]={nLayer1,nLayer2};
+
+      double my_r[2][3] = {{3.64, 4.81, 5.98},   //cm, barrel1
+			   {16, 22.0}};          //barrel 2
+
+      double my_halfLength[2][3] = {{20, 20, 25},  //cm, barrel 1
+				    {25,25}};      //barrel 2
+      
+      double my_tSilicon = 35 * um;
+
+      for (int n=0;n<2;n++) {
+	if (n==1) my_tSilicon = 85 *um;
+	for (int i=0;i<my_nLayer[n];i++) {
+	  make_barrel_pixel_layer(Form("BARREL%d_%d",n, i), g4Reco, my_r[n][i], my_halfLength[n][i], my_tSilicon, tAirgap[i]);
+	}
+      }
+
+      // update now that we know the outer radius
+      BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, max_bh_radius);
+      BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer1+nLayer2 - 1]);
+      BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer1+nLayer2 - 1]);
+      
+      max_bh_radius = my_r[1][nLayer2-1] + 1.5;
+      return max_bh_radius;
+    }
+  else{  //ver 0 - 4
+    for (int i = 0; i < nLayer; i++)
+      {
+	make_barrel_pixel_layer(Form("BARREL_%d", i), g4Reco, r[i], halfLength[i], tSilicon[i], 1);
+	max_bh_radius = r[i] + 1.5;
+	//std::cout << "done with barrel layer intialization at "<< r[i] << std::endl;
+      }
+  
+    // update now that we know the outer radius
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, max_bh_radius);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer - 1]);
+    BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer - 1]);
+    return max_bh_radius;
+  }
+}
+//---------------------------------------------------------------------//
+int make_barrel_pixel_layer(const string &name, PHG4Reco *g4Reco,
+                            double radius, double halflength, double tSilicon, double tAirgap)
+{
+  //---------------------------------
+  //build barrel layer
+  //---------------------------------
+  const int nSubLayer = 7;
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
 
   string layerName[nSubLayer] = {"SiliconSensor", "Metalconnection", "HDI", "Cooling",
                                  "Support1", "Support_Gap", "Support2"};
   string material[nSubLayer] = {"G4_Si", "G4_Al", "G4_KAPTON", "G4_WATER",
                                 "G4_GRAPHITE", "G4_AIR", "G4_GRAPHITE"};
-  double thickness[nSubLayer] = {285 * um, 15 * um, 20 * um, 100 * um,
-                                 50 * um, 1, 50 * um};
+  double thickness[nSubLayer] = {tSilicon, 15 * um, 20 * um, 100 * um,
+                                 50 * um, tAirgap, 50 * um};
 
-  int k = 0;  //layer id. Must be unique.
   double max_bh_radius = 0.;
-  PHG4CylinderSubsystem* cyl;
-  for (int i = 0; i < nLayer; i++)
-  {
-    //if (i>2) continue;
-    for (int j = 0; j < nSubLayer; j++)
-    {
-      cyl = new PHG4CylinderSubsystem("Barrel_" + layerName[j], k);
-      if (j == 0)
-      {
-        cyl->set_double_param("radius", r[i]);
-      }
-      else
-      {
-        cyl->set_double_param("radius", r[i] + thickness[j - 1]);
-      }
-      cyl->set_double_param("length", 2.0 * halfLength[i]);
-      cyl->set_string_param("material", material[j]);
-      cyl->set_double_param("thickness", thickness[j]);
-      max_bh_radius = std::max(max_bh_radius, (r[i] + thickness[j - 1] + thickness[j]));
-      cyl->SuperDetector("BARREL");
-      if (j == 0)
-      {
-        cyl->SetActive();  //only the Silicon Sensor is active
-      }
-      else
-      {
-        if (AbsorberActive) cyl->SetActive();
-      }
-      g4Reco->registerSubsystem(cyl);
-      k++;
-    }
-  }
+  PHG4CylinderSubsystem *cyl;
+  cout << "started to create cylinder layer: " << name << endl;
 
-  // update now that we know the outer radius
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, max_bh_radius);
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, halfLength[nLayer - 1]);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -halfLength[nLayer - 1]);
-  return max_bh_radius;
+  double currRadius = radius;
+  //   cout << currRadius << endl;
+  for (int l = 0; l < nSubLayer; l++)
+    {
+      cout << name << "_" << layerName[l] << "\t" << currRadius ;
+      cyl = new PHG4CylinderSubsystem(name + "_" + layerName[l], l);
+      cyl->SuperDetector(name);
+      cyl->set_double_param("radius", currRadius);
+      cyl->set_double_param("length", 2.0 * halflength);
+      cyl->set_string_param("material", material[l]);
+      cyl->set_double_param("thickness", thickness[l]);
+      if (l == 0) cyl->SetActive();  //only the Silicon Sensor is active
+      cyl->OverlapCheck(true);
+      g4Reco->registerSubsystem(cyl);
+      currRadius = currRadius + thickness[l];
+      cout << "\t" << currRadius << endl;
+    }
+  
+
+  return 0;
 }
-//---------------------------------------------------------------------//
+
+//-----------------------------------------------------------------------------------//
+
 #endif

--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -242,42 +242,22 @@ CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings)
   int ilayer = 0;
   PHG4SpacalSubsystem *cemc;
 
-  const bool use_2015_design = false;
-  if (use_2015_design)
-  {
-    cemc = new PHG4SpacalSubsystem("CEMC", ilayer);
+  cemc = new PHG4SpacalSubsystem("CEMC", ilayer);
 
-    cemc->set_int_param("config", PHG4CylinderGeom_Spacalv1::kFullProjective_2DTaper_SameLengthFiberPerTower);
-    cemc->set_double_param("radius", radius);            // overwrite minimal radius
-    cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness
-    cemc->set_int_param("azimuthal_n_sec", 32);
-    //    cemc->set_int_param("construction_verbose", 2);
+  cemc->set_int_param("virualize_fiber", 0);
+  cemc->set_int_param("azimuthal_seg_visible", 1);
+  cemc->set_int_param("construction_verbose", 0);
+  cemc->Verbosity(0);
 
-    cemc->SetActive();
-    cemc->SuperDetector("CEMC");
-    if (AbsorberActive) cemc->SetAbsorberActive();
-    cemc->OverlapCheck(OverlapCheck);
-  }
+  cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
+  cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2018ProjTilted/"));
+  cemc->set_double_param("radius", radius);            // overwrite minimal radius
+  cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness
 
-  else
-  {
-    cemc = new PHG4SpacalSubsystem("CEMC", ilayer);
-
-    cemc->set_int_param("virualize_fiber", 0);
-    cemc->set_int_param("azimuthal_seg_visible", 1);
-    cemc->set_int_param("construction_verbose", 0);
-    cemc->Verbosity(0);
-
-    cemc->UseCalibFiles(PHG4DetectorSubsystem::xml);
-    cemc->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/CEMC/Geometry_2018ProjTilted/"));
-    cemc->set_double_param("radius", radius);            // overwrite minimal radius
-    cemc->set_double_param("thickness", cemcthickness);  // overwrite thickness
-
-    cemc->SetActive();
-    cemc->SuperDetector("CEMC");
-    if (AbsorberActive) cemc->SetAbsorberActive();
-    cemc->OverlapCheck(OverlapCheck);
-  }
+  cemc->SetActive();
+  cemc->SuperDetector("CEMC");
+  if (AbsorberActive) cemc->SetAbsorberActive();
+  cemc->OverlapCheck(OverlapCheck);
 
   g4Reco->registerSubsystem(cemc);
 

--- a/common/G4_DSTReader_EICDetector.C
+++ b/common/G4_DSTReader_EICDetector.C
@@ -68,8 +68,30 @@ void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
     }
     if (Enable::BARREL)
     {
-      ana->AddNode("BARREL");
-    }
+      if (G4BARREL::SETTING::BARRELV5 ||G4BARREL::SETTING::BARRELV6) {
+	int nLayer1 = 3;   //barrel 1                                                                                                      
+	int nLayer2 = 2;   //barrel 2                                                                                                      
+	if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC                                                                
+	int nLayer[2]={nLayer1,nLayer2};
+
+	for (int n=0;n<2;n++) 
+	{
+	  for (int i;i<nLayer[n];i++) 
+	  {
+	    ana->AddNode(Form("BARREL%d_%d",n,i));
+	  }
+	}
+      }
+      else
+      {
+	int nLayer=5;
+	if (G4BARREL::SETTING::BARRELV4) nLayer=6;
+	for (int i;i<nLayer;i++)
+	{
+	  ana->AddNode(Form("BARREL%d",i));
+	}
+      }
+    }	
     if (Enable::MVTX)
     {
       ana->AddNode("MVTX");
@@ -99,7 +121,10 @@ void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
       ana->AddNode("FST_2");
       ana->AddNode("FST_3");
       ana->AddNode("FST_4");
-      ana->AddNode("FST_5");
+      if (G4FST::SETTING::FSTV4 || G4FST::SETTING::FSTV5)
+      {
+	ana->AddNode("FST_5");
+      }
     }
 
     if (Enable::CEMC)

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -13,6 +13,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
 #include <fun4all/Fun4AllServer.h>
@@ -39,6 +40,16 @@ namespace G4EEMC
   int use_projective_geometry = 0;
   double Gdz = 18. + 0.0001;
   double Gz0 = -170.;
+  enum enu_Eemc_clusterizer
+  {
+    kEemcGraphClusterizer,
+    kEemcTemplateClusterizer
+  };
+  //default template clusterizer, as developed by Sasha Bazilevsky
+  enu_Eemc_clusterizer Eemc_clusterizer = kEemcTemplateClusterizer;
+  // graph clusterizer
+  //enu_Eemc_clusterizer Eemc_clusterizer = kEemcGraphClusterizer;
+
 }  // namespace G4EEMC
 
 void EEMCInit()
@@ -70,19 +81,23 @@ void EEMCSetup(PHG4Reco *g4Reco)
     eemc->SetAbsorberActive();
   }
 
-  /* path to central copy of calibrations repositry */
+  /* path to central copy of calibrations repository */
   ostringstream mapping_eemc;
 
   /* Use non-projective geometry */
   if (!G4EEMC::use_projective_geometry)
   {
     mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/towerMap_EEMC_v006.txt";
-    eemc->SetTowerMappingFile(mapping_eemc.str());
+    eemc->set_string_param("mappingtower", mapping_eemc.str());
   }
 
   /* use projective geometry */
   else
   {
+    cout << "The projective version has serious problems with overlaps" << endl;
+    cout << "Do Not Use!" << endl;
+    cout << "If you insist, copy G4_EEMC.C locally and comment out this exit" << endl;
+    gSystem->Exit(1);
     ostringstream mapping_eemc_4x4construct;
 
     mapping_eemc << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystals_v005.txt";
@@ -98,15 +113,6 @@ void EEMCSetup(PHG4Reco *g4Reco)
 
 void EEMC_Cells()
 {
-  int verbosity = std::max(Enable::VERBOSITY, Enable::EEMC_VERBOSITY);
-
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("EEMCCellReco");
-  hc->Detector("EEMC");
-  se->registerSubsystem(hc);
-
-  return;
 }
 
 void EEMC_Towers()
@@ -161,11 +167,27 @@ void EEMC_Clusters()
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
-  ClusterBuilder->Detector("EEMC");
-  ClusterBuilder->Verbosity(verbosity);
-  se->registerSubsystem(ClusterBuilder);
+  if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("EEMCRawClusterBuilderTemplate");
 
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4EEMC::Eemc_clusterizer == G4EEMC::kEemcGraphClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("EEMCRawClusterBuilderFwd");
+
+    ClusterBuilder->Detector("EEMC");
+    ClusterBuilder->Verbosity(verbosity);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "EEMC_Clusters - unknown clusterizer setting " << G4EEMC::Eemc_clusterizer << endl;
+    gSystem->Exit(1);
+  }
   return;
 }
 

--- a/common/G4_FEMC.C
+++ b/common/G4_FEMC.C
@@ -89,12 +89,6 @@ void FEMCSetup(PHG4Reco *g4Reco, const int absorberactive = 0)
 
 void FEMC_Cells()
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
-  hc->Detector("FEMC");
-  se->registerSubsystem(hc);
-
   return;
 }
 

--- a/common/G4_FEMC_EIC.C
+++ b/common/G4_FEMC_EIC.C
@@ -3,16 +3,21 @@
 
 #include <GlobalVariables.C>
 
+#include <g4calo/RawTowerBuilderByHitIndex.h>
+#include <g4calo/RawTowerDigitizer.h>
+
+#include <g4detectors/PHG4ForwardCalCellReco.h>
+#include <g4detectors/PHG4ForwardEcalSubsystem.h>
+
+#include <g4eval/CaloEvaluator.h>
+
+#include <g4main/PHG4Reco.h>
+
 #include <caloreco/RawClusterBuilderFwd.h>
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
+
 #include <fun4all/Fun4AllServer.h>
-#include <g4calo/RawTowerBuilderByHitIndex.h>
-#include <g4calo/RawTowerDigitizer.h>
-#include <g4detectors/PHG4ForwardCalCellReco.h>
-#include <g4detectors/PHG4ForwardEcalSubsystem.h>
-#include <g4eval/CaloEvaluator.h>
-#include <g4main/PHG4Reco.h>
 
 R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libg4calo.so)
@@ -46,10 +51,23 @@ namespace G4FEMC
   enu_Femc_clusterizer Femc_clusterizer = kFemcTemplateClusterizer;
   // graph clusterizer
   //enu_Femc_clusterizer Femc_clusterizer = kFemcGraphClusterizer;
+  namespace SETTING
+  {
+    bool FullEtaAcc = false;
+    bool fsPHENIX = false;
+    bool EC2x = false;
+  }  // namespace SETTING
 }  // namespace G4FEMC
 
 void FEMCInit()
 {
+  // simple way to check if only 1 of the settings is true
+  if ((G4FEMC::SETTING::FullEtaAcc ? 1 : 0) + (G4FEMC::SETTING::fsPHENIX ? 1 : 0) > 1)
+  {
+    cout << "use only  G4FHCAL::SETTING::FullEtaAcc=true or G4FHCAL::SETTING::fsPHENIX=true" << endl;
+    gSystem->Exit(1);
+  }
+
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FEMC::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FEMC::Gz0 + G4FEMC::Gdz / 2.);
 }
@@ -66,13 +84,26 @@ void FEMCSetup(PHG4Reco *g4Reco)
 
   ostringstream mapping_femc;
 
-  //  femc->SetEICDetector();
-
+  // PbScint ECAL with nominal eta coverage
+  if (G4FEMC::SETTING::FullEtaAcc)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fullEtaCov.txt";
+  }
+  // doubled granularity ECAL
+  else if (G4FEMC::SETTING::EC2x)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_2x.txt";
+  }
   // fsPHENIX ECAL
-  //  mapping_femc<< getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  else if (G4FEMC::SETTING::fsPHENIX)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  }
   // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
-  mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
-
+  else
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+  }
   cout << mapping_femc.str() << endl;
   femc->SetTowerMappingFile(mapping_femc.str());
   femc->OverlapCheck(OverlapCheck);
@@ -85,14 +116,6 @@ void FEMCSetup(PHG4Reco *g4Reco)
 
 void FEMC_Cells()
 {
-  int verbosity = std::max(Enable::VERBOSITY, Enable::FEMC_VERBOSITY);
-
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FEMCCellReco");
-  hc->Detector("FEMC");
-  se->registerSubsystem(hc);
-
   return;
 }
 
@@ -108,7 +131,26 @@ void FEMC_Towers()
   //  mapping_femc << getenv("CALIBRATIONROOT") <<
   //   	"/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
   // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
-  mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+  // PbScint ECAL with nominal eta coverage
+  if (G4FEMC::SETTING::FullEtaAcc)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fullEtaCov.txt";
+  }
+  // doubled granularity ECAL
+  else if (G4FEMC::SETTING::EC2x)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_2x.txt";
+  }
+  // fsPHENIX ECAL
+  else if (G4FEMC::SETTING::fsPHENIX)
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_fsPHENIX_v004.txt";
+  }
+  // PbScint ECAL with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_femc << getenv("CALIBRATIONROOT") << "/ForwardEcal/mapping/towerMap_FEMC_v007.txt";
+  }
 
   RawTowerBuilderByHitIndex *tower_FEMC = new RawTowerBuilderByHitIndex("TowerBuilder_FEMC");
   tower_FEMC->Detector("FEMC");
@@ -261,7 +303,7 @@ void FEMC_Eval(const std::string &outputfile)
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  CaloEvaluator *eval = new CaloEvaluator("FEMCEVALUATOR", "FEMC", outputfile.c_str());
+  CaloEvaluator *eval = new CaloEvaluator("FEMCEVALUATOR", "FEMC", outputfile);
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 

--- a/common/G4_FGEM_fsPHENIX.C
+++ b/common/G4_FGEM_fsPHENIX.C
@@ -267,7 +267,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_0",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -277,7 +277,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_1",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -299,7 +299,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_2",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -309,7 +309,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_3",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,
@@ -319,7 +319,7 @@ void FGEM_FastSim_Reco()
   kalman->add_phg4hits(
       "G4HIT_FGEM_4",                    //      const std::string& phg4hitsNames,
       PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-      1. / sqrt(12),                     //      const float radres,
+      1. / sqrt(12.),                     //      const float radres,
       70e-4,                             //      const float phires,
       100e-4,                            //      const float lonres,
       1,                                 //      const float eff,

--- a/common/G4_FHCAL.C
+++ b/common/G4_FHCAL.C
@@ -14,6 +14,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <caloreco/RawClusterBuilderFwd.h>
+#include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
 #include <fun4all/Fun4AllServer.h>
@@ -41,10 +42,44 @@ namespace G4FHCAL
   double Gz0 = 400.;
   double Gdz = 100.;
   double outer_radius = 262.;
+  enum enu_FHcal_clusterizer
+  {
+    kFHcalGraphClusterizer,
+    kFHcalTemplateClusterizer
+  };
+  //template clusterizer, as developed by Sasha Bazilevsky
+  enu_FHcal_clusterizer FHcal_clusterizer = kFHcalTemplateClusterizer;
+  // graph clusterizer
+  //enu_FHcal_clusterizer FHcal_clusterizer = kFHcalGraphClusterizer;
+  namespace SETTING
+  {
+    bool FullEtaAcc = false;
+    bool HC2x = false;
+    bool HC4x = false;
+    bool towercalib1 = false;
+    bool towercalibSiPM = false;
+    bool towercalibHCALIN = false;
+    bool towercalib3 = false;
+  }  // namespace SETTING
 }  // namespace G4FHCAL
 
 void FHCALInit()
 {
+  // simple way to check if only 1 of the settings is true
+  if ((G4FHCAL::SETTING::FullEtaAcc ? 1 : 0) + (G4FHCAL::SETTING::HC4x ? 1 : 0) + (G4FHCAL::SETTING::HC2x ? 1 : 0) > 1)
+  {
+    cout << "use only  G4FHCAL::SETTING::FullEtaAcc=true or G4FHCAL::SETTING::HC2x=true or G4FHCAL::SETTING::HC4x=true" << endl;
+    gSystem->Exit(1);
+  }
+  if ((G4FHCAL::SETTING::towercalib1 ? 1 : 0) + (G4FHCAL::SETTING::towercalibSiPM ? 1 : 0) +
+          (G4FHCAL::SETTING::towercalibHCALIN ? 1 : 0) + (G4FHCAL::SETTING::towercalib3 ? 1 : 0) >
+      1)
+  {
+    cout << "use only G4FHCAL::SETTING::towercalib1 = true or G4FHCAL::SETTING::towercalibSiPM = true"
+         << " or G4FHCAL::SETTING::towercalibHCALIN = true or G4FHCAL::SETTING::towercalib3 = true" << endl;
+    gSystem->Exit(1);
+  }
+
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4FHCAL::outer_radius);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4FHCAL::Gz0 + G4FHCAL::Gdz / 2.);
 }
@@ -56,32 +91,54 @@ void FHCALSetup(PHG4Reco *g4Reco)
   Fun4AllServer *se = Fun4AllServer::instance();
 
   /** Use dedicated FHCAL module */
-  PHG4ForwardHcalSubsystem *hhcal = new PHG4ForwardHcalSubsystem("FHCAL");
+  PHG4ForwardHcalSubsystem *fhcal = new PHG4ForwardHcalSubsystem("FHCAL");
 
-  ostringstream mapping_hhcal;
+  ostringstream mapping_fhcal;
 
-  /* path to central copy of calibrations repositry */
-  mapping_hhcal << getenv("CALIBRATIONROOT");
-  mapping_hhcal << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
-  //  cout << mapping_hhcal.str() << endl;
-  //mapping_hhcal << "towerMap_FHCAL_latest.txt";
+  // Switch to desired calo setup
+  // HCal Fe-Scint with doubled granularity
+  if (G4FHCAL::SETTING::HC2x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance doubled granularity
+  else if (G4FHCAL::SETTING::HC2x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
+  }
+  // HCal Fe-Scint with four times granularity
+  else if (G4FHCAL::SETTING::HC4x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance four times granularity
+  else if (G4FHCAL::SETTING::HC4x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance
+  else if (G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT")
+                  << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
+  }
 
-  hhcal->SetTowerMappingFile(mapping_hhcal.str());
-  hhcal->OverlapCheck(OverlapCheck);
+  fhcal->SetTowerMappingFile(mapping_fhcal.str());
+  fhcal->OverlapCheck(OverlapCheck);
+  fhcal->SetActive();
+  fhcal->SuperDetector("FHCAL");
+  if (AbsorberActive) fhcal->SetAbsorberActive();
 
-  if (AbsorberActive) hhcal->SetAbsorberActive();
-
-  g4Reco->registerSubsystem(hhcal);
+  g4Reco->registerSubsystem(fhcal);
 }
 
 void FHCAL_Cells(int verbosity = 0)
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
-
-  PHG4ForwardCalCellReco *hc = new PHG4ForwardCalCellReco("FHCALCellReco");
-  hc->Detector("FHCAL");
-  se->registerSubsystem(hc);
-
   return;
 }
 
@@ -92,9 +149,38 @@ void FHCAL_Towers()
   Fun4AllServer *se = Fun4AllServer::instance();
 
   ostringstream mapping_fhcal;
-  mapping_fhcal << getenv("CALIBRATIONROOT")
-                << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
-  //mapping_fhcal << "towerMap_FHCAL_latest.txt";
+
+  // Switch to desired calo setup
+  // HCal Fe-Scint with doubled granularity
+  if (G4FHCAL::SETTING::HC2x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance doubled granularity
+  else if (G4FHCAL::SETTING::HC2x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_2x_fullEtaCov.txt";
+  }
+  // HCal Fe-Scint with four times granularity
+  else if (G4FHCAL::SETTING::HC4x )
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance four times granularity
+  else if (G4FHCAL::SETTING::HC4x && G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_4x_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with nominal acceptance
+  else if (G4FHCAL::SETTING::FullEtaAcc)
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_default_fullEtaCov.txt";
+  }
+  // full HCal Fe-Scint with enlarged beam pipe opening for Mar 2020 beam pipe
+  else
+  {
+    mapping_fhcal << getenv("CALIBRATIONROOT") << "/ForwardHcal/mapping/towerMap_FHCAL_v005.txt";
+  }
 
   RawTowerBuilderByHitIndex *tower_FHCAL = new RawTowerBuilderByHitIndex("TowerBuilder_FHCAL");
   tower_FHCAL->Detector("FHCAL");
@@ -103,44 +189,122 @@ void FHCAL_Towers()
 
   se->registerSubsystem(tower_FHCAL);
 
-  // const double FHCAL_photoelectron_per_GeV = 500;
+  // enable usage of different tower calibrations for systematic studies
+  if (G4FHCAL::SETTING::towercalib1)
+  {
+    cout << "1: using towercalib1 for FHCAL towers" << endl;
+    const double FHCAL_photoelectron_per_GeV = 500;
+    RawTowerDigitizer *TowerDigitizer_FHCAL = new RawTowerDigitizer("FHCALRawTowerDigitizer");
 
-  // RawTowerDigitizer *TowerDigitizer_FHCAL = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer_FHCAL->Detector("FHCAL");
+    TowerDigitizer_FHCAL->Verbosity(verbosity);
+    TowerDigitizer_FHCAL->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer_FHCAL->set_digi_algorithm(RawTowerDigitizer::kSiPM_photon_digitization);
+    TowerDigitizer_FHCAL->set_pedstal_central_ADC(0);
+    TowerDigitizer_FHCAL->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+    TowerDigitizer_FHCAL->set_photonelec_ADC(1);     //not simulating ADC discretization error
+    TowerDigitizer_FHCAL->set_photonelec_yield_visible_GeV(FHCAL_photoelectron_per_GeV);
+    TowerDigitizer_FHCAL->set_zero_suppression_ADC(16);  // eRD1 test beam setting
 
-  // TowerDigitizer_FHCAL->Detector("FHCAL");
-  // TowerDigitizer_FHCAL->Verbosity(verbosity);
-  // TowerDigitizer_FHCAL->set_raw_tower_node_prefix("RAW");
-  // TowerDigitizer_FHCAL->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
-  // TowerDigitizer_FHCAL->set_pedstal_central_ADC(0);
-  // TowerDigitizer_FHCAL->set_pedstal_width_ADC(8);// eRD1 test beam setting
-  // TowerDigitizer_FHCAL->set_photonelec_ADC(1);//not simulating ADC discretization error
-  // TowerDigitizer_FHCAL->set_photonelec_yield_visible_GeV( FHCAL_photoelectron_per_GeV );
-  // TowerDigitizer_FHCAL->set_zero_suppression_ADC(16); // eRD1 test beam setting
+    se->registerSubsystem(TowerDigitizer_FHCAL);
 
-  // se->registerSubsystem( TowerDigitizer_FHCAL );
+    RawTowerCalibration *TowerCalibration_FHCAL = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration_FHCAL->Detector("FHCAL");
+    TowerCalibration_FHCAL->Verbosity(verbosity);
+    TowerCalibration_FHCAL->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration_FHCAL->set_calib_const_GeV_ADC(1. / FHCAL_photoelectron_per_GeV);
+    TowerCalibration_FHCAL->set_pedstal_ADC(0);
 
-  // RawTowerCalibration *TowerCalibration_FHCAL = new RawTowerCalibration("FHCALRawTowerCalibration");
-  // TowerCalibration_FHCAL->Detector("FHCAL");
-  // TowerCalibration_FHCAL->Verbosity(verbosity);
-  // TowerCalibration_FHCAL->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  // TowerCalibration_FHCAL->set_calib_const_GeV_ADC( 1. / FHCAL_photoelectron_per_GeV );
-  // TowerCalibration_FHCAL->set_pedstal_ADC( 0 );
+    se->registerSubsystem(TowerCalibration_FHCAL);
+  }
+  else if (G4FHCAL::SETTING::towercalibSiPM)
+  {
+    //from https://sphenix-collaboration.github.io/doxygen/d4/d58/Fun4All__G4__Prototype4_8C_source.html
+    const double sampling_fraction = 0.019441;     //  +/-  0.019441 from 0 Degree indenting 12 GeV electron showers
+    const double photoelectron_per_GeV = 500;      //500 photon per total GeV deposition
+    const double ADC_per_photoelectron_HG = 3.8;   // From Sean Stoll, Mar 29
+    const double ADC_per_photoelectron_LG = 0.24;  // From Sean Stoll, Mar 29
 
-  // se->registerSubsystem( TowerCalibration_FHCAL );
+    cout << "2: using towercalibSiPM for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSiPM_photon_digitization);
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(1);
+    TowerDigitizer->set_photonelec_ADC(1. / ADC_per_photoelectron_LG);
+    TowerDigitizer->set_photonelec_yield_visible_GeV(photoelectron_per_GeV / sampling_fraction);
+    TowerDigitizer->set_zero_suppression_ADC(-1000);  // no-zero suppression
+    se->registerSubsystem(TowerDigitizer);
 
-  RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
-  TowerDigitizer->Detector("FHCAL");
-  TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
-  se->registerSubsystem(TowerDigitizer);
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->set_raw_tower_node_prefix("RAW");
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / ADC_per_photoelectron_LG / photoelectron_per_GeV);
+    TowerCalibration->set_pedstal_ADC(0);
+    TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
+    se->registerSubsystem(TowerCalibration);
+  }
+  else if (G4FHCAL::SETTING::towercalibHCALIN)
+  {
+    const double visible_sample_fraction_HCALIN = 7.19505e-02;  // 1.34152e-02
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_raw_tower_node_prefix("RAW");
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(1);
+    TowerDigitizer->set_photonelec_ADC(32. / 5.);
+    TowerDigitizer->set_photonelec_yield_visible_GeV(32. / 5 / (0.4e-3));
+    TowerDigitizer->set_zero_suppression_ADC(-1000);  // no-zero suppression
+    se->registerSubsystem(TowerDigitizer);
 
-  RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
-  TowerCalibration->Detector("FHCAL");
-  TowerCalibration->Verbosity(verbosity);
-  TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
-  TowerCalibration->set_pedstal_ADC(0);
-  se->registerSubsystem(TowerCalibration);
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->set_raw_tower_node_prefix("RAW");
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
+    TowerCalibration->set_pedstal_ADC(0);
+    TowerCalibration->set_zero_suppression_GeV(-1);  // no-zero suppression
+    se->registerSubsystem(TowerCalibration);
+  }
+  else if (G4FHCAL::SETTING::towercalib3)
+  {
+    cout << "3: using towercalib3 for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->set_pedstal_central_ADC(0);
+    TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
+    TowerDigitizer->Verbosity(verbosity);
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->Verbosity(verbosity);
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+    TowerCalibration->set_pedstal_ADC(0);
+    se->registerSubsystem(TowerCalibration);
+  }
+  else
+  {
+    cout << "def: using default for FHCAL towers" << endl;
+    RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("FHCALRawTowerDigitizer");
+    TowerDigitizer->Detector("FHCAL");
+    TowerDigitizer->Verbosity(verbosity);
+    TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kNo_digitization);
+    se->registerSubsystem(TowerDigitizer);
+
+    RawTowerCalibration *TowerCalibration = new RawTowerCalibration("FHCALRawTowerCalibration");
+    TowerCalibration->Detector("FHCAL");
+    TowerCalibration->Verbosity(verbosity);
+    TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
+    TowerCalibration->set_calib_const_GeV_ADC(1. / 0.03898);  // calibrated with muons
+    TowerCalibration->set_pedstal_ADC(0);
+    se->registerSubsystem(TowerCalibration);
+  }
 }
 
 void FHCAL_Clusters()
@@ -148,11 +312,28 @@ void FHCAL_Clusters()
   int verbosity = std::max(Enable::VERBOSITY, Enable::FHCAL_VERBOSITY);
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
-  ClusterBuilder->Detector("FHCAL");
-  ClusterBuilder->Verbosity(verbosity);
-  ClusterBuilder->set_threshold_energy(0.100);
-  se->registerSubsystem(ClusterBuilder);
+  if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
+    RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("FHCALRawClusterBuilderTemplate");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->SetPlanarGeometry();  // has to be called after Detector()
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else if (G4FHCAL::FHcal_clusterizer == G4FHCAL::kFHcalTemplateClusterizer)
+  {
+    RawClusterBuilderFwd *ClusterBuilder = new RawClusterBuilderFwd("FHCALRawClusterBuilderFwd");
+    ClusterBuilder->Detector("FHCAL");
+    ClusterBuilder->Verbosity(verbosity);
+    ClusterBuilder->set_threshold_energy(0.100);
+    se->registerSubsystem(ClusterBuilder);
+  }
+  else
+  {
+    cout << "FHCAL_Clusters - unknown clusterizer setting " << G4FHCAL::FHcal_clusterizer << endl;
+    gSystem->Exit(1);
+  }
 
   return;
 }

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -1,7 +1,15 @@
+/*---------------------------------------------------------------------*
+ * Barrel tracker designed by LANL EIC team                            *
+ * See technical notes for details: arXiv:2009.02888                   *
+ * Contact Ping and Xuan @LANL for questions:                          *
+ *   Xuan: xuanli@lanl.gov                                             *
+ *   Ping: cpwong@lanl.gov                                             *
+ *---------------------------------------------------------------------*/
+
 #ifndef MACRO_G4FSTEIC_C
 #define MACRO_G4FSTEIC_C
 
-#include <GlobalVariables.C>
+#include "GlobalVariables.C"
 
 #include <g4detectors/PHG4SectorSubsystem.h>
 
@@ -11,40 +19,153 @@
 
 R__LOAD_LIBRARY(libg4detectors.so)
 
-int make_LANL_FST_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
-                          double Rmax);
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco, double zpos, double Rmin,
+                          double Rmax, double tSilicon);
 //-----------------------------------------------------------------------------------//
 namespace Enable
 {
-  bool FST = false;
-  bool FST_OVERLAPCHECK = false;
-}  // namespace Enable
+  static bool FST = false;
+}
+
+namespace G4FST
+{
+  namespace SETTING
+  {
+    bool FSTV0 = false;
+    bool FSTV1 = false;
+    bool FSTV2 = false;
+    bool FSTV3 = false;
+    bool FSTV41 = false;
+    bool FSTV42 = false;
+    bool FSTV4 = false;
+    bool FSTV5 = false;
+    bool FST_TPC = false;
+  }  // namespace SETTING
+}  // namespace G4FST
+
 //-----------------------------------------------------------------------------------//
 void FST_Init()
 {
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 44.);
+  if ((G4FST::SETTING::FSTV0 ? 1 : 0) +
+      (G4FST::SETTING::FSTV1 ? 1 : 0) +
+      (G4FST::SETTING::FSTV2 ? 1 : 0) +
+      (G4FST::SETTING::FSTV3 ? 1 : 0) +
+      (G4FST::SETTING::FSTV4 ? 1 : 0) +
+      (G4FST::SETTING::FSTV41 ? 1 : 0) +
+      (G4FST::SETTING::FSTV42 ? 1 : 0) +
+      (G4FST::SETTING::FSTV5 ? 1 : 0) +
+      (G4FST::SETTING::FST_TPC ? 1 : 0) > 1)
+  {
+    cout << "use only G4FST::SETTING::FSTV0=true ";
+    cout << "or G4FST::SETTING::FSTV1=true ";
+    cout << "or G4FST::SETTING::FSTV2=true ";
+    cout << "or G4FST::SETTING::FSTV3=true ";
+    cout << "or G4FST::SETTING::FSTV4=true ";
+    cout << "or G4FST::SETTING::FSTV41=true ";
+    cout << "or G4FST::SETTING::FSTV42=true ";
+    cout << "or G4FST::SETTING::FSTV5=true ";
+    cout << "or G4FST::SETTING::FST_TPC=true "<< endl;
+    gSystem->Exit(1);
+  }
+
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 45.);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 282.);
 }
 //-----------------------------------------------------------------------------------//
 void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
 {
+  const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
+  const double mm = .1 * cm;
+  const double um = 1e-3 * mm;
+
   //Design from Xuan Li @LANL
-  make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30);  //cm
-  make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35);
-  make_LANL_FST_station("FST_2", g4Reco, 77, 5, 40);
-  make_LANL_FST_station("FST_3", g4Reco, 101, 6, 40);
-  make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 43);
-  //make_LANL_FST_station("FST_5", g4Reco, 280, 17, 41);
+  // Different FST version documented in arXiv:2009.0288
+  if (G4FST::SETTING::FSTV1)
+  {                                                              // version 1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV2)
+  {                                                              // version 2
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 270, 6.5, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV3)
+  {                                                              // version 3
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV41)
+  {                                                              // version 4.1
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV42)
+  {                                                              // version 4.2
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 100 * um);
+  }
+  else if (G4FST::SETTING::FSTV4)
+  {                                                              // version 4
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 50 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 36, 50 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 50 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 50 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 50 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 270, 15, 45, 50 * um);
+  }
+  else if (G4FST::SETTING::FSTV5)
+  {
+    make_LANL_FST_station("FST_0", g4Reco, 35,   4,   25, 35*um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 62.3, 4.5, 42, 35*um);
+    make_LANL_FST_station("FST_2", g4Reco, 90,   6.5,   43, 35*um);
+    make_LANL_FST_station("FST_3", g4Reco, 115,  8.9,   44, 85*um);
+    make_LANL_FST_station("FST_4", g4Reco, 125,  9.5, 45, 85*um);
+    make_LANL_FST_station("FST_5", g4Reco, 300,  16.8,  45, 85*um);  //optional disk at further location
+  }
+  else if (G4FST::SETTING::FST_TPC)
+  {                                                                // tpc version (based on version 4)
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4,   17, 35 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 17, 35 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5,   17, 35 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101,7.5, 17, 85 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125,9.5,   45, 85 * um);
+    //make_LANL_FST_station("FST_5", g4Reco, 280, 16, 45, 50 * um);  //optional disk at further location
+
+  }
+  else
+  {                                                               // Version 0
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 30, 100 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 35, 100 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 36, 100 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 6, 38.5, 100 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 6.5, 45, 100 * um);
+  }
 }
 //-----------------------------------------------------------------------------------//
-int make_LANL_FST_station(string name, PHG4Reco *g4Reco,
-                          double zpos, double Rmin, double Rmax)
+int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco,
+                          double zpos, double Rmin, double Rmax, double tSilicon)  //silicon thickness
 {
   //  cout
   //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
   //      << name << endl;
-
-  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FST_OVERLAPCHECK;
 
   // always facing the interaction point
   double polar_angle = 0;
@@ -77,14 +198,14 @@ int make_LANL_FST_station(string name, PHG4Reco *g4Reco,
   fst->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
   fst->get_geometry().set_N_Sector(1);
   fst->get_geometry().set_material("G4_AIR");
-  fst->OverlapCheck(OverlapCheck);
+  fst->OverlapCheck(true);
 
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
   // build up layers
 
-  fst->get_geometry().AddLayer("SiliconSensor", "G4_Si", 285 * um, true, 100);
+  fst->get_geometry().AddLayer("SiliconSensor", "G4_Si", tSilicon, true, 100);
   fst->get_geometry().AddLayer("Metalconnection", "G4_Al", 15 * um, false, 100);
   fst->get_geometry().AddLayer("HDI", "G4_KAPTON", 20 * um, false, 100);
   fst->get_geometry().AddLayer("Cooling", "G4_WATER", 100 * um, false, 100);
@@ -95,5 +216,7 @@ int make_LANL_FST_station(string name, PHG4Reco *g4Reco,
   g4Reco->registerSubsystem(fst);
   return 0;
 }
-//-----------------------------------------------------------------------------------//
+
 #endif
+
+//-----------------------------------------------------------------------------------//

--- a/common/G4_FwdJets.C
+++ b/common/G4_FwdJets.C
@@ -1,10 +1,14 @@
 #ifndef MACRO_G4FWDJETS_C
 #define MACRO_G4FWDJETS_C
 
+// #include <GlobalVariables.C>
+
+#include <g4jets/ClusterJetInput.h>
 #include <g4jets/FastJetAlgo.h>
 #include <g4jets/JetReco.h>
 #include <g4jets/TowerJetInput.h>
 #include <g4jets/TruthJetInput.h>
+#include <g4jets/TrackJetInput.h>
 
 #include <g4eval/JetEvaluator.h>
 
@@ -29,38 +33,95 @@ void Jet_FwdReco()
   Fun4AllServer *se = Fun4AllServer::instance();
 
   // truth particle level jets
-  JetReco *truthjetreco = new JetReco();
+  JetReco *truthjetreco = new JetReco("TRUTHJETRECO");
   truthjetreco->add_input(new TruthJetInput(Jet::PARTICLE));
-  //truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Truth_r02");
-  truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.3), "AntiKt_Truth_r03");
-  // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.4),"AntiKt_Truth_r04");
   truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Truth_r05");
-  // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.6),"AntiKt_Truth_r06");
   truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Truth_r07");
-  // truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.8),"AntiKt_Truth_r08");
+  truthjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Truth_r10");
   truthjetreco->set_algo_node("ANTIKT");
   truthjetreco->set_input_node("TRUTH");
   truthjetreco->Verbosity(verbosity);
   se->registerSubsystem(truthjetreco);
 
   // tower jets
-  JetReco *towerjetreco = new JetReco();
+  JetReco *towerjetreco = new JetReco("TOWERJETRECO");
   towerjetreco->add_input(new TowerJetInput(Jet::FEMC_TOWER));
   towerjetreco->add_input(new TowerJetInput(Jet::FHCAL_TOWER));
   towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWER));
   towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWER));
   towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWER));
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.2),"AntiKt_Tower_r02");
-  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.3), "AntiKt_Tower_r03");
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.4),"AntiKt_Tower_r04");
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Tower_r05");
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.6),"AntiKt_Tower_r06");
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Tower_r07");
-  // towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT,0.8),"AntiKt_Tower_r08");
+  towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Tower_r10");
   towerjetreco->set_algo_node("ANTIKT");
   towerjetreco->set_input_node("TOWER");
   towerjetreco->Verbosity(verbosity);
   se->registerSubsystem(towerjetreco);
+
+  // cluster jets
+  JetReco *clusterjetreco = new JetReco("CLUSTERJETRECO");
+  clusterjetreco->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::FHCAL_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALOUT_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::CEMC_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALIN_CLUSTER));
+  clusterjetreco->add_input(new ClusterJetInput(Jet::HCALOUT_CLUSTER));
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Cluster_r05");
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Cluster_r07");
+  clusterjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Cluster_r10");
+  clusterjetreco->set_algo_node("ANTIKT");
+  clusterjetreco->set_input_node("CLUSTER");
+  clusterjetreco->Verbosity(verbosity);
+  se->registerSubsystem(clusterjetreco);
+
+  // tower jets
+  JetReco *towerjetrecofwd = new JetReco("TOWERJETRECOFWD");
+  towerjetrecofwd->add_input(new TowerJetInput(Jet::FEMC_TOWER));
+  towerjetrecofwd->add_input(new TowerJetInput(Jet::FHCAL_TOWER));
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_TowerFwd_r05");
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_TowerFwd_r07");
+  towerjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_TowerFwd_r10");
+  towerjetrecofwd->set_algo_node("ANTIKT");
+  towerjetrecofwd->set_input_node("TOWER");
+  towerjetrecofwd->Verbosity(verbosity);
+  se->registerSubsystem(towerjetrecofwd);
+
+  // cluster jets
+  JetReco *clusterjetrecofwd = new JetReco("CLUSTERJETRECOFWD");
+  clusterjetrecofwd->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  clusterjetrecofwd->add_input(new ClusterJetInput(Jet::FHCAL_CLUSTER));
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_ClusterFwd_r05");
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_ClusterFwd_r07");
+  clusterjetrecofwd->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_ClusterFwd_r10");
+  clusterjetrecofwd->set_algo_node("ANTIKT");
+  clusterjetrecofwd->set_input_node("CLUSTER");
+  clusterjetrecofwd->Verbosity(verbosity);
+  se->registerSubsystem(clusterjetrecofwd);
+
+
+  // // track jets
+  JetReco *trackjetreco = new JetReco("TRACKJETRECO");
+  trackjetreco->add_input(new TrackJetInput(Jet::TRACK, TRACKING::TrackNodeName));
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Track_r05");
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Track_r07");
+  trackjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 1.0), "AntiKt_Track_r10");
+  trackjetreco->set_algo_node("ANTIKT");
+  trackjetreco->set_input_node("TRACK");
+  trackjetreco->Verbosity(verbosity);
+  se->registerSubsystem(trackjetreco);
+
+  // // track jets
+  JetReco *fulljetreco = new JetReco("FULLJETRECO");
+  fulljetreco->add_input(new TrackJetInput(Jet::TRACK, TRACKING::TrackNodeName));
+  fulljetreco->add_input(new ClusterJetInput(Jet::FEMC_CLUSTER));
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.5), "AntiKt_Full_r05");
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.7), "AntiKt_Full_r07");
+  fulljetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.8), "AntiKt_Full_r08");
+  fulljetreco->set_algo_node("ANTIKT");
+  fulljetreco->set_input_node("FULL");
+  fulljetreco->Verbosity(verbosity);
+  se->registerSubsystem(fulljetreco);
+
 
   return;
 }
@@ -70,12 +131,78 @@ void Jet_FwdEval(const std::string &outfilename = "g4fwdjets_eval.root")
   int verbosity = std::max(Enable::VERBOSITY, Enable::FWDJETS_VERBOSITY);
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  JetEvaluator *eval = new JetEvaluator("JETEVALUATOR",
-                                        "AntiKt_Tower_r05",
-                                        "AntiKt_Truth_r05",
-                                        outfilename);
-  eval->Verbosity(verbosity);
-  se->registerSubsystem(eval);
+  JetEvaluator *evaltrk05 = new JetEvaluator("JETEVALUATORTRACK05","AntiKt_Track_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_track_05_eval.root");
+  evaltrk05->Verbosity(verbosity);
+  se->registerSubsystem(evaltrk05);
+
+  JetEvaluator *evalfull05 = new JetEvaluator("JETEVALUATORFULL05","AntiKt_Full_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_full_05_eval.root");
+  evalfull05->Verbosity(verbosity);
+  se->registerSubsystem(evalfull05);
+
+  JetEvaluator *evalt05 = new JetEvaluator("JETEVALUATORTOWER05","AntiKt_Tower_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_tower_05_eval.root");
+  evalt05->Verbosity(verbosity);
+  se->registerSubsystem(evalt05);
+  JetEvaluator *evalt07 = new JetEvaluator("JETEVALUATORTOWER07","AntiKt_Tower_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_tower_07_eval.root");
+  evalt07->Verbosity(verbosity);
+  se->registerSubsystem(evalt07);
+  JetEvaluator *evalt10 = new JetEvaluator("JETEVALUATORTOWER10","AntiKt_Tower_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_tower_10_eval.root");
+  evalt10->Verbosity(verbosity);
+  se->registerSubsystem(evalt10);
+
+  JetEvaluator *evalc05 = new JetEvaluator("JETEVALUATORCLUSTER05", "AntiKt_Cluster_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_cluster_05_eval.root");
+  evalc05->Verbosity(verbosity);
+  se->registerSubsystem(evalc05);
+
+  JetEvaluator *evalc07 = new JetEvaluator("JETEVALUATORCLUSTER07", "AntiKt_Cluster_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_cluster_07_eval.root");
+  evalc07->Verbosity(verbosity);
+  se->registerSubsystem(evalc07);
+
+  JetEvaluator *evalc10 = new JetEvaluator("JETEVALUATORCLUSTER10", "AntiKt_Cluster_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_cluster_10_eval.root");
+  evalc10->Verbosity(verbosity);
+  se->registerSubsystem(evalc10);
+
+  JetEvaluator *evaltfwd05 = new JetEvaluator("JETEVALUATORFWDTOWER05","AntiKt_TowerFwd_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_TowerFwd_05_eval.root");
+  evaltfwd05->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd05);
+  JetEvaluator *evaltfwd07 = new JetEvaluator("JETEVALUATORFWDTOWER07","AntiKt_TowerFwd_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_TowerFwd_07_eval.root");
+  evaltfwd07->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd07);
+  JetEvaluator *evaltfwd10 = new JetEvaluator("JETEVALUATORFWDTOWER10","AntiKt_TowerFwd_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_TowerFwd_10_eval.root");
+  evaltfwd10->Verbosity(verbosity);
+  se->registerSubsystem(evaltfwd10);
+
+  JetEvaluator *evalcfwd05 = new JetEvaluator("JETEVALUATORFWDCLUSTER05", "AntiKt_ClusterFwd_r05",
+                                        "AntiKt_Truth_r05", "g4fwdjets_ClusterFwd_05_eval.root");
+  evalcfwd05->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd05);
+
+  JetEvaluator *evalcfwd07 = new JetEvaluator("JETEVALUATORFWDCLUSTER07", "AntiKt_ClusterFwd_r07",
+                                        "AntiKt_Truth_r07", "g4fwdjets_ClusterFwd_07_eval.root");
+  evalcfwd07->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd07);
+
+  JetEvaluator *evalcfwd10 = new JetEvaluator("JETEVALUATORFWDCLUSTER10", "AntiKt_ClusterFwd_r10",
+                                        "AntiKt_Truth_r10", "g4fwdjets_ClusterFwd_10_eval.root");
+  evalcfwd10->Verbosity(verbosity);
+  se->registerSubsystem(evalcfwd10);
+
+  // JetEvaluator *eval3 = new JetEvaluator("JETEVALUATOR3",
+  //                                       "AntiKt_Full_r07",
+  //                                       "AntiKt_Truth_r07",
+  //                                       "g4fwdjets_full_07_eval.root");
+  // eval3->Verbosity(verbosity);
+  // se->registerSubsystem(eval3);
 
   return;
 }

--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -17,7 +17,9 @@ void AddLayers_MiniTPCDrift(PHG4SectorSubsystem *gem);
 namespace Enable
 {
   bool EGEM = false;
+  bool EGEM_FULL = true;
   bool FGEM = false;
+  bool FGEM_ORIG = false;
 }  // namespace Enable
 
 void EGEM_Init()
@@ -42,10 +44,15 @@ void EGEMSetup(PHG4Reco *g4Reco)
    * TPC length = 211 cm --> from z = -105.5 to z = +105.5
    */
   float thickness = 3.;
-  make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
-  make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
-  make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
-  make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
+  if (Enable::EGEM_FULL){
+    make_GEM_station("EGEM_0", g4Reco, -20.5 + thickness, -0.94, -1.95);
+    make_GEM_station("EGEM_1", g4Reco, -69.5 + thickness, -2.07, -3.21);
+    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);
+  } else {
+    make_GEM_station("EGEM_2", g4Reco, -137.0 + thickness, -1.4, -3.5);
+    make_GEM_station("EGEM_3", g4Reco, -160.0 + thickness, -1.5, -3.6);    
+  }
 }
 
 void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
@@ -60,10 +67,19 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   double zpos;
   PHG4SectorSubsystem *gem;
 
+  if(Enable::FGEM_ORIG){
+  	make_GEM_station("FGEM_0", g4Reco, 17.5, 0.94, 1.95, N_Sector);
+  	make_GEM_station("FGEM_1", g4Reco, 66.5, 2.07, 3.20, N_Sector);
+  }
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_2";
-  etamax = 2;
+  if(Enable::FGEM_ORIG){
+  	etamax = 3.3;
+  }
+  else{
+	etamax = 2;
+  }
   etamin = min_eta;
   zpos = 134.0;
 
@@ -84,7 +100,7 @@ void FGEMSetup(PHG4Reco *g4Reco, const int N_Sector = 8,  //
   ///////////////////////////////////////////////////////////////////////////
 
   name = "FGEM_3";
-  etamax = 2;
+  etamax = 3.3;
   etamin = min_eta;
   zpos = 157.0;
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -272,7 +272,7 @@ void HCALInner_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalInRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALIN");
-    ClusterBuilder->SetCylindricalGeometry();
+    ClusterBuilder->SetCylindricalGeometry();  // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -196,7 +196,7 @@ void HCALOuter_Clusters()
   {
     RawClusterBuilderTemplate *ClusterBuilder = new RawClusterBuilderTemplate("HcalOutRawClusterBuilderTemplate");
     ClusterBuilder->Detector("HCALOUT");
-    ClusterBuilder->SetCylindricalGeometry();
+    ClusterBuilder->SetCylindricalGeometry();  // has to be called after Detector()
     ClusterBuilder->Verbosity(verbosity);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -77,10 +77,9 @@ namespace Input
   int SIMPLE_NUMBER = 1;
   int SIMPLE_VERBOSITY = 0;
 
-//  bool UPSILON = false; // moved to GlobalVariables.C, as used in downstream vairables
   int UPSILON_NUMBER = 1;
   int UPSILON_VERBOSITY = 0;
-//  std::set<int> UPSILON_EmbedIds; // moved to GlobalVariables.C, as used in downstream vairables
+  // other UPSILON settings which are also used elsewhere are in GlobalVariables.C
 
   double PILEUPRATE = 0.;
   bool READHITS = false;
@@ -105,14 +104,14 @@ namespace INPUTREADEIC
 
 namespace INPUTREADHITS
 {
-  string filename;
-  string listfile;
+  map<unsigned int, std::string> filename;
+  map<unsigned int, std::string> listfile;
 }  // namespace INPUTREADHITS
 
 namespace INPUTEMBED
 {
-  string filename;
-  string listfile;
+  map<unsigned int, std::string> filename;
+  map<unsigned int, std::string> listfile;
 }  // namespace INPUTEMBED
 
 namespace PYTHIA6
@@ -132,7 +131,7 @@ namespace SARTRE
 
 namespace PILEUP
 {
-  string pileupfile = "/sphenix/sim/sim01/sphnxpro/sHijing_HepMC/sHijing_0-12fm.dat";
+  string pileupfile = "/sphenix/sim/sim01/sphnxpro/MDC1/sHijing_HepMC/data/sHijing_0_20fm-0000000001-00000.dat";
   double TpcDriftVelocity = 8.0 / 1000.0;
 }  // namespace PILEUP
 
@@ -417,22 +416,34 @@ void InputManagers()
   if (Input::EMBED)
   {
     gSystem->Load("libg4dst.so");
-    Fun4AllInputManager *in1 = new Fun4AllNoSyncDstInputManager("DSTinEmbed");
-    if (!INPUTEMBED::filename.empty() && INPUTEMBED::listfile.empty())
+    if (!INPUTEMBED::filename.empty() && !INPUTEMBED::listfile.empty())
     {
-      in1->fileopen(INPUTEMBED::filename);
-    }
-    else if (!INPUTEMBED::listfile.empty())
-    {
-      in1->AddListFile(INPUTEMBED::listfile);
-    }
-    else
-    {
-      cout << "no filename INPUTEMBED::filename or listfile INPUTEMBED::listfile given" << endl;
+      cout << "only filenames or filelists are supported, not mixtures" << endl;
       gSystem->Exit(1);
     }
-    in1->Repeat();  // if file(or filelist) is exhausted, start from beginning
-    se->registerInputManager(in1);
+    if (INPUTEMBED::filename.empty() && INPUTEMBED::listfile.empty())
+    {
+      cout << "you need to give an input filenames or filelist" << endl;
+      gSystem->Exit(1);
+    }
+    for (auto iter = INPUTEMBED::filename.begin(); iter != INPUTEMBED::filename.end(); ++iter)
+    {
+      string mgrname = "DSTin" + to_string(iter->first);
+      Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
+      hitsin->fileopen(iter->second);
+      hitsin->Verbosity(Input::VERBOSITY);
+      hitsin->Repeat();
+      se->registerInputManager(hitsin);
+    }
+    for (auto iter = INPUTEMBED::listfile.begin(); iter != INPUTEMBED::listfile.end(); ++iter)
+    {
+      string mgrname = "DSTin" + to_string(iter->first);
+      Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
+      hitsin->AddListFile(iter->second);
+      hitsin->Verbosity(Input::VERBOSITY);
+      hitsin->Repeat();
+      se->registerInputManager(hitsin);
+    }
   }
   if (Input::HEPMC)
   {
@@ -454,22 +465,33 @@ void InputManagers()
   }
   else if (Input::READHITS)
   {
-    Fun4AllInputManager *hitsin = new Fun4AllDstInputManager("DSTin");
-    if (!INPUTREADHITS::filename.empty() && INPUTREADHITS::listfile.empty())
+    gSystem->Load("libg4dst.so");
+    if (!INPUTREADHITS::filename.empty() && !INPUTREADHITS::listfile.empty())
     {
-      hitsin->fileopen(INPUTREADHITS::filename);
-    }
-    else if (!INPUTREADHITS::listfile.empty())
-    {
-      hitsin->AddListFile(INPUTREADHITS::listfile);
-    }
-    else
-    {
-      cout << "no filename INPUTREADHITS::filename or listfile INPUTREADHITS::listfile given" << endl;
+      cout << "only filenames or filelists are supported, not mixtures" << endl;
       gSystem->Exit(1);
     }
-    hitsin->Verbosity(Input::VERBOSITY);
-    se->registerInputManager(hitsin);
+    if (INPUTREADHITS::filename.empty() && INPUTREADHITS::listfile.empty())
+    {
+      cout << "you need to give an input filenames or filelist" << endl;
+      gSystem->Exit(1);
+    }
+    for (auto iter = INPUTREADHITS::filename.begin(); iter != INPUTREADHITS::filename.end(); ++iter)
+    {
+      string mgrname = "DSTin" + to_string(iter->first);
+      Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
+      hitsin->fileopen(iter->second);
+      hitsin->Verbosity(Input::VERBOSITY);
+      se->registerInputManager(hitsin);
+    }
+    for (auto iter = INPUTREADHITS::listfile.begin(); iter != INPUTREADHITS::listfile.end(); ++iter)
+    {
+      string mgrname = "DSTin" + to_string(iter->first);
+      Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
+      hitsin->AddListFile(iter->second);
+      hitsin->Verbosity(Input::VERBOSITY);
+      se->registerInputManager(hitsin);
+    }
   }
   else
   {

--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -1,0 +1,166 @@
+#ifndef MACRO_G4KFPARTICLE_C
+#define MACRO_G4KFPARTICLE_C
+
+#include <GlobalVariables.C>
+
+#include <kfparticle_sphenix/KFParticle_sPHENIX.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libkfparticle_sphenix.so)
+
+namespace Enable
+{
+  bool KFPARTICLE = false;
+  bool KFPARTICLE_SAVE_NTUPLE = false;
+  bool KFPARTICLE_APPEND_TO_DST = true;
+  bool KFPARTICLE_TRUTH_MATCH = false;
+  bool KFPARTICLE_DETECTOR_INFO = false;
+  int KFPARTICLE_VERBOSITY = 0;
+  std::string KFPARTICLE_TRACKMAP = "SvtxTrackMap";
+  std::string KFPARTICLE_VERTEXMAP = "SvtxVertexMap";
+}  // namespace Enable
+
+namespace KFParticleBaseCut
+{
+  float minTrackPT = 0.5; // GeV
+  float maxTrackchi2nDoF = 2;
+  float minTrackIPchi2 = 15; // IP = DCA of track with vertex
+  float maxVertexchi2nDoF = 2;
+  float maxTrackTrackDCA = 0.05; // cm
+  float minMotherPT = 0; // GeV
+}  // namespace KFParticleBaseCut
+
+void KFParticleInit() {} //I guess this line isnt needed
+
+void KFParticle_Upsilon_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "Upsilon";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(2);
+  daughterList[0] = make_pair("electron", +1);
+  daughterList[1] = make_pair("electron", -1);
+  kfparticle->getChargeConjugate(false);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(0); // Upsilon decays are prompt, tracks are more likely to point to vertex
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(7);
+  kfparticle->setMaximumMass(11);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+void KFParticle_D0_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "D0";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(2);
+  daughterList[0] = make_pair("kaon", -1);
+  daughterList[1] = make_pair("pion", +1);
+  kfparticle->getChargeConjugate(true);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(1.750);
+  kfparticle->setMaximumMass(1.950);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+void KFParticle_Lambdac_Reco()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  std::string motherName = "Lambdac";
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  kfparticle->Verbosity(verbosity);
+
+  kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
+  kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
+  kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
+  kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
+
+  kfparticle->setContainerName(motherName);
+  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
+
+  std::pair<std::string, int> daughterList[99];
+  kfparticle->setNumberOfTracks(3);
+  daughterList[0] = make_pair("proton", +1);
+  daughterList[1] = make_pair("kaon", -1);
+  daughterList[2] = make_pair("pion", +1);
+  kfparticle->getChargeConjugate(true);
+  kfparticle->setDaughters(daughterList);
+  kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
+  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
+
+  kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
+  kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
+
+  kfparticle->setMotherName(motherName);
+  kfparticle->setMinimumMass(2.150);
+  kfparticle->setMaximumMass(2.400);
+  kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
+  kfparticle->constrainToPrimaryVertex(false);
+
+  se->registerSubsystem(kfparticle);
+
+  return;
+}
+
+
+#endif

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -18,6 +18,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <tpc/TpcClusterizer.h>
+#include <tpc/TpcClusterCleaner.h>
 #include <tpc/TpcSpaceChargeCorrection.h>
 #include <qa_modules/QAG4SimulationTpc.h>
 
@@ -222,6 +223,10 @@ void TPC_Clustering()
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(verbosity);
   se->registerSubsystem(tpcclusterizer);
+
+  auto tpcclustercleaner = new TpcClusterCleaner;
+  tpcclustercleaner->Verbosity(verbosity);
+  se->registerSubsystem(tpcclustercleaner);
 
   // space charge correction
   if( G4TPC::ENABLE_CORRECTIONS )

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -14,6 +14,7 @@
 #include <g4eval/SvtxEvaluator.h>
 
 #include <trackreco/PHCASeeding.h>
+#include <trackreco/PHHybridSeeding.h>
 #include <trackreco/PHGenFitTrackProjection.h>
 #include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHGenFitTrkProp.h>
@@ -23,6 +24,7 @@
 #include <trackreco/PHRaveVertexing.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
 #include <trackreco/PHSiliconTruthTrackSeeding.h>
+#include <trackreco/PHTpcTrackSeedVertexAssoc.h>
 #include <trackreco/PHTrackSeeding.h>
 #include <trackreco/PHTruthSiliconAssociation.h>
 #include <trackreco/PHTruthTrackSeeding.h>
@@ -32,11 +34,12 @@
 #include <trackreco/ActsEvaluator.h>
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSourceLinks.h>
+#include <trackreco/PHActsSiliconSeeding.h>
 #include <trackreco/PHActsTracks.h>
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsTrkProp.h>
+#include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHActsVertexFinder.h>
-#include <trackreco/PHActsVertexFitter.h>
 #include <trackreco/PHTpcResiduals.h>
 #endif
 
@@ -81,13 +84,17 @@ namespace G4TRACKING
   //   PHActsTrkFitter                               // Kalman fitter makes final fit to assembled tracks
 
   bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
+  bool use_tpc_seed_vertex_assoc = true;
 
   // Possible variations - these are normally false
   bool use_PHTpcTracker_seeding = false;   // false for using the default PHCASeeding to get TPC track seeds, true to use PHTpcTracker
+  bool use_hybrid_seeding = false;         // false for using the default PHCASeeding, true to use PHHybridSeeding (STAR core, ALICE KF)
   bool use_truth_si_matching = false;      // if true, associates silicon clusters using best truth track match to TPC seed tracks - for diagnostics only
   bool use_truth_track_seeding = false;    // false for normal track seeding, use true to run with truth track seeding instead  ***** WORKS FOR GENFIT ONLY
   bool use_Genfit = false;                 // if false, acts KF is run on proto tracks assembled above, if true, use Genfit track propagation and fitting
-  bool use_init_vertexing = false;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
+  bool use_acts_silicon_seeding = true;   // if true runs acts silicon seeding
+  bool use_acts_init_vertexing = false;    // if true runs acts initial vertex finder, false runs truth vertexing
+  bool use_phinit_vertexing = false && !use_acts_init_vertexing;         // false for using smeared truth vertex, set to true to get initial vertex from MVTX hits using PHInitZVertexing
   bool use_rave_vertexing = true;          // Use Rave to find and fit for vertex after track fitting
   bool use_primary_vertex = false;         // refit Genfit tracks (only) with primary vertex included - adds second node to node tree, adds second evaluator, outputs separate ntuples
   bool use_acts_evaluator = false;         // Turn to true for an acts evaluator which outputs acts specific information in a tuple
@@ -167,16 +174,57 @@ void Tracking_Reco()
   // Tracking
   //------------
 
-  // Initial vertex finding (independent of tracking)
+  if(!G4TRACKING::use_Genfit)
+    {
+#if __cplusplus >= 201703L
+      /// Geometry must be built before any Acts modules
+      MakeActsGeometry* geom = new MakeActsGeometry();
+      geom->Verbosity(verbosity);
+      geom->setMagField(G4MAGNET::magfield);
+      geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
+
+      /// Need a flip of the sign for constant field in tpc tracker
+      if(G4TRACKING::use_PHTpcTracker_seeding 
+	 && G4MAGNET::magfield.find(".root") == std::string::npos)
+	geom->setMagFieldRescale(-1 * G4MAGNET::magfield_rescale);
+      se->registerSubsystem(geom);
+      
+      /// Always run PHActsSourceLinks first, to convert TrkrClusters 
+      /// to the Acts equivalent
+      PHActsSourceLinks* sl = new PHActsSourceLinks();
+      sl->Verbosity(verbosity);
+      sl->setMagField(G4MAGNET::magfield);
+      sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
+      se->registerSubsystem(sl);
+#endif  
+    }
+
+  // Initial vertex finding
   //=================================
-  if (!G4TRACKING::use_init_vertexing)
-  {
-    // We cheat to get the initial vertex for the full track reconstruction case
-    PHInitVertexing* init_vtx = new PHTruthVertexing("PHTruthVertexing");
-    init_vtx->Verbosity(0);
-    se->registerSubsystem(init_vtx);
-  }
-  else
+  if(G4TRACKING::use_acts_silicon_seeding && !G4TRACKING::use_Genfit)
+    {
+      #if __cplusplus >= 201703L
+
+      PHActsSiliconSeeding* silicon_Seeding = new PHActsSiliconSeeding();
+      silicon_Seeding->Verbosity(verbosity);
+      se->registerSubsystem(silicon_Seeding);
+      
+      if(G4TRACKING::use_acts_init_vertexing)
+	{
+	  PHActsInitialVertexFinder* init_vtx = new PHActsInitialVertexFinder();
+	  init_vtx->Verbosity(verbosity);
+	  se->registerSubsystem(init_vtx);
+	}
+      else
+	{
+	  PHTruthVertexing *init_vtx = new PHTruthVertexing();
+	  init_vtx->Verbosity(verbosity);
+	  init_vtx->set_acts_silicon(true);
+	  se->registerSubsystem(init_vtx);
+	}
+      #endif
+    }
+  else if (G4TRACKING::use_phinit_vertexing)
   {
     // get the initial vertex for track fitting from the MVTX hits
     PHInitZVertexing* init_zvtx = new PHInitZVertexing(7, 7, "PHInitZVertexing");
@@ -187,6 +235,14 @@ void Tracking_Reco()
     init_zvtx->set_min_zvtx_tracks(G4TRACKING::init_vertexing_min_zvtx_tracks);
     init_zvtx->Verbosity(verbosity);
     se->registerSubsystem(init_zvtx);
+  }
+  else
+  {
+    // We cheat to get the initial vertex for the full track reconstruction case
+    PHInitVertexing* init_vtx = new PHTruthVertexing("PHTruthVertexing");
+    init_vtx->Verbosity(verbosity);
+    se->registerSubsystem(init_vtx);
+
   }
 
   // Truth track seeding and propagation in one module
@@ -208,7 +264,7 @@ void Tracking_Reco()
     std::cout << "Using normal TPC track seeding " << std::endl;
 
     // TPC track seeding from data
-    if (G4TRACKING::use_PHTpcTracker_seeding)
+    if (G4TRACKING::use_PHTpcTracker_seeding && !G4TRACKING::use_hybrid_seeding)
     {
       std::cout << "   Using PHTpcTracker track seeding " << std::endl;
 
@@ -219,16 +275,34 @@ void Tracking_Reco()
       tracker->set_track_follower_optimization_precise_fit(false);                // true for quality, false for speed
       tracker->enable_json_export(false);                                         // save event as json, filename is automatic and stamped by current time in ms
       tracker->enable_vertexing(false);                                           // rave vertexing is pretty slow at large multiplicities...
-      tracker->Verbosity(0);
+      tracker->Verbosity(verbosity);
       se->registerSubsystem(tracker);
+    }
+    else if(G4TRACKING::use_hybrid_seeding && !G4TRACKING::use_PHTpcTracker_seeding)
+    {
+      std::cout << "   Using PHHybridSeeding track seeding " << std::endl;
+      PHHybridSeeding* hseeder = new PHHybridSeeding("PHHybridSeeding");
+      hseeder->set_field_dir(G4MAGNET::magfield_rescale);
+      hseeder->setSearchRadius(3.,6.); // mm (iter1, iter2)
+      hseeder->setSearchAngle(M_PI/8.,M_PI/8.); // radians (iter1, iter2)
+      hseeder->setMinTrackSize(10,5); // (iter1, iter2)
+      hseeder->setNThreads(1);
+      hseeder->Verbosity(0);
+      se->registerSubsystem(hseeder);
     }
     else
     {
+      if(G4TRACKING::use_hybrid_seeding && G4TRACKING::use_PHTpcTracker_seeding)
+      {
+        std::cerr << "***WARNING: MULTIPLE SEEDER OPTIONS SELECTED!***" << std::endl;
+        std::cerr << "  Current config selects both PHTpcTracker and PHHybridSeeding." << std::endl;
+        std::cerr << "  Since config doesn't make sense, reverting to default..." << std::endl;
+      }
       std::cout << "   Using PHCASeeding track seeding " << std::endl;
 
       auto seeder = new PHCASeeding("PHCASeeding");
       seeder->set_field_dir(G4MAGNET::magfield_rescale);  // to get charge sign right
-      seeder->Verbosity(0);
+      seeder->Verbosity(verbosity);
       seeder->SetLayerRange(7, 55);
       seeder->SetSearchWindow(0.01, 0.02);  // (eta width, phi width)
       seeder->SetMinHitsPerCluster(2);
@@ -236,6 +310,14 @@ void Tracking_Reco()
       se->registerSubsystem(seeder);
     }
   }
+
+  if(G4TRACKING::use_tpc_seed_vertex_assoc)
+    {
+      // This does not care which seeder is used
+      PHTpcTrackSeedVertexAssoc *vtxassoc = new PHTpcTrackSeedVertexAssoc();
+      vtxassoc->Verbosity(0);
+      se->registerSubsystem(vtxassoc);
+    }
 
   // Genfit track propagation and final fitting (starts from TPC track seeds)
   //=================================================
@@ -292,7 +374,7 @@ void Tracking_Reco()
       // use truth particle matching in TPC to assign clusters in silicon to TPC tracks from CA seeder
       // intended only for diagnostics
       PHTruthSiliconAssociation* silicon_assoc = new PHTruthSiliconAssociation();
-      silicon_assoc->Verbosity(0);
+      silicon_assoc->Verbosity(verbosity);
       se->registerSubsystem(silicon_assoc);
     }
     else
@@ -303,15 +385,19 @@ void Tracking_Reco()
       // start with a complete TPC track seed from one of the CA seeders
 
       // use truth information to assemble silicon clusters into track stubs for now
-      PHSiliconTruthTrackSeeding* silicon_seeding = new PHSiliconTruthTrackSeeding();
-      silicon_seeding->Verbosity(0);
-      se->registerSubsystem(silicon_seeding);
+      if(!G4TRACKING::use_acts_silicon_seeding)
+	{
+	  PHSiliconTruthTrackSeeding* silicon_seeding = new PHSiliconTruthTrackSeeding();
+	  silicon_seeding->Verbosity(verbosity);
+	  se->registerSubsystem(silicon_seeding);
+	  
+	}
 
       // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
       PHSiliconTpcTrackMatching* silicon_match = new PHSiliconTpcTrackMatching();
-      silicon_match->Verbosity(0);
-      if (!G4TRACKING::use_PHTpcTracker_seeding)
-        silicon_match->set_seeder(true);  // module defaults to PHCASeeding, use true for PHTpcTracker seeding
+      silicon_match->Verbosity(verbosity);
+      if (G4TRACKING::use_PHTpcTracker_seeding && !G4TRACKING::use_tpc_seed_vertex_assoc)
+        silicon_match->set_seeder(false);  // module defaults to CASeeding, for PHTpcTracker seeding use false here ONLY when not using  PHTpcTrackSeedVertexAssoc.
       silicon_match->set_field(G4MAGNET::magfield);
       silicon_match->set_field_dir(G4MAGNET::magfield_rescale);
       silicon_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
@@ -326,8 +412,8 @@ void Tracking_Reco()
       else
       {
         // after distortion corrections and rerunning clustering, default tuned values are 0.02 and 0.004 in low occupancy events
-        silicon_match->set_phi_search_window(0.02);
-        silicon_match->set_eta_search_window(0.004);
+        silicon_match->set_phi_search_window(0.03);
+        silicon_match->set_eta_search_window(0.005);
       }
       silicon_match->set_test_windows_printout(false);  // used for tuning search windows only
       se->registerSubsystem(silicon_match);
@@ -340,7 +426,7 @@ void Tracking_Reco()
 
       // Match TPC track stubs from CA seeder to clusters in the micromegas layers
       PHMicromegasTpcTrackMatching* mm_match = new PHMicromegasTpcTrackMatching();
-      mm_match->Verbosity(0);
+      mm_match->Verbosity(verbosity);
       mm_match->set_sc_calib_mode(G4TRACKING::SC_CALIBMODE);
       if (G4TRACKING::SC_CALIBMODE)
       {
@@ -373,25 +459,13 @@ void Tracking_Reco()
     std::cout << "   Using Acts track fitting " << std::endl;
 
 #if __cplusplus >= 201703L
-    /// Geometry must be built before any Acts modules
-    MakeActsGeometry* geom = new MakeActsGeometry();
-    geom->Verbosity(verbosity);
-    geom->setMagField(G4MAGNET::magfield);
-    geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-    se->registerSubsystem(geom);
+  
 
-    /// Always run PHActsSourceLinks and PHActsTracks first, to convert TrkRClusters and SvtxTracks to the Acts equivalent
-    PHActsSourceLinks* sl = new PHActsSourceLinks();
-    sl->Verbosity(verbosity);
-    sl->setMagField(G4MAGNET::magfield);
-    sl->setMagFieldRescale(G4MAGNET::magfield_rescale);
-    se->registerSubsystem(sl);
-
-    PHActsTracks* actsTracks = new PHActsTracks();
+    PHActsTracks* actsTracks = new PHActsTracks("PHActsTracks1");
     actsTracks->Verbosity(verbosity);
     se->registerSubsystem(actsTracks);
 
-    PHActsTrkFitter* actsFit = new PHActsTrkFitter();
+    PHActsTrkFitter* actsFit = new PHActsTrkFitter("PHActsFirstTrkFitter");
     actsFit->Verbosity(verbosity);
     actsFit->doTimeAnalysis(false);
     /// If running with distortions, fit only the silicon+MMs first
@@ -406,9 +480,20 @@ void Tracking_Reco()
       se->registerSubsystem(residuals);
     }
 
-    PHActsVertexFinder* vtxer = new PHActsVertexFinder();
-    vtxer->Verbosity(verbosity);
-    se->registerSubsystem(vtxer);
+    PHActsVertexFinder *finder = new PHActsVertexFinder("PHActsVertexFinder");
+    finder->Verbosity(verbosity);
+    se->registerSubsystem(finder);
+
+    PHActsTracks *actsTracks2 = new PHActsTracks("PHActsTracks2");
+    actsTracks2->Verbosity(verbosity);
+    actsTracks2->setSecondFit(true);
+    se->registerSubsystem(actsTracks2);
+
+    PHActsTrkFitter* actsFit2 = new PHActsTrkFitter("PHActsSecondTrKFitter");
+    actsFit2->Verbosity(verbosity);
+    actsFit2->doTimeAnalysis(false);
+    actsFit2->fitSiliconMMs(false);
+    se->registerSubsystem(actsFit2);
 
 #endif
   }
@@ -460,7 +545,7 @@ void Tracking_Eval(const std::string& outputfile)
   eval->do_gpoint_eval(false);
   eval->do_eval_light(true);
   eval->set_use_initial_vertex(G4TRACKING::g4eval_use_initial_vertex);
-  eval->scan_for_embedded(false);  // take all tracks if false - take only embedded tracks if true
+  eval->scan_for_embedded(true);  // take all tracks if false - take only embedded tracks if true
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 
@@ -470,7 +555,7 @@ void Tracking_Eval(const std::string& outputfile)
     if (G4TRACKING::use_acts_evaluator)
     {
       ActsEvaluator* actsEval = new ActsEvaluator(outputfile + "_acts.root", eval);
-      actsEval->Verbosity(0);
+      actsEval->Verbosity(verbosity);
       actsEval->setEvalCKF(false);
       se->registerSubsystem(actsEval);
     }

--- a/common/G4_World.C
+++ b/common/G4_World.C
@@ -11,7 +11,7 @@ namespace G4WORLD
 {
   double AddSpace = 100.;            // add this much space in cm around edge of detector
   string WorldMaterial = "G4_AIR";   // default world material, use G4_Galactic for material scan
-  string PhysicsList = "QGSP_BERT";  // for calorimeters use HP lists
+  string PhysicsList = "FTFP_BERT";  // for calorimeters use HP lists
 }  // namespace G4WORLD
 
 void WorldInit(PHG4Reco *g4Reco)

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -59,7 +59,9 @@ int Fun4All_G4_EICDetector(
   // about the number of layers used for the cell reco code
   //
   //Input::READHITS = true;
-  INPUTREADHITS::filename = inputFile;
+  INPUTREADHITS::filename[0] = inputFile;
+  // if you use a filelist
+  // INPUTREADHITS::listfile[0] = inputFile;
 
   // Or:
   // Use one or more particle generators
@@ -67,7 +69,10 @@ int Fun4All_G4_EICDetector(
   // all other options only play a role if it is active
   // In case embedding into a production output, please double check your G4Setup_EICDetector.C and G4_*.C consistent with those in the production macro folder
   //  Input::EMBED = true;
-  INPUTEMBED::filename = embed_input_file;
+  INPUTEMBED::filename[0] = embed_input_file;
+  // if you use a filelist
+  //INPUTEMBED::listfile[0] = embed_input_file;
+
   // Use Pythia 8
   //  Input::PYTHIA8 = true;
 
@@ -145,6 +150,11 @@ int Fun4All_G4_EICDetector(
     INPUTGENERATOR::VectorMesonGenerator[0]->set_pt_range(0., 10.);
     // Y species - select only one, last one wins
     INPUTGENERATOR::VectorMesonGenerator[0]->set_upsilon_1s();
+    if (Input::HEPMC || Input::EMBED)
+    {
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_reuse_existing_vertex(true);
+      INPUTGENERATOR::VectorMesonGenerator[0]->set_existing_vertex_offset_vector(0.0, 0.0, 0.0);
+    }
   }
   // particle gun
   // if you run more than one of these Input::GUN_NUMBER > 1
@@ -188,13 +198,13 @@ int Fun4All_G4_EICDetector(
   // Write the DST
   //======================
 
-  //  Enable::DSTOUT = true;
+  Enable::DSTOUT = false;
   DstOut::OutputDir = outdir;
   DstOut::OutputFile = outputFile;
   Enable::DSTOUT_COMPRESS = false;  // Compress DST files
 
   //Option to convert DST to human command readable TTree for quick poke around the outputs
-  //Enable::DSTREADER = true;
+  Enable::DSTREADER = true;
 
   // turn the display on (default off)
   Enable::DISPLAY = false;
@@ -213,34 +223,40 @@ int Fun4All_G4_EICDetector(
   // whether to simulate the Be section of the beam pipe
   Enable::PIPE = true;
   // EIC beam pipe extension beyond the Be-section:
-  //G4PIPE::use_forward_pipes = true;
+  G4PIPE::use_forward_pipes = true;
 
-  Enable::EGEM = true;
-  Enable::FGEM = true;
+  // gems
+  Enable::EGEM = false;
+  Enable::FGEM = false;
+  Enable::FGEM_ORIG = false; //5 forward gems; cannot be used with FST
   // barrel tracker
   Enable::BARREL = false;
-  Enable::FST = false;
+  //G4BARREL::SETTING::BARRELV6=true;
+  // fst
+  Enable::FST = true;
+  G4FST::SETTING::FSTV5 = true;
   // mvtx/tpc tracker
-  Enable::MVTX = true;
-  Enable::TPC = true;
+  Enable::MVTX = false;
+  Enable::TPC = false;
   //  Enable::TPC_ENDCAP = true;
 
   Enable::TRACKING = true;
   Enable::TRACKING_EVAL = Enable::TRACKING && true;
   G4TRACKING::DISPLACED_VERTEX = false;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
+  G4TRACKING::PROJECTION_EEMC = false;
   G4TRACKING::PROJECTION_CEMC = false;
   G4TRACKING::PROJECTION_FEMC = false;
   G4TRACKING::PROJECTION_FHCAL = false;
 
-  Enable::CEMC = true;
+  Enable::CEMC = false;
   //  Enable::CEMC_ABSORBER = true;
   Enable::CEMC_CELL = Enable::CEMC && true;
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
 
-  Enable::HCALIN = true;
+  Enable::HCALIN = false;
   //  Enable::HCALIN_ABSORBER = true;
   Enable::HCALIN_CELL = Enable::HCALIN && true;
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
@@ -249,7 +265,7 @@ int Fun4All_G4_EICDetector(
 
   Enable::MAGNET = true;
 
-  Enable::HCALOUT = true;
+  Enable::HCALOUT = false;
   //  Enable::HCALOUT_ABSORBER = true;
   Enable::HCALOUT_CELL = Enable::HCALOUT && true;
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
@@ -257,34 +273,31 @@ int Fun4All_G4_EICDetector(
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
 
   // EICDetector geometry - barrel
-  Enable::DIRC = true;
+  Enable::DIRC = false;
 
   // EICDetector geometry - 'hadron' direction
-  Enable::RICH = true;
-  Enable::AEROGEL = true;
+  Enable::RICH = false;
+  Enable::AEROGEL = false;
 
-  Enable::FEMC = true;
+  Enable::FEMC = false;
   //  Enable::FEMC_ABSORBER = true;
-  Enable::FEMC_CELL = Enable::FEMC && true;
-  Enable::FEMC_TOWER = Enable::FEMC_CELL && true;
+  Enable::FEMC_TOWER = Enable::FEMC && true;
   Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
   Enable::FEMC_EVAL = Enable::FEMC_CLUSTER && true;
 
-  Enable::FHCAL = true;
+  Enable::FHCAL = false;
   //  Enable::FHCAL_ABSORBER = true;
-  Enable::FHCAL_CELL = Enable::FHCAL && true;
-  Enable::FHCAL_TOWER = Enable::FHCAL_CELL && true;
+  Enable::FHCAL_TOWER = Enable::FHCAL && true;
   Enable::FHCAL_CLUSTER = Enable::FHCAL_TOWER && true;
   Enable::FHCAL_EVAL = Enable::FHCAL_CLUSTER && true;
 
   // EICDetector geometry - 'electron' direction
-  Enable::EEMC = true;
-  Enable::EEMC_CELL = Enable::EEMC && true;
-  Enable::EEMC_TOWER = Enable::EEMC_CELL && true;
+  Enable::EEMC = false;
+  Enable::EEMC_TOWER = Enable::EEMC && true;
   Enable::EEMC_CLUSTER = Enable::EEMC_TOWER && true;
   Enable::EEMC_EVAL = Enable::EEMC_CLUSTER && true;
 
-  Enable::PLUGDOOR = true;
+  Enable::PLUGDOOR = false;
 
   // Other options
   Enable::GLOBAL_RECO = true;
@@ -315,7 +328,7 @@ int Fun4All_G4_EICDetector(
   //---------------
   // World Settings
   //---------------
-  //  G4WORLD::PhysicsList = "QGSP_BERT"; //FTFP_BERT_HP best for calo
+  //  G4WORLD::PhysicsList = "FTFP_BERT"; //FTFP_BERT_HP best for calo
   //  G4WORLD::WorldMaterial = "G4_AIR"; // set to G4_GALACTIC for material scans
 
   //---------------
@@ -358,12 +371,6 @@ int Fun4All_G4_EICDetector(
   if (Enable::HCALIN_CELL) HCALInner_Cells();
 
   if (Enable::HCALOUT_CELL) HCALOuter_Cells();
-
-  if (Enable::FEMC_CELL) FEMC_Cells();
-
-  if (Enable::FHCAL_CELL) FHCAL_Cells();
-
-  if (Enable::EEMC_CELL) EEMC_Cells();
 
   //-----------------------------
   // CEMC towering and clustering

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -48,14 +48,24 @@ void G4Init()
 {
   // First some check for subsystems which do not go together
 
-  if (Enable::TPC && Enable::FST)
+  if (Enable::TPC && Enable::FST && !G4FST::SETTING::FST_TPC)
   {
-    cout << "TPC and FST cannot be enabled together" << endl;
+    cout << "FST setup cannot fit in the TPC" << endl;
     gSystem->Exit(1);
   }
-  else if ((Enable::TPC || Enable::MVTX) && Enable::BARREL)
+  else if (Enable::MVTX && Enable::BARREL)
   {
-    cout << "TPC/MVTX and BARREL cannot be enabled together" << endl;
+    cout << "MVTX and BARREL cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  }
+  else if (Enable::TPC && Enable::BARREL && !G4BARREL::SETTING::BARRELV6) {
+    cout << "Barrel setup cannot fit in the TPC" << endl;
+    gSystem->Exit(1);
+  }
+
+  if(Enable::FGEM_ORIG && Enable::FST)
+  {
+    cout << "FST cannot be enabled with 5 FGEM setup" << endl;
     gSystem->Exit(1);
   }
 
@@ -63,7 +73,7 @@ void G4Init()
   if (Enable::PIPE) PipeInit();
   if (Enable::PLUGDOOR) PlugDoorInit();
   if (Enable::EGEM) EGEM_Init();
-  if (Enable::FGEM) FGEM_Init();
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEM_Init();
   if (Enable::FST) FST_Init();
   if (Enable::BARREL) BarrelInit();
   if (Enable::MVTX) MvtxInit();
@@ -134,7 +144,7 @@ int G4Setup()
 
   if (Enable::PIPE) radius = Pipe(g4Reco, radius);
   if (Enable::EGEM) EGEMSetup(g4Reco);
-  if (Enable::FGEM) FGEMSetup(g4Reco);
+  if (Enable::FGEM || Enable::FGEM_ORIG) FGEMSetup(g4Reco);
   if (Enable::FST) FSTSetup(g4Reco);
   if (Enable::BARREL) Barrel(g4Reco, radius);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);


### PR DESCRIPTION
This pull request adds two FST designs and one barrel design. The latest version, version 5 of FST, consists of 6 silicon plane detectors with the last plane sits at z=300cm. Another FST design as shown in the following figure has 4 silicon planes located inside the TPC and 1 silicon plane outside the TPC. The 4 silicon plane has an outer radius of 17 cm, such that there is a 3 cm gap between the FST and the TPC for the FST service part. 

The latest version (version 6) of the barrel tracker has 4 layers of silicon sensors. The outermost layer of the barrel tracks has a radius of 16cm, such that the barrel track can fit in the TPC.

To switch to the TPC-compactible FST and Barrel set 
- G4FST::SETTING::FST_TPC=true
- G4BARREL::SETTING::BARRELV6=true

![Screen Shot 2021-03-15 at 2 21 38 PM](https://user-images.githubusercontent.com/14319626/111219125-42158b80-859d-11eb-843f-99c621f459e6.png)
Event display with the TPC (teal)+TPC endcap, FST (yellow) and the barrel (pink)
