### PR TITLE
Micromegas qa

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -14,6 +14,7 @@
 #include <g4main/PHG4Reco.h>
 
 #include <micromegas/MicromegasClusterizer.h>
+#include <qa_modules/QAG4SimulationMicromegas.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -25,6 +26,7 @@ namespace Enable
   bool MICROMEGAS = false;
   bool MICROMEGAS_CELL = false;
   bool MICROMEGAS_CLUSTER = false;
+  bool MICROMEGAS_QA = false;
 }  // namespace Enable
 
 namespace G4MICROMEGAS
@@ -178,4 +180,13 @@ void Micromegas_Clustering()
   se->registerSubsystem(new PHG4MicromegasDigitizer);
   se->registerSubsystem(new MicromegasClusterizer);
 }
+
+void Micromegas_QA()
+{
+  auto se = Fun4AllServer::instance();
+  auto qa = new QAG4SimulationMicromegas;
+  qa->Verbosity(Enable::QA_VERBOSITY);
+  se->registerSubsystem(qa);
+}
+
 #endif

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -257,6 +257,7 @@ int Fun4All_G4_sPHENIX(
   Enable::MICROMEGAS = true;
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
   Enable::MICROMEGAS_CLUSTER = Enable::MICROMEGAS_CELL && true;
+  Enable::MICROMEGAS_QA = Enable::MICROMEGAS_CLUSTER && Enable::QA && true;
 
   Enable::TRACKING_TRACK = true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && false;
@@ -506,6 +507,7 @@ int Fun4All_G4_sPHENIX(
   if (Enable::MVTX_QA) Mvtx_QA();
   if (Enable::INTT_QA) Intt_QA();
   if (Enable::TPC_QA) TPC_QA();
+  if (Enable::MICROMEGAS_QA) Micromegas_QA();
   if (Enable::TRACKING_QA) Tracking_QA();
 
   if (Enable::TRACKING_QA and Enable::CEMC_QA and Enable::HCALIN_QA and Enable::HCALOUT_QA) QA_G4CaloTracking();

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -254,7 +254,7 @@ int Fun4All_G4_sPHENIX(
   Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
   Enable::TPC_QA = Enable::TPC_CLUSTER and Enable::QA && true;
 
-  //Enable::MICROMEGAS = true;
+  Enable::MICROMEGAS = true;
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
   Enable::MICROMEGAS_CLUSTER = Enable::MICROMEGAS_CELL && true;
 


### PR DESCRIPTION
This PR enables the Micromegas by default in th QA low occupancy branch. This way one should be able to see the Micromegas Layers in the Tracking QA, and monitor changes to the Micromegas chain in Jenkins. 
It also adds a Micromegas-specific QA module, to run together with the other existing QA modules
Modifications to Jenkins/Jupiter plots will be the subject of a different PR
This change must also be ported to QA-tracking-high-occupancy