### PR TITLE
Clean up for tracking and FST macros

### DIFF
--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -25,7 +25,8 @@ int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco, double zpos, dou
 namespace Enable
 {
   static bool FST = false;
-}
+  bool FST_OVERLAPCHECK = false;
+}  // namespace Enable
 
 namespace G4FST
 {
@@ -47,14 +48,15 @@ namespace G4FST
 void FST_Init()
 {
   if ((G4FST::SETTING::FSTV0 ? 1 : 0) +
-      (G4FST::SETTING::FSTV1 ? 1 : 0) +
-      (G4FST::SETTING::FSTV2 ? 1 : 0) +
-      (G4FST::SETTING::FSTV3 ? 1 : 0) +
-      (G4FST::SETTING::FSTV4 ? 1 : 0) +
-      (G4FST::SETTING::FSTV41 ? 1 : 0) +
-      (G4FST::SETTING::FSTV42 ? 1 : 0) +
-      (G4FST::SETTING::FSTV5 ? 1 : 0) +
-      (G4FST::SETTING::FST_TPC ? 1 : 0) > 1)
+          (G4FST::SETTING::FSTV1 ? 1 : 0) +
+          (G4FST::SETTING::FSTV2 ? 1 : 0) +
+          (G4FST::SETTING::FSTV3 ? 1 : 0) +
+          (G4FST::SETTING::FSTV4 ? 1 : 0) +
+          (G4FST::SETTING::FSTV41 ? 1 : 0) +
+          (G4FST::SETTING::FSTV42 ? 1 : 0) +
+          (G4FST::SETTING::FSTV5 ? 1 : 0) +
+          (G4FST::SETTING::FST_TPC ? 1 : 0) >
+      1)
   {
     cout << "use only G4FST::SETTING::FSTV0=true ";
     cout << "or G4FST::SETTING::FSTV1=true ";
@@ -64,7 +66,7 @@ void FST_Init()
     cout << "or G4FST::SETTING::FSTV41=true ";
     cout << "or G4FST::SETTING::FSTV42=true ";
     cout << "or G4FST::SETTING::FSTV5=true ";
-    cout << "or G4FST::SETTING::FST_TPC=true "<< endl;
+    cout << "or G4FST::SETTING::FST_TPC=true " << endl;
     gSystem->Exit(1);
   }
 
@@ -133,20 +135,20 @@ void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
   }
   else if (G4FST::SETTING::FSTV5)
   {
-    make_LANL_FST_station("FST_0", g4Reco, 35,   4,   25, 35*um);  //cm
-    make_LANL_FST_station("FST_1", g4Reco, 62.3, 4.5, 42, 35*um);
-    make_LANL_FST_station("FST_2", g4Reco, 90,   6.5,   43, 35*um);
-    make_LANL_FST_station("FST_3", g4Reco, 115,  8.9,   44, 85*um);
-    make_LANL_FST_station("FST_4", g4Reco, 125,  9.5, 45, 85*um);
-    make_LANL_FST_station("FST_5", g4Reco, 300,  16.8,  45, 85*um);  //optional disk at further location
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 25, 35 * um);  //cm
+    make_LANL_FST_station("FST_1", g4Reco, 62.3, 4.5, 42, 35 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 90, 6.5, 43, 35 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 115, 8.9, 44, 85 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 9.5, 45, 85 * um);
+    make_LANL_FST_station("FST_5", g4Reco, 300, 16.8, 45, 85 * um);  //optional disk at further location
   }
   else if (G4FST::SETTING::FST_TPC)
