### PR TITLE
remove acts evaluator header

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -29,7 +29,6 @@
 #include <trackreco/PHTruthVertexing.h>
 
 #if __cplusplus >= 201703L
-#include <trackreco/ActsEvaluator.h>
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSourceLinks.h>
 #include <trackreco/PHActsSiliconSeeding.h>


### PR DESCRIPTION
Remove this header as it is not used by default anymore (and is being removed from the trackreco Makefile)