### PR TITLE
remove obsolete PHActsInitialVertexFinder.h include

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -34,7 +34,6 @@
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSiliconSeeding.h>
 #include <trackreco/PHActsTrkFitter.h>
-#include <trackreco/PHActsInitialVertexFinder.h>
 #include <trackreco/PHSimpleVertexFinder.h>
 
 #include <tpccalib/TpcSpaceChargeReconstruction.h>


### PR DESCRIPTION
That PR removes an unused include. The include itself is removed in the next PRs which then crashes jenkins