### PR TITLE
Revert "reordering includes helps - no idea why"

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -3,10 +3,6 @@
 
 #include <GlobalVariables.C>
 
-// leave this here - there is a weird library interaction
-// if G4_KFParticle.C gets included after G4Setup_sPHENIX.C
-#include <G4_KFParticle.C>
-
 #include <DisplayOn.C>
 #include <G4Setup_sPHENIX.C>
 #include <G4_Bbc.C>
@@ -16,6 +12,7 @@
 #include <G4_HIJetReco.C>
 #include <G4_Input.C>
 #include <G4_Jets.C>
+#include <G4_KFParticle.C>
 #include <G4_ParticleFlow.C>
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/macros#460. Put the problematic qa coe into its own library fixes this without everybody having to change their macros