### PR TITLE
use sampling fraction for tower calibration if kNo_digitization is chosen

### DIFF
--- a/common/G4_CEmc_EIC.C
+++ b/common/G4_CEmc_EIC.C
@@ -283,7 +283,14 @@ void CEMC_Towers()
   CemcTowerCalibration->Detector("CEMC");
   CemcTowerCalibration->Verbosity(verbosity);
   CemcTowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);
+  if (G4CEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    CemcTowerCalibration->set_calib_const_GeV_ADC(1.0 / 0.023);  // 2.3% sampling fraction from test beam
+  }
+  else
+  {
+    CemcTowerCalibration->set_calib_const_GeV_ADC(1. / photoelectron_per_GeV / 0.9715);
+  }
   CemcTowerCalibration->set_pedstal_ADC(0);
 
   se->registerSubsystem(CemcTowerCalibration);

--- a/common/G4_EEMC.C
+++ b/common/G4_EEMC.C
@@ -164,7 +164,14 @@ void EEMC_Towers()
   TowerCalibration_EEMC->Detector("EEMC");
   TowerCalibration_EEMC->Verbosity(verbosity);
   TowerCalibration_EEMC->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration_EEMC->set_calib_const_GeV_ADC(1. / EEMC_photoelectron_per_GeV);
+  if (G4EEMC::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    TowerCalibration_EEMC->set_calib_const_GeV_ADC(1.);
+  }
+  else
+  {
+    TowerCalibration_EEMC->set_calib_const_GeV_ADC(1. / EEMC_photoelectron_per_GeV);
+  }
   TowerCalibration_EEMC->set_pedstal_ADC(0);
 
   se->registerSubsystem(TowerCalibration_EEMC);

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -264,7 +264,14 @@ void HCALInner_Towers()
   //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
   //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
+  if (G4HCALIN::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(1. / visible_sample_fraction_HCALIN);
+  }
+  else
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(0.4e-3 / visible_sample_fraction_HCALIN);
+  }
   TowerCalibration->set_pedstal_ADC(0);
   se->registerSubsystem(TowerCalibration);
 

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -189,7 +189,14 @@ void HCALOuter_Towers()
   //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
   //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);
-  TowerCalibration->set_calib_const_GeV_ADC(0.2e-3 / visible_sample_fraction_HCALOUT);
+  if (G4HCALIN::TowerDigi == RawTowerDigitizer::kNo_digitization)
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(1. / visible_sample_fraction_HCALOUT);
+  }
+  else
+  {
+    TowerCalibration->set_calib_const_GeV_ADC(0.2e-3 / visible_sample_fraction_HCALOUT);
+  }
   TowerCalibration->set_pedstal_ADC(0);
   se->registerSubsystem(TowerCalibration);
 


### PR DESCRIPTION
Previously towers did not make it into clusters when RawTowerDigitizer::kNo_digitization was chosen for the tower reconstruction. The reason was that the tower calibration was adjusted for the default digitization. This PR now uses the sampling fraction for set_calib_const_GeV_ADC in case no digitization is chosen. The default settings are not affected.