-  {                                                                // tpc version (based on version 4)
-    make_LANL_FST_station("FST_0", g4Reco, 35, 4,   17, 35 * um);  //cm
+  {                                                              // tpc version (based on version 4)
+    make_LANL_FST_station("FST_0", g4Reco, 35, 4, 17, 35 * um);  //cm
     make_LANL_FST_station("FST_1", g4Reco, 53, 4.5, 17, 35 * um);
-    make_LANL_FST_station("FST_2", g4Reco, 77, 5,   17, 35 * um);
-    make_LANL_FST_station("FST_3", g4Reco, 101,7.5, 17, 85 * um);
-    make_LANL_FST_station("FST_4", g4Reco, 125,9.5,   45, 85 * um);
+    make_LANL_FST_station("FST_2", g4Reco, 77, 5, 17, 35 * um);
+    make_LANL_FST_station("FST_3", g4Reco, 101, 7.5, 17, 85 * um);
+    make_LANL_FST_station("FST_4", g4Reco, 125, 9.5, 45, 85 * um);
     //make_LANL_FST_station("FST_5", g4Reco, 280, 16, 45, 50 * um);  //optional disk at further location
   }
   else
@@ -162,6 +164,7 @@ void FSTSetup(PHG4Reco *g4Reco, const double min_eta = 1.245)
 int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco,
                           double zpos, double Rmin, double Rmax, double tSilicon)  //silicon thickness
 {
+  const bool OverlapCheck = Enable::OVERLAPCHECK || Enable::FST_OVERLAPCHECK;
   //  cout
   //      << "make_GEM_station - GEM construction with PHG4SectorSubsystem - make_GEM_station_EdgeReadout  of "
   //      << name << endl;
@@ -197,7 +200,7 @@ int make_LANL_FST_station(const string &name, PHG4Reco *g4Reco,
   fst->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
   fst->get_geometry().set_N_Sector(1);
   fst->get_geometry().set_material("G4_AIR");
-  fst->OverlapCheck(true);
+  fst->OverlapCheck(OverlapCheck);
 
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;

--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -55,7 +55,7 @@ void Tracking_Reco()
   Fun4AllServer *se = Fun4AllServer::instance();
 
   PHG4TrackFastSim *kalman = new PHG4TrackFastSim("PHG4TrackFastSim");
-  //  kalman->Verbosity();
+  kalman->Verbosity(verbosity);
   //  kalman->Smearing(false);
   if (G4TRACKING::DISPLACED_VERTEX)
   {
@@ -83,40 +83,43 @@ void Tracking_Reco()
   //-------------------------
   if (Enable::BARREL)
   {
-    double pitch=20e-4/sqrt(12);
-    
-    if (G4BARREL::SETTING::BARRELV5 ||G4BARREL::SETTING::BARRELV6) {
-      int nLayer1 = 3;   //barrel 1                                                                                                      
-      int nLayer2 = 2;   //barrel 2                                                                                                      
-      if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC                                                                
-      int nLayer[2]={nLayer1,nLayer2};
-      
-      for (int n=0;n<2;n++) {
-	if (n==1)  pitch=36.4e-4/sqrt(12);
-	for (int i;i<nLayer[n];i++) {
-	  kalman->add_phg4hits(Form("G4HIT_BARREL%d_%d",n,i),  // const std::string& phg4hitsNames,
-			       PHG4TrackFastSim::Cylinder,     // const DETECTOR_TYPE phg4dettype,
-			       5e-4,                           // const float radres,   *ignored in cylindrical detector*
-			       pitch,                          // const float phires,
-			       pitch,                          // const float lonres,
-			       0.95,                           // const float eff,
-			       0);                             // const float noise 
-	}
+    double pitch = 20e-4 / sqrt(12);
+
+    if (G4BARREL::SETTING::BARRELV5 || G4BARREL::SETTING::BARRELV6)
+    {
+      int nLayer1 = 3;                               //barrel 1
+      int nLayer2 = 2;                               //barrel 2
+      if (G4BARREL::SETTING::BARRELV6) nLayer2 = 1;  //compactible w/ TPC
+      int nLayer[2] = {nLayer1, nLayer2};
+
+      for (int n = 0; n < 2; n++)
+      {
+        if (n == 1) pitch = 36.4e-4 / sqrt(12);
+        for (int i; i < nLayer[n]; i++)
+        {
+          kalman->add_phg4hits(Form("G4HIT_BARREL%d_%d", n, i),  // const std::string& phg4hitsNames,
+                               PHG4TrackFastSim::Cylinder,       // const DETECTOR_TYPE phg4dettype,
+                               5e-4,                             // const float radres,   *ignored in cylindrical detector*
+                               pitch,                            // const float phires,
+                               pitch,                            // const float lonres,
+                               0.95,                             // const float eff,
+                               0);                               // const float noise
+        }
       }
     }
-    else 
+    else
     {
-      int nLayer=5;
-      if (G4BARREL::SETTING::BARRELV4) nLayer=6;
-      for (int i;i<nLayer;i++) 
+      int nLayer = 5;
+      if (G4BARREL::SETTING::BARRELV4) nLayer = 6;
+      for (int i; i < nLayer; i++)
       {
-	kalman->add_phg4hits(Form("G4HIT_BARREL_%d",i),      // const std::string& phg4hitsNames,                                             
-			     PHG4TrackFastSim::Cylinder,     // const DETECTOR_TYPE phg4dettype,                                              
-			     5e-4,                           // const float radres,   *ignored in cylindrical detector*                       
-			     pitch,                          // const float phires,                                                           
-			     pitch,                          // const float lonres,                                                           
-			     0.95,                           // const float eff,                                                              
-			     0);                             // const float noise                                                             
+        kalman->add_phg4hits(Form("G4HIT_BARREL_%d", i),  // const std::string& phg4hitsNames,
+                             PHG4TrackFastSim::Cylinder,  // const DETECTOR_TYPE phg4dettype,
+                             5e-4,                        // const float radres,   *ignored in cylindrical detector*
+                             pitch,                       // const float phires,
+                             pitch,                       // const float lonres,
+                             0.95,                        // const float eff,
+                             0);                          // const float noise
       }
     }
   }
@@ -176,9 +179,12 @@ void Tracking_Reco()
   if (Enable::FGEM || Enable::FGEM_ORIG)
   {
     int first_gem(0);
-    if (Enable::FGEM_ORIG){
+    if (Enable::FGEM_ORIG)
+    {
       first_gem = 0;
-    }else{
+    }
+    else
+    {
       first_gem = 2;
     }
     // GEM2, 70um azimuthal resolution, 1cm radial strips
@@ -198,19 +204,19 @@ void Tracking_Reco()
   //-------------------------
   if (Enable::FST)
   {
-    float pitch=20e-4;
-    int nPlane=5;
-    if (G4FST::SETTING::FSTV4 || G4FST::SETTING::FSTV5) 
+    float pitch = 20e-4;
+    int nPlane = 5;
+    if (G4FST::SETTING::FSTV4 || G4FST::SETTING::FSTV5)
     {
-      nPlane=6;
+      nPlane = 6;
     }
 
     for (int i = 0; i < nPlane; i++)
     {
-      if (i>=3) pitch=36.4e-4;
+      if (i >= 3) pitch = 36.4e-4;
       kalman->add_phg4hits(Form("G4HIT_FST_%d", i),           //      const std::string& phg4hitsNames,
                            PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
-			   pitch,                             //      const float radres,
+                           pitch,                             //      const float radres,
                            pitch,                             //      const float phires,
                            50e-4 / sqrt(12.),                 //      const float lonres, *ignored in plane detector*
                            1,                                 //      const float eff,
@@ -252,7 +258,6 @@ void Tracking_Reco()
   return;
 }
 
-
 //-----------------------------------------------------------------------------//
 
 void Tracking_Eval(const std::string &outputfile)
@@ -268,10 +273,10 @@ void Tracking_Eval(const std::string &outputfile)
   // Fast Tracking evaluation
   //----------------
 
-
   PHG4TrackFastSimEval *fast_sim_eval = new PHG4TrackFastSimEval("FastTrackingEval");
   fast_sim_eval->set_trackmapname(TRACKING::TrackNodeName);
   fast_sim_eval->set_filename(outputfile);
+  fast_sim_eval->Verbosity(verbosity);
   se->registerSubsystem(fast_sim_eval);
 }
 #endif


### PR DESCRIPTION
Few minor clean ups on tracking and FST macros

- allow overlap checks for FST via flags
- propagate verbosity to fast tracking module
- clang-format