### PR TITLE
fix vertex eval

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -87,7 +87,7 @@ namespace G4TRACKING
   bool use_genfit = false;                 // if false, acts KF is run on proto tracks. If true, use Genfit track propagation and fitting
 
   // Initial vertexing
-  bool g4eval_use_initial_vertex = false;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
+  bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
   bool use_truth_init_vertexing = false;    // if true runs truth vertexing, if false runs acts initial vertex finder
 
   // TPC seeding options


### PR DESCRIPTION
Fallout from the tracking reorganization from Tony - if this switch is false, the SvtxVertexEvaluator defaults to the wrong vertex map name and thus there is no vertex evaluation. Only affects the vertex evaluation, so this PR just flips the switch to true by default.