### PR TITLE
Fix tracking macro to match moving PHTpcResiduals to tpccalib

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -34,7 +34,7 @@
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHActsVertexFinder.h>
-#include <trackreco/PHTpcResiduals.h>
+#include <tpccalib/PHTpcResiduals.h>
 #endif
 
 #include <trackbase/TrkrHitTruthAssoc.h>
@@ -47,6 +47,7 @@
 
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
+R__LOAD_LIBRARY(libtpccalib.so)
 R__LOAD_LIBRARY(libPHTpcTracker.so)
 R__LOAD_LIBRARY(libqa_modules.so)
 


### PR DESCRIPTION
- load libtpccalib.so
- set proper path to include PHTpcResidulals (it is now in tpccalib)
This change is necessary for https://github.com/sPHENIX-Collaboration/coresoftware/pull/1193 to succeed.
Problem is: it will crash any other build untill the previous PR is merged. @pinkenburg @blackcathj: not sure how you usually handle this.