### PR TITLE
Apply EIC beam parameter by default to EICSmear event generator inputs

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -182,7 +182,7 @@ namespace INPUTHEPMC
 namespace INPUTREADEIC
 {
   string filename;
-}
+}  // namespace INPUTREADEIC
 
 namespace INPUTREADHITS
 {
@@ -230,6 +230,7 @@ namespace INPUTGENERATOR
   PHPythia8 *Pythia8 = nullptr;
   PHSartre *Sartre = nullptr;
   PHSartreParticleTrigger *SartreTrigger = nullptr;
+  ReadEICFiles *EICFileReader = nullptr;
 }  // namespace INPUTGENERATOR
 
 namespace INPUTMANAGER
@@ -462,9 +463,10 @@ void InputRegister()
   }
   if (Input::READEIC)
   {
-    ReadEICFiles *eicr = new ReadEICFiles();
-    eicr->OpenInputFile(INPUTREADEIC::filename);
-    se->registerSubsystem(eicr);
+    INPUTGENERATOR::EICFileReader = new ReadEICFiles();
+    INPUTGENERATOR::EICFileReader->OpenInputFile(INPUTREADEIC::filename);
+    INPUTGENERATOR::EICFileReader->Verbosity(Input::VERBOSITY);
+    se->registerSubsystem(INPUTGENERATOR::EICFileReader);
   }
   // here are the various utility modules which read particles and
   // put them onto the G4 particle stack

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -183,12 +183,6 @@ int Fun4All_G4_EICDetector(
     //! apply EIC beam parameter following EIC CDR
     Input::ApplyEICBeamParameter(INPUTGENERATOR::Sartre);
   }
-  // EIC smear files
-  if (Input::READEIC)
-  {
-    //! apply EIC beam parameter following EIC CDR
-    Input::ApplyEICBeamParameter(INPUTGENERATOR::EICFileReader);
-  }
 
   //--------------
   // Set Input Manager specific options
@@ -213,6 +207,13 @@ int Fun4All_G4_EICDetector(
 
   // register all input generators with Fun4All
   InputRegister();
+
+  // Reads event generators in EIC smear files, which is registered in InputRegister
+  if (Input::READEIC)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::EICFileReader);
+  }
 
   // set up production relatedstuff
   //   Enable::PRODUCTION = true;

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -183,6 +183,12 @@ int Fun4All_G4_EICDetector(
     //! apply EIC beam parameter following EIC CDR
     Input::ApplyEICBeamParameter(INPUTGENERATOR::Sartre);
   }
+  // EIC smear files
+  if (Input::READEIC)
+  {
+    //! apply EIC beam parameter following EIC CDR
+    Input::ApplyEICBeamParameter(INPUTGENERATOR::EICFileReader);
+  }
 
   //--------------
   // Set Input Manager specific options


### PR DESCRIPTION
By default applying the EIC beam parameters, such as the beam crossing angle, to the EICSmear event generator intputs. 

Thanks to Wenqing Fan at LBNL for pointing out this feature is missing for the EIC smear generator event, although applied to other event generator input interfaces as in https://github.com/sPHENIX-Collaboration/macros/pull/381 

A test case is https://github.com/blackcathj/macros/pull/new/beam-xing-detector-eicsmear 