### PR TITLE
Fix epd

### DIFF
--- a/common/G4_EPD.C
+++ b/common/G4_EPD.C
@@ -12,10 +12,17 @@ R__LOAD_LIBRARY(libg4epd.so)
 namespace Enable
 {
   bool EPD = false;
+  bool EPD_SUPPORT = false;
   bool EPD_OVERLAPCHECK = false;
 }  // namespace Enable
 
-void EPDInit() {}
+void EPDInit()
+{
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 90.);
+  // using default z-position and add 10 cm for tile thickness
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -310.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 310.);
+}
 
 void EPD(PHG4Reco* g4Reco)
 {

--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -31,7 +31,7 @@ namespace G4PIPE
   double al_pipe_cone_length = 8.56;
 
   double al_pipe_ext_radius = 2.5005;
-  double al_pipe_ext_length = 90.0;  // extension beyond conical part
+  double al_pipe_ext_length = 89.9;  // extension beyond conical part
 }  // namespace G4PIPE
 
 void PipeInit()


### PR DESCRIPTION
This PR adds the sizes for the surrounding black hole for the EPC (empty so far, worked because it is hidden inside the sPHENIX volume). Yesterdays addition to the al beampipe leads to an overlap of the beampipe with the forward enclosure. Shaved off 1mm which should take care of that (our beampipes need to be checked for continuous vacuum)