### PR TITLE
reordering includes helps - no idea why

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -3,6 +3,10 @@
 
 #include <GlobalVariables.C>
 
+// leave this here - there is a weird library interaction
+// if G4_KFParticle.C gets included after G4Setup_sPHENIX.C
+#include <G4_KFParticle.C>
+
 #include <DisplayOn.C>
 #include <G4Setup_sPHENIX.C>
 #include <G4_Bbc.C>
@@ -12,7 +16,6 @@
 #include <G4_HIJetReco.C>
 #include <G4_Input.C>
 #include <G4_Jets.C>
-#include <G4_KFParticle.C>
 #include <G4_ParticleFlow.C>
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>


### PR DESCRIPTION
This PR includes G4_KFParticle.C right after the global vars. This order seem to prevent the crash we had (it is caused by adding a lib dependency on sphenix_kfparticle to the qamodules lib). No idea what's going on here