### PR TITLE
Moved the digitization from the _clustering to _cells.

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -129,15 +129,9 @@ void Intt_Cells()
   //reco->set_double_param("tmin",-20.0);
   reco->Verbosity(verbosity);
   se->registerSubsystem(reco);
-  return;
-}
 
-void Intt_Clustering()
-{
-  int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
-  Fun4AllServer* se = Fun4AllServer::instance();
-  // Intt
-  //=====
+  // Intt digitization
+  //===========
   // these should be used for the Intt
   /*
 	How threshold are calculated based on default FPHX settings
@@ -177,6 +171,15 @@ void Intt_Clustering()
     digiintt->set_adc_scale(G4MVTX::n_maps_layer + i, userrange);
   }
   se->registerSubsystem(digiintt);
+
+  return;
+}
+
+void Intt_Clustering()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
+  Fun4AllServer* se = Fun4AllServer::instance();
+
   InttClusterizer* inttclusterizer = new InttClusterizer("InttClusterizer", G4MVTX::n_maps_layer, G4MVTX::n_maps_layer + G4INTT::n_intt_layer - 1);
   inttclusterizer->Verbosity(verbosity);
   // no Z clustering for Intt type 1 layers (we DO want Z clustering for type 0 layers)

--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -170,12 +170,13 @@ void Micromegas_Cells()
   }
 
   se->registerSubsystem(reco);
+
+  se->registerSubsystem(new PHG4MicromegasDigitizer);
 }
 
 void Micromegas_Clustering()
 {
   auto se = Fun4AllServer::instance();
-  se->registerSubsystem(new PHG4MicromegasDigitizer);
   se->registerSubsystem(new MicromegasClusterizer);
 }
 #endif

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -223,6 +223,13 @@ void Mvtx_Cells()
     maps_hits->set_timing_window(ilayer, -5000, 5000);
   }
   se->registerSubsystem(maps_hits);
+
+  PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();
+  digimvtx->Verbosity(verbosity);
+  // energy deposit in 25 microns = 9.6 KeV = 1000 electrons collected after recombination
+  //digimvtx->set_adc_scale(0.95e-6);  // default set in code is 0.95e-06, which is 99 electrons
+  se->registerSubsystem(digimvtx);
+
   return;
 }
 
@@ -230,11 +237,7 @@ void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-  PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();
-  digimvtx->Verbosity(verbosity);
-  // energy deposit in 25 microns = 9.6 KeV = 1000 electrons collected after recombination
-  //digimvtx->set_adc_scale(0.95e-6);  // default set in code is 0.95e-06, which is 99 electrons
-  se->registerSubsystem(digimvtx);
+
   // For the Mvtx layers
   //================
   MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -192,16 +192,9 @@ void TPC_Cells()
   padplane->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);  // sPHENIX layer number of first Tpc readout layer
   padplane->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
   padplane->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);
-}
 
-void TPC_Clustering()
-{
-  int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
-
-  Fun4AllServer* se = Fun4AllServer::instance();
-
-  // Tpc
-  //====
+  // Tpc digitizer
+  //=========
   PHG4TpcDigitizer* digitpc = new PHG4TpcDigitizer();
   digitpc->SetTpcMinLayer(G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   double ENC = 670.0;  // standard
@@ -213,6 +206,14 @@ void TPC_Clustering()
        << " maps+Intt layers set to " << G4MVTX::n_maps_layer + G4INTT::n_intt_layer << endl;
 
   se->registerSubsystem(digitpc);
+
+}
+
+void TPC_Clustering()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
+
+  Fun4AllServer* se = Fun4AllServer::instance();
 
   //-------------
   // Cluster Hits


### PR DESCRIPTION
This PR moves the digitization so that it is enabled by the <subsystem>_cells flag, not the <subsystem>_clustering flag. Now the _cells flag causes both hit reconstruction and hit digitization to be run. The _clustering flag now causes only clustering (and cluster cleaning, in the case of the TPC) to be run.