### PR TITLE
Remove second track fit which is obsolete

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -501,11 +501,6 @@ void Tracking_Reco()
       finder->Verbosity(verbosity);
       se->registerSubsystem(finder);
       
-      PHActsTrkFitter* actsFit2 = new PHActsTrkFitter("PHActsSecondTrKFitter");
-      actsFit2->Verbosity(verbosity);
-      actsFit2->doTimeAnalysis(false);
-      actsFit2->fitSiliconMMs(false);
-      se->registerSubsystem(actsFit2);
     }
   
   //=========================================================    


### PR DESCRIPTION
Remove the second track fit from the truth track seeding chain, since it is now obsolete.