### PR TITLE
make digitisation configurable via G4* namespace

### DIFF
--- a/common/G4_CEmc_EIC.C
+++ b/common/G4_CEmc_EIC.C
@@ -60,6 +60,15 @@ namespace G4CEMC
   // if the user changes these, the z position of the
   // calorimeter must be changed in the function CEmc(...)
 
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
   enum enu_Cemc_clusterizer
   {
     kCemcGraphClusterizer,
@@ -67,12 +76,16 @@ namespace G4CEMC
     kCemcTemplateClusterizer
   };
 
-  //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha
-  //! Bazilevsky
+  // default: template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
   enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
-  //! graph clusterizer, RawClusterBuilderGraph
+  // graph clusterizer, RawClusterBuilderGraph
   // enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
 }  // namespace G4CEMC
+
+namespace CEMC_TOWER
+{
+  double emin = NAN;
+}
 
 // Black hole and size parameters set in CEmc function
 void CEmcInit(const int nslats = 1)
@@ -245,6 +258,10 @@ void CEMC_Towers()
   RawTowerBuilder *CemcTowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
   CemcTowerBuilder->Detector("CEMC");
   CemcTowerBuilder->set_sim_tower_node_prefix("SIM");
+  if (isfinite(CEMC_TOWER::emin))
+  {
+    CemcTowerBuilder->EminCut(CEMC_TOWER::emin);
+  }
   CemcTowerBuilder->Verbosity(verbosity);
   se->registerSubsystem(CemcTowerBuilder);
 
@@ -254,7 +271,7 @@ void CEMC_Towers()
   RawTowerDigitizer *CemcTowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
   CemcTowerDigitizer->Detector("CEMC");
   CemcTowerDigitizer->Verbosity(verbosity);
-  CemcTowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
+  CemcTowerDigitizer->set_digi_algorithm(G4CEMC::TowerDigi);
   CemcTowerDigitizer->set_pedstal_central_ADC(0);
   CemcTowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting
   CemcTowerDigitizer->set_photonelec_ADC(1);     // not simulating ADC discretization error

--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -56,6 +56,15 @@ namespace G4CEMC
   int Min_cemc_layer = 1;
   int Max_cemc_layer = 1;
 
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
   // set a default value for SPACAL configuration
   //  // 1D azimuthal projective SPACAL (fast)
   //int Cemc_spacal_configuration = PHG4CylinderGeom_Spacalv1::k1DProjectiveSpacal;
@@ -351,7 +360,7 @@ void CEMC_Towers()
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("EmcRawTowerDigitizer");
   TowerDigitizer->Detector("CEMC");
   TowerDigitizer->Verbosity(verbosity);
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
+  TowerDigitizer->set_digi_algorithm(G4CEMC::TowerDigi);
   TowerDigitizer->set_variable_pedestal(true);  //read ped central and width from calibrations file comment next 2 lines if true
                                                 //  TowerDigitizer->set_pedstal_central_ADC(0);
                                                 //  TowerDigitizer->set_pedstal_width_ADC(8);  // eRD1 test beam setting

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -40,6 +40,15 @@ namespace G4EEMC
   int use_projective_geometry = 0;
   double Gdz = 18. + 0.0001;
   double Gz0 = -170.;
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
   enum enu_Eemc_clusterizer
   {
     kEemcGraphClusterizer,
@@ -140,7 +149,7 @@ void EEMC_Towers()
   TowerDigitizer_EEMC->Detector("EEMC");
   TowerDigitizer_EEMC->Verbosity(verbosity);
   TowerDigitizer_EEMC->set_raw_tower_node_prefix("RAW");
-  TowerDigitizer_EEMC->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitization);
+  TowerDigitizer_EEMC->set_digi_algorithm(G4EEMC::TowerDigi);
   TowerDigitizer_EEMC->set_pedstal_central_ADC(0);
   TowerDigitizer_EEMC->set_pedstal_width_ADC(8);  // eRD1 test beam setting
   TowerDigitizer_EEMC->set_photonelec_ADC(1);     //not simulating ADC discretization error

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -57,6 +57,15 @@ namespace G4HCALIN
 
   int inner_hcal_eic = 0;
 
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
   enum enu_HCalIn_clusterizer
   {
     kHCalInGraphClusterizer,
@@ -237,7 +246,7 @@ void HCALInner_Towers()
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
   TowerDigitizer->Detector("HCALIN");
   //  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
+  TowerDigitizer->set_digi_algorithm(G4HCALIN::TowerDigi);
   TowerDigitizer->set_pedstal_central_ADC(0);
   TowerDigitizer->set_pedstal_width_ADC(1);  // From Jin's guess. No EMCal High Gain data yet! TODO: update
   TowerDigitizer->set_photonelec_ADC(32. / 5.);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -44,6 +44,16 @@ namespace G4HCALOUT
 {
   double outer_radius = 264.71;
   double size_z = 304.91 * 2;
+
+  // Digitization (default photon digi):
+  RawTowerDigitizer::enu_digi_algorithm TowerDigi = RawTowerDigitizer::kSimple_photon_digitization;
+  // directly pass the energy of sim tower to digitized tower
+  // kNo_digitization
+  // simple digitization with photon statistics, single amplitude ADC conversion and pedestal
+  // kSimple_photon_digitization
+  // digitization with photon statistics on SiPM with an effective pixel N, ADC conversion and pedestal
+  // kSiPM_photon_digitization
+
   enum enu_HCalOut_clusterizer
   {
     kHCalOutGraphClusterizer,
@@ -164,7 +174,7 @@ void HCALOuter_Towers()
   RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
   TowerDigitizer->Detector("HCALOUT");
   //  TowerDigitizer->set_raw_tower_node_prefix("RAW_LG");
-  TowerDigitizer->set_digi_algorithm(RawTowerDigitizer::kSimple_photon_digitalization);
+  TowerDigitizer->set_digi_algorithm(G4HCALOUT::TowerDigi);
   TowerDigitizer->set_pedstal_central_ADC(0);
   TowerDigitizer->set_pedstal_width_ADC(1);  // From Jin's guess. No EMCal High Gain data yet! TODO: update
   TowerDigitizer->set_photonelec_ADC(16. / 5.);


### PR DESCRIPTION
This PR makes the digitizer configurable via the G4* namespace. The default is what was previously hardcoded (RawTowerDigitizer::kSimple_photon_digitization). Previously the cemc with its many channels adds close to 30GeV which are also picked up by the clusterizer. This makes single particle sims very impractical when just looking at grand totals