### PR TITLE
Track Fitting Without Vertex

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -670,7 +670,8 @@ void Tracking_Eval(const std::string& outputfile)
   eval->do_cluster_eval(true);
   eval->do_g4hit_eval(true);
   eval->do_hit_eval(true);  // enable to see the hits that includes the chamber physics...
-  eval->do_gpoint_eval(false);
+  eval->do_gpoint_eval(true);
+  eval->do_vtx_eval_light(true);
   eval->do_eval_light(true);
   eval->set_use_initial_vertex(G4TRACKING::g4eval_use_initial_vertex);
   eval->set_use_genfit_vertex(G4TRACKING::use_genfit);


### PR DESCRIPTION
This changes the default track reconstruction chain to be vertex independent. The initial vertex finder and second track fit are removed completely and replaced by Tony's new simple vertex finder and a new module which propagates the track parameters from the position WRT to the beam line to the vertex position.  This PR needs the changes in coresoftware from the corresponding [PR](https://github.com/sPHENIX-Collaboration/coresoftware/pull/1288) to function.