### PR TITLE
remove other headers

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -30,9 +30,7 @@
 
 #if __cplusplus >= 201703L
 #include <trackreco/MakeActsGeometry.h>
-#include <trackreco/PHActsSourceLinks.h>
 #include <trackreco/PHActsSiliconSeeding.h>
-#include <trackreco/PHActsTracks.h>
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHActsVertexFinder.h>


### PR DESCRIPTION
Remove other headers that is needed for the cleanup PR. Apparently my local tests are getting confused by the build libraries (which still contain these header files) and my local compiled libraries (which don't).

