### PR TITLE
start differentiating between calorimeter absorber and support structures

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -41,6 +41,7 @@ namespace Enable
   bool HCALIN_CLUSTER = false;
   bool HCALIN_EVAL = false;
   bool HCALIN_QA = false;
+  bool HCALIN_SUPPORT = false;
   int HCALIN_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -174,7 +175,7 @@ double HCalInner(PHG4Reco *g4Reco,
 //! A rough version of the inner HCal support ring, from Richie's CAD drawing. - Jin
 void HCalInner_SupportRing(PHG4Reco *g4Reco)
 {
-  bool AbsorberActive = Enable::ABSORBER || Enable::HCALIN_ABSORBER;
+  bool AbsorberActive = Enable::SUPPORT || Enable::HCALIN_SUPPORT;
 
   const double z_ring1 = (2025 + 2050) / 2. / 10.;
   const double innerradius_sphenix = 116.;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -27,10 +27,11 @@ namespace DstOut
 // Global settings affecting multiple subsystems
 namespace Enable
 {
-  bool OVERLAPCHECK = false;
   bool ABSORBER = false;
   bool DSTOUT = false;
   bool DSTOUT_COMPRESS = false;
+  bool OVERLAPCHECK = false;
+  bool SUPPORT = false;
   int VERBOSITY = 0;
 }  // namespace Enable
 


### PR DESCRIPTION
This PR starts the proper handling of support structures. So far absorbers which came from the calorimeters have been used to also characterize support structures. This PR adds a global bool SUPPORT and the first implementation in the inner hcal