### PR TITLE
Fix overlap

### DIFF
--- a/common/G4_BeamLine.C
+++ b/common/G4_BeamLine.C
@@ -36,7 +36,7 @@ namespace Enable
 namespace BeamLine
 {
   double starting_z =  G4PIPE::be_pipe_length / 2. + G4PIPE::al_pipe_length + G4PIPE::al_pipe_cone_length + G4PIPE::al_pipe_ext_length;
-  double enclosure_z_max = 2000. + (700-starting_z);
+  double enclosure_z_max = 2050. + (700-starting_z);
   double enclosure_r_max = 30.;  // 30cm radius to cover magnets
   double enclosure_center = 0.5 * (starting_z + enclosure_z_max);
 

--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -31,7 +31,7 @@ namespace G4PIPE
   double al_pipe_cone_length = 8.56;
 
   double al_pipe_ext_radius = 2.5005;
-  double al_pipe_ext_length = 60.0;  // extension beyond conical part
+  double al_pipe_ext_length = 90.0;  // extension beyond conical part
 }  // namespace G4PIPE
 
 void PipeInit()


### PR DESCRIPTION
This PR fixes an overlap of the forward beampipe enclosure with the epd. Now the Al beampipe from sPHENIX is extended through the epd (added 30 cm in length). The forward enclosure is larger to accommodate the magnets