### PR TITLE
Remove Acts vertexing

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -34,7 +34,6 @@
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSiliconSeeding.h>
 #include <trackreco/PHActsTrkFitter.h>
-#include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHSimpleVertexFinder.h>
 
 #include <tpccalib/TpcSpaceChargeReconstruction.h>


### PR DESCRIPTION
We don't use the vertexing anymore and this module is slow in the `trackreco` compilation, so remove it here so that we can remove it from the `trackreco` makefile.