### PR TITLE
implement selection of 3d fieldmap

### DIFF
--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -88,7 +88,7 @@ int G4Setup()
   if (stringline.fail())
   {  // conversion to double fails -> we have a string
 
-    if (G4MAGNET::magfield.find("sPHENIX.root") != string::npos)
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos)
     {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     }


### PR DESCRIPTION
This implements the choice to read the newest sphenix 3d fieldmap (the previous 3d fieldmap name was just a placeholder). The fieldmap itself is chosen in the Fun4All macro