### PR TITLE
Remove FEMC from sPHENIX setup

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -312,13 +312,6 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
   Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER and Enable::QA && true;
 
-  // forward EMC
-  //Enable::FEMC = true;
-  Enable::FEMC_ABSORBER = true;
-  Enable::FEMC_TOWER = Enable::FEMC && true;
-  Enable::FEMC_CLUSTER = Enable::FEMC_TOWER && true;
-  Enable::FEMC_EVAL = Enable::FEMC_CLUSTER and Enable::QA && true;
-
   Enable::EPD = false;
 
   //! forward flux return plug door. Out of acceptance and off by default.
@@ -426,9 +419,6 @@ int Fun4All_G4_sPHENIX(
   // if enabled, do topoClustering early, upstream of any possible jet reconstruction
   if (Enable::TOPOCLUSTER) TopoClusterReco();
 
-  if (Enable::FEMC_TOWER) FEMC_Towers();
-  if (Enable::FEMC_CLUSTER) FEMC_Clusters();
-
   //--------------
   // SVTX tracking
   //--------------
@@ -499,8 +489,6 @@ int Fun4All_G4_sPHENIX(
   if (Enable::HCALIN_EVAL) HCALInner_Eval(outputroot + "_g4hcalin_eval.root");
 
   if (Enable::HCALOUT_EVAL) HCALOuter_Eval(outputroot + "_g4hcalout_eval.root");
-
-  if (Enable::FEMC_EVAL) FEMC_Eval(outputroot + "_g4femc_eval.root");
 
   if (Enable::JETS_EVAL) Jet_Eval(outputroot + "_g4jet_eval.root");
 

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -8,7 +8,6 @@
 #include <G4_CEmc_Albedo.C>
 #include <G4_CEmc_Spacal.C>
 #include <G4_EPD.C>
-#include <G4_FEMC.C>
 #include <G4_HcalIn_ref.C>
 #include <G4_HcalOut_ref.C>
 #include <G4_Intt.C>
@@ -62,7 +61,6 @@ void G4Init()
   MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
   if (Enable::HCALOUT) HCalOuterInit();
   if (Enable::PLUGDOOR) PlugDoorInit();
-  if (Enable::FEMC) FEMCInit();
   if (Enable::EPD) EPDInit();
   if (Enable::USER) UserInit();
   if (Enable::BLACKHOLE) BlackHoleInit();
@@ -121,7 +119,6 @@ int G4Setup()
   if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
   if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
   if (Enable::PLUGDOOR) PlugDoor(g4Reco);
-  if (Enable::FEMC) FEMCSetup(g4Reco);
   if (Enable::EPD) EPD(g4Reco);
   if (Enable::USER) UserDetector(g4Reco);
 
@@ -174,12 +171,6 @@ void ShowerCompress(int verbosity = 0)
   compress->AddTowerContainer("TOWER_SIM_HCALOUT");
   compress->AddTowerContainer("TOWER_RAW_HCALOUT");
   compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
-  compress->AddHitContainer("G4HIT_FEMC");
-  compress->AddHitContainer("G4HIT_ABSORBER_FEMC");
-  compress->AddCellContainer("G4CELL_FEMC");
-  compress->AddTowerContainer("TOWER_SIM_FEMC");
-  compress->AddTowerContainer("TOWER_RAW_FEMC");
-  compress->AddTowerContainer("TOWER_CALIB_FEMC");
   se->registerSubsystem(compress);
 
   return;
@@ -208,9 +199,6 @@ void DstCompress(Fun4AllDstOutputManager *out)
     out->StripNode("G4CELL_CEMC");
     out->StripNode("G4CELL_HCALIN");
     out->StripNode("G4CELL_HCALOUT");
-    out->StripNode("G4HIT_FEMC");
-    out->StripNode("G4HIT_ABSORBER_FEMC");
-    out->StripNode("G4CELL_FEMC");
   }
 }
 #endif


### PR DESCRIPTION
This is a follow up to https://github.com/sPHENIX-Collaboration/macros/pull/402 in separation of the EIC specific parts from the sPHENIX software repository and moving them to the EIC repositories. This pull request remove the link of sPHENIX macros to the FEMC modules, which will be located in the EIC repository ( https://github.com/eic/fun4all_eicdetectors/pull/2 )

Full list of relocation pull requests: 

- https://github.com/sPHENIX-Collaboration/calibrations/pull/77
- https://github.com/eic/fun4all_eiccalibration/pull/1

- https://github.com/sPHENIX-Collaboration/coresoftware/pull/1138
- https://github.com/eic/fun4all_eicdetectors/pull/2

- https://github.com/sPHENIX-Collaboration/macros/pull/402
- https://github.com/eic/fun4all_eicmacros/pull/31