### PR TITLE
Add PHTrackCleaner to normal Acts tracking chain.

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -23,6 +23,7 @@
 #include <trackreco/PHRaveVertexing.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
 #include <trackreco/PHTpcTrackSeedVertexAssoc.h>
+#include <trackreco/PHTrackCleaner.h>
 #include <trackreco/PHTrackSeeding.h>
 #include <trackreco/PHTruthSiliconAssociation.h>
 #include <trackreco/PHTruthTrackSeeding.h>
@@ -421,6 +422,10 @@ void Tracking_Reco()
 	  se->registerSubsystem(residuals);
 	}
       
+      // Choose the best silicon matched track for each TPC track seed
+      PHTrackCleaner *cleaner= new PHTrackCleaner();
+      cleaner->Verbosity(verbosity);
+      se->registerSubsystem(cleaner);
       
       PHActsVertexFinder *finder = new PHActsVertexFinder();
       finder->Verbosity(verbosity);


### PR DESCRIPTION
This PR make PHTrackCleaner a normal part of the Acts tracking chain. It is run after the first Acts track fit. It finds the best match for each TPC track seed to the silicon track stubs, and deletes all other tracks corresponding to that track stub. 