### PR TITLE
Swap to Acts track projection module

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -35,6 +35,7 @@
 #include <trackreco/PHActsSiliconSeeding.h>
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsInitialVertexFinder.h>
+#include <trackreco/PHActsTrackProjection.h>
 #include <trackreco/PHSimpleVertexFinder.h>
 
 #include <tpccalib/TpcSpaceChargeReconstruction.h>
@@ -641,7 +642,7 @@ void Tracking_Reco()
      
   // Track Projections
   //===============
-  PHGenFitTrackProjection* projection = new PHGenFitTrackProjection();
+  PHActsTrackProjection *projection = new PHActsTrackProjection();
   projection->Verbosity(verbosity);
   se->registerSubsystem(projection);
   


### PR DESCRIPTION
Swap the genfit track projection module to the Acts track projection module.

Note that this module previously had a bug in it where it would cause crashes on a very rare basis as uncovered by Jenkins. I think this has been fixed, but it is hard to test locally. I'd like to merge this and over the course of the next ~week see if Jenkins finds any issues, local tests with 100k tracks show no crashes.