### PR TITLE
replace back of plugdoor by black hole to speed up showers

### DIFF
--- a/common/G4_PlugDoor.C
+++ b/common/G4_PlugDoor.C
@@ -14,6 +14,7 @@ namespace Enable
   bool PLUGDOOR = false;
   bool PLUGDOOR_ABSORBER = false;
   bool PLUGDOOR_OVERLAPCHECK = false;
+  bool PLUGDOOR_BLACKHOLE = false;
 }  // namespace Enable
 
 namespace G4PLUGDOOR
@@ -27,6 +28,7 @@ namespace G4PLUGDOOR
 
   double length = z_2 - z_1;
   double place_z = (z_1 + z_2) / 2.;
+  double thickness = 2.;  // 2 cm thick
 }  // namespace G4PLUGDOOR
 
 void PlugDoorInit()
@@ -34,35 +36,124 @@ void PlugDoorInit()
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4PLUGDOOR::r_2);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4PLUGDOOR::place_z + G4PLUGDOOR::length / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -(G4PLUGDOOR::place_z + G4PLUGDOOR::length / 2.));
+  if (Enable::PLUGDOOR_BLACKHOLE)
+  {
+    if (G4PLUGDOOR::thickness >= G4PLUGDOOR::z_2 - G4PLUGDOOR::z_1)
+    {
+      cout << "G4_PlugDoor::PlugDoorInit(): thickness " << G4PLUGDOOR::thickness
+           << " exceeds door thickness " << G4PLUGDOOR::z_2 - G4PLUGDOOR::z_1
+           << endl;
+      gSystem->Exit(1);
+    }
+  }
 }
 void PlugDoor(PHG4Reco *g4Reco)
 {
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PLUGDOOR_OVERLAPCHECK;
-  const bool flux_door_active = Enable::ABSORBER || Enable::PLUGDOOR_ABSORBER;
+  bool flux_door_active = Enable::ABSORBER || Enable::PLUGDOOR_ABSORBER;
 
   const string material("Steel_1006");
 
-  PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 0);
-  flux_return_plus->set_double_param("length", G4PLUGDOOR::length);
-  flux_return_plus->set_double_param("radius", G4PLUGDOOR::r_1);
-  flux_return_plus->set_double_param("place_z", G4PLUGDOOR::place_z);
-  flux_return_plus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
-  flux_return_plus->set_string_param("material", material);
-  flux_return_plus->SetActive(flux_door_active);
-  //  flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
-  flux_return_plus->OverlapCheck(OverlapCheck);
-  g4Reco->registerSubsystem(flux_return_plus);
+  if (Enable::PLUGDOOR_BLACKHOLE)
+  {
+    double place_z_plate = G4PLUGDOOR::z_1 + G4PLUGDOOR::thickness / 2.;
+    double place_z_cyl = (G4PLUGDOOR::z_1 + G4PLUGDOOR::z_2 + G4PLUGDOOR::thickness) / 2.;
+    PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 0);
+    flux_return_plus->set_double_param("length", G4PLUGDOOR::thickness);
+    flux_return_plus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_plus->set_double_param("place_z", place_z_plate);
+    flux_return_plus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
+    flux_return_plus->set_string_param("material", material);
+    flux_return_plus->SetActive(flux_door_active);
+    flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+    flux_return_plus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_plus);
 
-  PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 0);
-  flux_return_minus->set_double_param("length", G4PLUGDOOR::length);
-  flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1);
-  flux_return_minus->set_double_param("place_z", -G4PLUGDOOR::place_z);
-  flux_return_minus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
-  flux_return_minus->set_string_param("material", material);
-  flux_return_minus->SetActive(flux_door_active);
-  //  flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
-  flux_return_minus->OverlapCheck(OverlapCheck);
-  g4Reco->registerSubsystem(flux_return_minus);
+    flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 1);
+    flux_return_plus->set_double_param("length", G4PLUGDOOR::length - G4PLUGDOOR::thickness);
+    flux_return_plus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_plus->set_double_param("place_z", place_z_cyl);
+    flux_return_plus->set_double_param("thickness", G4PLUGDOOR::thickness);
+    flux_return_plus->set_string_param("material", material);
+    flux_return_plus->SetActive(flux_door_active);
+    flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+    flux_return_plus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_plus);
+
+    // Black hole behind door with thickness G4PLUGDOOR::thickness
+    // same color as door - you will not distinguish it in the display
+    flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 2);
+    flux_return_plus->set_double_param("length", G4PLUGDOOR::length - G4PLUGDOOR::thickness);
+    flux_return_plus->set_double_param("radius", G4PLUGDOOR::r_1 + G4PLUGDOOR::thickness);
+    flux_return_plus->set_double_param("place_z", place_z_cyl);
+    flux_return_plus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1 - G4PLUGDOOR::thickness);
+    flux_return_plus->set_string_param("material", material);
+    flux_return_plus->SetActive(flux_door_active);
+    flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+    flux_return_plus->OverlapCheck(OverlapCheck);
+    flux_return_plus->BlackHole();
+    g4Reco->registerSubsystem(flux_return_plus);
+
+    PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 0);
+    flux_return_minus->set_double_param("length", G4PLUGDOOR::thickness);
+    flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_minus->set_double_param("place_z", -place_z_plate);
+    flux_return_minus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
+    flux_return_minus->set_string_param("material", material);
+    flux_return_minus->SetActive(flux_door_active);
+    flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+    flux_return_minus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_minus);
+
+    flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 1);
+    flux_return_minus->set_double_param("length", G4PLUGDOOR::length - G4PLUGDOOR::thickness);
+    flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_minus->set_double_param("place_z", -place_z_cyl);
+    flux_return_minus->set_double_param("thickness", G4PLUGDOOR::thickness);
+    flux_return_minus->set_string_param("material", material);
+    flux_return_minus->SetActive(flux_door_active);
+    flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+    flux_return_minus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_minus);
+
+    // Black hole behind door with thickness G4PLUGDOOR::thickness
+    // same color as door - you will not distinguish it in the display
+    flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 2);
+    flux_return_minus->set_double_param("length", G4PLUGDOOR::length - G4PLUGDOOR::thickness);
+    flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1 + G4PLUGDOOR::thickness);
+    flux_return_minus->set_double_param("place_z", -place_z_cyl);
+    flux_return_minus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1 - G4PLUGDOOR::thickness);
+    flux_return_minus->set_string_param("material", material);
+    flux_return_minus->SetActive(flux_door_active);
+    flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+    flux_return_minus->OverlapCheck(OverlapCheck);
+    flux_return_minus->BlackHole();
+    g4Reco->registerSubsystem(flux_return_minus);
+  }
+  else
+  {
+    PHG4CylinderSubsystem *flux_return_plus = new PHG4CylinderSubsystem("FLUXRET_ETA_PLUS", 3);
+    flux_return_plus->set_double_param("length", G4PLUGDOOR::length);
+    flux_return_plus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_plus->set_double_param("place_z", G4PLUGDOOR::place_z);
+    flux_return_plus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
+    flux_return_plus->set_string_param("material", material);
+    flux_return_plus->SetActive(flux_door_active);
+    flux_return_plus->SuperDetector("FLUXRET_ETA_PLUS");
+    flux_return_plus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_plus);
+
+    PHG4CylinderSubsystem *flux_return_minus = new PHG4CylinderSubsystem("FLUXRET_ETA_MINUS", 3);
+    flux_return_minus->set_double_param("length", G4PLUGDOOR::length);
+    flux_return_minus->set_double_param("radius", G4PLUGDOOR::r_1);
+    flux_return_minus->set_double_param("place_z", -G4PLUGDOOR::place_z);
+    flux_return_minus->set_double_param("thickness", G4PLUGDOOR::r_2 - G4PLUGDOOR::r_1);
+    flux_return_minus->set_string_param("material", material);
+    flux_return_minus->SetActive(flux_door_active);
+    flux_return_minus->SuperDetector("FLUXRET_ETA_MINUS");
+    flux_return_minus->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(flux_return_minus);
+  }
 
   return;
 }


### PR DESCRIPTION
This PR replaces the back part of the plugdoor by a black hole to speed up the sims. Initial tests with a disk right in front of it show that the backsplash from it is not properly simulated by the default 2cm thickness, even 10 cm iron gives only 1/3 of the backsplash. The backsplash measurement is crude - just hits, not energy but I don't have time for this right now. But if someone is interested - the mechanics are now in place to do so. Naturally with 2cm it runs orders of magnitude fast (100 events for 30cm take many hours, 2cm few minutes)
![2cmbacksplash](https://user-images.githubusercontent.com/7316141/137534712-cd4bd5c6-1a87-4665-a57c-106f673130d2.png)
backsplash hits using 2cm of iron for plugdoor thickness before terminating shower
![10cmbacksplash](https://user-images.githubusercontent.com/7316141/137534794-801f1439-2c71-4be3-abfc-e20f6b0ff06e.png)
backsplash hits using 10cm of iron for plugdoor thickness before terminating shower
![30cmbacksplash](https://user-images.githubusercontent.com/7316141/137534853-295b7e9f-7174-4efd-a398-4a043e868cf6.png)
backsplash using original 30cm thickness
