### PR TITLE
Added HF QA and fast sim tracking service

### DIFF
--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -31,16 +31,19 @@ namespace KFParticle
   std::string UpsilonName = "Upsilon";
   std::string UpsilonDecayDescriptor = UpsilonName + " -> e^+ e^-";
   std::pair<float, float> UpsilonMassRange(8, 11);
+  bool UpsilonTrigger = false;
  
   bool runD0Reco = false;
   std::string D0Name = "D0";
   std::string D0DecayDescriptor = "[" + D0Name + " -> K^- pi^+]cc";
   std::pair<float, float> D0MassRange(1.75, 1.95);
+  bool D0Trigger = false;
 
   bool runLambdacReco = false;
   std::string LambdacName = "Lambdac";
   std::string LambdacDecayDescriptor = "[" + motherName + " -> proton^+ K^- pi^+]cc";
   std::pair<float, float> LambdacMassRange(2.15, 2.45);
+  bool LambdacTrigger = false;
 } //namesppace KFParticle
 
 namespace KFParticleBaseCut
@@ -177,6 +180,7 @@ void KFParticle_QA()
     DecayFinder *UpsilonFinder = new DecayFinder("DecayFinder_" + KFParticle::UpsilonName);
     UpsilonFinder->Verbosity(verbosity);
     UpsilonFinder->setDecayDescriptor(KFParticle::UpsilonDecayDescriptor);
+    UpsilonFinder->triggerOnDecay(KFParticle::UpsilonTrigger);
     UpsilonFinder->saveDST(true);
     UpsilonFinder->allowPi0(true);
     UpsilonFinder->allowPhotons(true);
@@ -194,6 +198,7 @@ void KFParticle_QA()
     DecayFinder *D0Finder = new DecayFinder("DecayFinder_" + KFParticle::D0Name);
     D0Finder->Verbosity(verbosity);
     D0Finder->setDecayDescriptor(KFParticle::D0DecayDescriptor);
+    D0Finder->triggerOnDecay(KFParticle::D0Trigger);
     D0Finder->saveDST(true);
     D0Finder->allowPi0(true);
     D0Finder->allowPhotons(true);
@@ -211,6 +216,7 @@ void KFParticle_QA()
     DecayFinder *LambdacFinder = new DecayFinder("DecayFinder_" + KFParticle::LambdacName);
     LambdacFinder->Verbosity(verbosity);
     LambdacFinder->setDecayDescriptor(KFParticle::LambdacDecayDescriptor);
+    LambdacFinder->triggerOnDecay(KFParticle::LambdacTrigger);
     LambdacFinder->saveDST(true);
     LambdacFinder->allowPi0(true);
     LambdacFinder->allowPhotons(true);

--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -5,6 +5,7 @@
 
 #define HomogeneousField
 #include <kfparticle_sphenix/KFParticle_sPHENIX.h>
+#include <decayfinder/DecayFinder.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -22,6 +23,26 @@ namespace Enable
   std::string KFPARTICLE_VERTEXMAP = "SvtxVertexMap";
 }  // namespace Enable
 
+namespace KFParticle
+{
+  bool runQA = false;
+
+  bool runUpsilonReco = false;
+  std::string UpsilonName = "Upsilon";
+  std::string UpsilonDecayDescriptor = UpsilonName + " -> e^+ e^-";
+  std::pair<float, float> UpsilonMassRange(8, 11);
+ 
+  bool runD0Reco = false;
+  std::string D0Name = "D0";
+  std::string D0DecayDescriptor = "[" + D0Name + " -> K^- pi^+]cc";
+  std::pair<float, float> D0MassRange(1.75, 1.95);
+
+  bool runLambdacReco = false;
+  std::string LambdacName = "Lambdac";
+  std::string LambdacDecayDescriptor = "[" + motherName + " -> proton^+ K^- pi^+]cc";
+  std::pair<float, float> LambdacMassRange(2.15, 2.45);
+} //namesppace KFParticle
+
 namespace KFParticleBaseCut
 {
   float minTrackPT = 0.5; // GeV
@@ -32,28 +53,20 @@ namespace KFParticleBaseCut
   float minMotherPT = 0; // GeV
 }  // namespace KFParticleBaseCut
 
-void KFParticleInit() {} //I guess this line isnt needed
-
 void KFParticle_Upsilon_Reco()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  std::string motherName = "Upsilon";
-  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + KFParticle::UpsilonName + "_Reco");
   kfparticle->Verbosity(verbosity);
+  kfparticle->setDecayDescriptor(KFParticle::UpsilonDecayDescriptor);
 
   kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
   kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
   kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
   kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
-
-  std::string decayDescriptor = motherName + " -> e^+ e^-";
-  kfparticle->setDecayDescriptor(decayDescriptor);
-
-  kfparticle->setContainerName(motherName);
-  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
   kfparticle->setMinimumTrackIPchi2(0); // Upsilon decays are prompt, tracks are more likely to point to vertex
@@ -62,10 +75,13 @@ void KFParticle_Upsilon_Reco()
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
   kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
 
-  kfparticle->setMinimumMass(7);
-  kfparticle->setMaximumMass(11);
+  kfparticle->setMinimumMass(UpsilonMassRange.first);
+  kfparticle->setMaximumMass(UpsilonMassRange.second);
   kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
   kfparticle->constrainToPrimaryVertex(false);
+
+  kfparticle->setContainerName(KFParticle::UpsilonName);
+  kfparticle->setOutputName("KFParticleOutput_" + KFParticle::UpsilonName + "_reconstruction.root");
 
   se->registerSubsystem(kfparticle);
 
@@ -79,20 +95,14 @@ void KFParticle_D0_Reco()
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  std::string motherName = "D0";
-  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + KFParticle::D0Name + "_Reco");
   kfparticle->Verbosity(verbosity);
+  kfparticle->setDecayDescriptor(KFParticle::D0DecayDescriptor);
 
   kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
   kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
   kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
   kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
-
-  std::string decayDescriptor = "[" + motherName + " -> K^- pi^+]cc";
-  kfparticle->setDecayDescriptor(decayDescriptor);
-
-  kfparticle->setContainerName(motherName);
-  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
   kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
@@ -101,10 +111,13 @@ void KFParticle_D0_Reco()
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
   kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
 
-  kfparticle->setMinimumMass(1.750);
-  kfparticle->setMaximumMass(1.950);
+  kfparticle->setMinimumMass(D0MassRange.first);
+  kfparticle->setMaximumMass(D0MassRange.second);
   kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
   kfparticle->constrainToPrimaryVertex(false);
+
+  kfparticle->setContainerName(KFParticle::D0Name);
+  kfparticle->setOutputName("KFParticleOutput_" + KFParticle::D0Name + "_reconstruction.root");
 
   se->registerSubsystem(kfparticle);
 
@@ -118,20 +131,14 @@ void KFParticle_Lambdac_Reco()
 
   Fun4AllServer *se = Fun4AllServer::instance();
 
-  std::string motherName = "Lambdac";
-  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + motherName + "_Reco");
+  KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("KFParticle_" + KFParticle::LambdacName + "_Reco");
   kfparticle->Verbosity(verbosity);
+  kfparticle->setDecayDescriptor(KFParticle::LambdacDecayDescriptor);
 
   kfparticle->saveDST(Enable::KFPARTICLE_APPEND_TO_DST);
   kfparticle->saveOutput(Enable::KFPARTICLE_SAVE_NTUPLE);
   kfparticle->doTruthMatching(Enable::KFPARTICLE_TRUTH_MATCH);
   kfparticle->getDetectorInfo(Enable::KFPARTICLE_DETECTOR_INFO);
-
-  std::string decayDescriptor = "[" + motherName + " -> proton^+ K^- pi^+]cc";
-  kfparticle->setDecayDescriptor(decayDescriptor);
-
-  kfparticle->setContainerName(motherName);
-  kfparticle->setOutputName("KFParticleOutput_" + motherName + "_reconstruction.root");
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
   kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
@@ -140,15 +147,77 @@ void KFParticle_Lambdac_Reco()
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
   kfparticle->setMaximumDaughterDCA(KFParticleBaseCut::maxTrackTrackDCA);
 
-  kfparticle->setMinimumMass(2.150);
-  kfparticle->setMaximumMass(2.400);
+  kfparticle->setMinimumMass(LambdacMassRange.first);
+  kfparticle->setMaximumMass(LambdacMassRange.second);
   kfparticle->setMotherPT(KFParticleBaseCut::minMotherPT);
   kfparticle->constrainToPrimaryVertex(false);
+
+  kfparticle->setContainerName(KFParticle::LambdacName);
+  kfparticle->setOutputName("KFParticleOutput_" + KFParticle::LambdacName + "_reconstruction.root");
 
   se->registerSubsystem(kfparticle);
 
   return;
 }
 
+void KFParticle_QA()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::KFPARTICLE_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  if (KFParticle::runUpsilonReco)
+  {
+    DecayFinder *UpsilonFinder = new DecayFinder("DecayFinder_" + KFParticle::UpsilonName);
+    UpsilonFinder->Verbosity(verbosity);
+    UpsilonFinder->setDecayDescriptor(KFParticle::UpsilonDecayDescriptor);
+    UpsilonFinder->saveDST(true);
+    UpsilonFinder->allowPi0(true);
+    UpsilonFinder->allowPhotons(true);
+    se->registerSubsystem(UpsilonFinder);
+
+    QAG4SimulationKFParticle *UpsilonQA = new QAG4SimulationKFParticle("QA_" + KFParticle::UpsilonName, 
+      								       KFParticle::UpsilonName, 
+								       UpsilonMassRange.first,  
+								       UpsilonMassRange.second);
+    se->registerSubsystem(UpsilonQA);
+  }
+
+  if (KFParticle::runD0Reco)
+  {
+    DecayFinder *D0Finder = new DecayFinder("DecayFinder_" + KFParticle::D0Name);
+    D0Finder->Verbosity(verbosity);
+    D0Finder->setDecayDescriptor(KFParticle::D0DecayDescriptor);
+    D0Finder->saveDST(true);
+    D0Finder->allowPi0(true);
+    D0Finder->allowPhotons(true);
+    se->registerSubsystem(D0Finder);
+
+    QAG4SimulationKFParticle *D0QA = new QAG4SimulationKFParticle("QA_" + KFParticle::D0Name,
+                                                                  KFParticle::D0Name,
+                                                                  D0MassRange.first,
+                                                                  D0MassRange.second);
+    se->registerSubsystem(D0QA);
+  }
+
+  if (KFParticle::runLambdacReco)
+  {
+    DecayFinder *LambdacFinder = new DecayFinder("DecayFinder_" + KFParticle::LambdacName);
+    LambdacFinder->Verbosity(verbosity);
+    LambdacFinder->setDecayDescriptor(KFParticle::LambdacDecayDescriptor);
+    LambdacFinder->saveDST(true);
+    LambdacFinder->allowPi0(true);
+    LambdacFinder->allowPhotons(true);
+    se->registerSubsystem(LambdacFinder);
+
+    QAG4SimulationKFParticle *LambdacQA = new QAG4SimulationKFParticle("QA_" + KFParticle::LambdacName, 
+                                                                       KFParticle::LambdacName, 
+                                                                       LambdacMassRange.first,  
+                                                                       LambdacMassRange.second);
+    se->registerSubsystem(LambdacQA);
+  }
+
+  return;
+}
 
 #endif

--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -25,7 +25,7 @@ namespace Enable
 
 namespace KFParticle
 {
-  bool runQA = false;
+  bool QA = false;
 
   bool runUpsilonReco = false;
   std::string UpsilonName = "Upsilon";
@@ -85,6 +85,8 @@ void KFParticle_Upsilon_Reco()
 
   se->registerSubsystem(kfparticle);
 
+  KFParticle::runUpsilonReco = true;
+
   return;
 }
 
@@ -121,6 +123,8 @@ void KFParticle_D0_Reco()
 
   se->registerSubsystem(kfparticle);
 
+  KFParticle::runD0Reco = true;
+
   return;
 }
 
@@ -156,6 +160,8 @@ void KFParticle_Lambdac_Reco()
   kfparticle->setOutputName("KFParticleOutput_" + KFParticle::LambdacName + "_reconstruction.root");
 
   se->registerSubsystem(kfparticle);
+
+  KFParticle::runLambdacReco = true;
 
   return;
 }

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -32,7 +32,6 @@ namespace Enable
   bool MVTX_CLUSTER = false;
   bool MVTX_QA = false;
   bool MVTX_ABSORBER = false;
-  bool MVTX_SERVICE = true;
   int MVTX_VERBOSITY = 0;
 
 }  // namespace Enable
@@ -41,18 +40,6 @@ namespace G4MVTX
 {
   int n_maps_layer = 3;        // must be 0-3, setting it to zero removes Mvtx completely, n < 3 gives the first n layers
   double radius_offset = 0.7;  // clearance around radius
-
-  double single_stave_service_copper_area = 0.0677;   //Cross-sectional area of copper for 1 stave [cm^2]
-  double single_stave_service_water_area = 0.0098;    //Cross-sectional area of water for 1 stave [cm^2]
-  double single_stave_service_plastic_area = 0.4303;  //Cross-sectional area of plastic for 1 stave [cm^2]
-
-  const int n_service_layers = 1;               //Number of service cable service_layers to generate
-  double service_layer_start_radius[] = {8.5};  //Inner radius of where the cables begin [cm]
-  int n_staves_service_layer[] = {48};          //Number of staves associated to each service layer
-
-  double service_barrel_radius = 10.75;  // [cm] From final design review
-  double service_barrel_start = -35;     //[cm] Approx.
-  double service_barrel_length = 150;    // [cm] length of service barrel ~(to patch panel)
 }  // namespace G4MVTX
 
 namespace G4MVTXAlignment 
@@ -63,127 +50,9 @@ namespace G4MVTXAlignment
 
 void MvtxInit()
 {
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4MVTX::service_barrel_radius);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -1 * (G4MVTX::service_barrel_length - G4MVTX::service_barrel_start + 5.));
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 25.);
-}
-
-double calculateArea(double inner_radius, double outer_radius)  //Calculate the area of a disk
-{
-  return M_PI * (std::pow(outer_radius, 2) - std::pow(inner_radius, 2));
-}
-
-double calculateOR(double inner_radius, double area)  //Calculate the outer radius of a disk, knowing the inner radius and the area
-{
-  return std::sqrt(area / M_PI + std::pow(inner_radius, 2));
-}
-
-void calculateMaterialBoundaries(int& service_layer_ID, double& outer_copper_radius, double& outer_water_radius, double& outer_plastic_radius)  //Calculate where the transition between each material occurs
-{
-  outer_copper_radius = calculateOR(G4MVTX::service_layer_start_radius[service_layer_ID], G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_copper_area);
-  outer_water_radius = calculateOR(outer_copper_radius, G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_water_area);
-  outer_plastic_radius = calculateOR(outer_water_radius, G4MVTX::n_staves_service_layer[service_layer_ID] * G4MVTX::single_stave_service_plastic_area);
-}
-
-double MVTXService(PHG4Reco* g4Reco, double radius)
-{
-  // Note, cables are all south
-  // Setup service_layers
-  bool AbsorberActive = Enable::ABSORBER || Enable::MVTX_ABSORBER;
-  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::MVTX_OVERLAPCHECK;
-  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
-
-  double copper_OR[G4MVTX::n_service_layers], water_OR[G4MVTX::n_service_layers], plastic_OR[G4MVTX::n_service_layers];  //Objects for material outer radii
-  int subsystem_service_layer = 0;
-  std::string copper_name, water_name, plastic_name;
-  PHG4CylinderSubsystem* cyl;
-
-  for (int i = 0; i < G4MVTX::n_service_layers; ++i)  //Build a service_layer of copper, then water, then plastic
-  {
-    calculateMaterialBoundaries(i, copper_OR[i], water_OR[i], plastic_OR[i]);
-
-    copper_name = "MVTX_Service_copper_service_layer_" + std::to_string(i);
-    water_name = "MVTX_Service_water_service_layer_" + std::to_string(i);
-    plastic_name = "MVTX_Service_plastic_service_layer_" + std::to_string(i);
-
-    cyl = new PHG4CylinderSubsystem(copper_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
-    cyl->set_double_param("radius", G4MVTX::service_layer_start_radius[i]);
-    cyl->set_int_param("lengthviarapidity", 0);
-    cyl->set_double_param("length", G4MVTX::service_barrel_length);
-    cyl->set_string_param("material", "G4_Cu");
-    cyl->set_double_param("thickness", copper_OR[i] - G4MVTX::service_layer_start_radius[i]);
-    cyl->SuperDetector("MVTXSERVICE");
-    if (AbsorberActive) cyl->SetActive();
-    cyl->OverlapCheck(OverlapCheck);
-    g4Reco->registerSubsystem(cyl);
-    subsystem_service_layer += 1;
-
-    cyl = new PHG4CylinderSubsystem(water_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
-    cyl->set_double_param("radius", copper_OR[i]);
-    cyl->set_int_param("lengthviarapidity", 0);
-    cyl->set_double_param("length", G4MVTX::service_barrel_length);
-    cyl->set_string_param("material", "G4_WATER");
-    cyl->set_double_param("thickness", water_OR[i] - copper_OR[i]);
-    cyl->SuperDetector("MVTXSERVICE");
-    if (AbsorberActive) cyl->SetActive();
-    cyl->OverlapCheck(OverlapCheck);
-    g4Reco->registerSubsystem(cyl);
-    subsystem_service_layer += 1;
-
-    cyl = new PHG4CylinderSubsystem(plastic_name, subsystem_service_layer);
-    cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
-    cyl->set_double_param("radius", water_OR[i]);
-    cyl->set_int_param("lengthviarapidity", 0);
-    cyl->set_double_param("length", G4MVTX::service_barrel_length);
-    cyl->set_string_param("material", "G4_POLYETHYLENE");
-    cyl->set_double_param("thickness", plastic_OR[i] - water_OR[i]);
-    cyl->SuperDetector("MVTXSERVICE");
-    if (AbsorberActive) cyl->SetActive();
-    cyl->OverlapCheck(OverlapCheck);
-    g4Reco->registerSubsystem(cyl);
-    subsystem_service_layer += 1;
-  }
-
-  cyl = new PHG4CylinderSubsystem("MVTX_Service_shell_service_layer", subsystem_service_layer);
-  cyl->set_double_param("place_z", -1 * (G4MVTX::service_barrel_length + G4MVTX::service_barrel_start) - no_overlapp);
-  cyl->set_double_param("radius", G4MVTX::service_barrel_radius);
-  cyl->set_int_param("lengthviarapidity", 0);
-  cyl->set_double_param("length", G4MVTX::service_barrel_length);
-  cyl->set_string_param("material", "PEEK");  //Service barrel is carbon fibre (peek?)
-  cyl->set_double_param("thickness", 0.1);    //Service barrel is 1mm thick
-  cyl->SuperDetector("MVTXSERVICE");
-  if (AbsorberActive) cyl->SetActive();
-  cyl->OverlapCheck(OverlapCheck);
-  g4Reco->registerSubsystem(cyl);
-
-  radius = G4MVTX::service_barrel_radius;
-
-  if (verbosity > 0)
-  {
-    cout << "=========================== MVTX Service Barrel =============================" << endl;
-    cout << " MVTX Service Material Description:" << endl;
-
-    cout << "  Single stave copper area  = " << G4MVTX::single_stave_service_copper_area << " cm^2" << endl;
-    cout << "  Single stave water area   = " << G4MVTX::single_stave_service_water_area << " cm^2" << endl;
-    cout << "  Single stave plastic area = " << G4MVTX::single_stave_service_plastic_area << " cm^2" << endl;
-
-    for (int j = 0; j < G4MVTX::n_service_layers; ++j)
-    {
-      cout << "  service_layer " << j << " starts at " << G4MVTX::service_layer_start_radius[j] << " cm" << endl;
-      cout << "  service_layer " << j << " services " << G4MVTX::n_staves_service_layer[j] << " staves" << endl;
-    }
-
-    cout << "  Service barrel radius = " << G4MVTX::service_barrel_radius << " cm" << endl;
-    cout << "  Service barrel start = " << G4MVTX::service_barrel_start << " cm" << endl;
-    cout << "  Service barrel length = " << G4MVTX::service_barrel_length << " cm" << endl;
-    cout << "===============================================================================" << endl;
-  }
-
-  radius += no_overlapp;
-
-  return radius;
+  //BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 5);
+  //BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -20);
+  //BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 25.);
 }
 
 double Mvtx(PHG4Reco* g4Reco, double radius,
@@ -212,7 +81,6 @@ double Mvtx(PHG4Reco* g4Reco, double radius,
   mvtx->OverlapCheck(maps_overlapcheck);
   g4Reco->registerSubsystem(mvtx);
   radius += G4MVTX::radius_offset;
-  if (Enable::MVTX_SERVICE) radius += MVTXService(g4Reco, radius);
   return radius;
 }
 

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -418,16 +418,16 @@ double TrackingService(PHG4Reco *g4Reco, double radius)
   cones.push_back(new ServiceStructure("L2_2", 0, G4TrackingService::LayerThickness, -15.206, -8.538, 9.650, 4.574));
   cylinders.push_back(new ServiceStructure("L2_3", 0, G4TrackingService::LayerThickness, -8.538, 0, 4.574, 0));
 
-  //for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius);
-  //for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
+  for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius);
+  for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
 
-  int nSets = 4
+  int nSets = 48;
   for (unsigned int i = 0; i < nSets; ++i)
   {
     double theta = 360.*i/nSets;
-    double r = 10;
-    radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta), 0, 100, theta);
-    radius += CreateCableBundle("Test2", g4Reco, radius, true, true, true, r*cos(theta), (r+10)*cos(theta), r*sin(theta), (r+10)*sin(theta), -50, 0, theta);
+    double r = G4TrackingService::BarrelRadius - 1.;
+    radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta),  -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), -1. * G4TrackingService::BarrelOffset - 5., theta);
+    radius += CreateCableBundle("Test2", g4Reco, radius, true, true, true, r*cos(theta), (r-4)*cos(theta), r*sin(theta), (r-4)*sin(theta), -1. * G4TrackingService::BarrelOffset - 5, -1. * G4TrackingService::BarrelOffset, theta);
   }
 
   return radius;

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -19,62 +19,131 @@
 
 using namespace std;
 
-class ServiceProperties
+class ServiceStructure
 {
   public:
-   ServiceProperties();
+   ServiceStructure();
 
-    explicit ServiceProperties(const string &name,
-                               const double &rad_len_aluminum,
-                               const double &rad_len_carbon,
-                               const double &z_south,
-                               const double &z_north,
-                               const double &r_south,
-                               const double &r_north);
+    explicit ServiceStructure(const string &name,
+                              const double &rad_len_aluminum,
+                              const double &rad_len_carbon,
+                              const double &zSouth,
+                              const double &zNorth,
+                              const double &rSouth,
+                              const double &rNorth);
 
-    virtual ~ServiceProperties(){};
+    virtual ~ServiceStructure(){};
 
     const string get_name();
     const double get_rad_len_aluminum();
     const double get_rad_len_carbon();
-    const double get_z_south();
-    const double get_z_north();
-    const double get_r_south();
-    const double get_r_north();
+    const double get_zSouth();
+    const double get_zNorth();
+    const double get_rSouth();
+    const double get_rNorth();
   
   private:
     const string m_name = "service";
     const double m_rad_len_aluminum = 0.0;
     const double m_rad_len_carbon = 0.0;
-    const double m_z_south = 0.0;
-    const double m_z_north = 0.0;
-    const double m_r_south = 0.0;
-    const double m_r_north = 0.0;
+    const double m_zSouth = 0.0;
+    const double m_zNorth = 0.0;
+    const double m_rSouth = 0.0;
+    const double m_rNorth = 0.0;
 };
 
-ServiceProperties::ServiceProperties(const string &name,
-                                     const double &rad_len_aluminum,
-                                     const double &rad_len_carbon,
-                                     const double &z_south,
-                                     const double &z_north,
-                                     const double &r_south,
-                                     const double &r_north)
+ServiceStructure::ServiceStructure(const string &name,
+                                   const double &rad_len_aluminum,
+                                   const double &rad_len_carbon,
+                                   const double &zSouth,
+                                   const double &zNorth,
+                                   const double &rSouth,
+                                   const double &rNorth)
   : m_name(name)
   , m_rad_len_aluminum(rad_len_aluminum)
   , m_rad_len_carbon(rad_len_carbon)
-  , m_z_south(z_south)
-  , m_z_north(z_north)
-  , m_r_south(r_south)
-  , m_r_north(r_north)
+  , m_zSouth(zSouth)
+  , m_zNorth(zNorth)
+  , m_rSouth(rSouth)
+  , m_rNorth(rNorth)
 {}
 
-const string ServiceProperties::get_name() { return m_name; }
-const double ServiceProperties::get_rad_len_aluminum() { return m_rad_len_aluminum; }
-const double ServiceProperties::get_rad_len_carbon() { return m_rad_len_carbon; }
-const double ServiceProperties::get_z_south() { return m_z_south; }
-const double ServiceProperties::get_z_north() { return m_z_north; }
-const double ServiceProperties::get_r_south() { return m_r_south; }
-const double ServiceProperties::get_r_north() { return m_r_north; }
+const string ServiceStructure::get_name() { return m_name; }
+const double ServiceStructure::get_rad_len_aluminum() { return m_rad_len_aluminum; }
+const double ServiceStructure::get_rad_len_carbon() { return m_rad_len_carbon; }
+const double ServiceStructure::get_zSouth() { return m_zSouth; }
+const double ServiceStructure::get_zNorth() { return m_zNorth; }
+const double ServiceStructure::get_rSouth() { return m_rSouth; }
+const double ServiceStructure::get_rNorth() { return m_rNorth; }
+
+class Cable
+{
+  public:
+    Cable();
+
+    explicit Cable(const string &name,
+                   const string &coreMaterial,
+                   const double &coreRadius,
+                   const double &sheathRadius,
+                   const double &xSouth, const double &xNorth,
+                   const double &ySouth, const double &yNorth,
+                   const double &zSouth, const double &zNorth);
+
+    virtual ~Cable(){};
+
+    const string get_name();
+    const string get_coreMaterial();
+    const double get_coreRadius();
+    const double get_sheathRadius();
+    const double get_xSouth();
+    const double get_xNorth();
+    const double get_ySouth();
+    const double get_yNorth();
+    const double get_zSouth();
+    const double get_zNorth();
+  
+  private:
+    const string m_name = "cable";
+    const string m_coreMaterial = "G4_Cu";
+    const double m_coreRadius = 1;
+    const double m_sheathRadius = 2;
+    const double m_xSouth = 0.;
+    const double m_xNorth = 1.;
+    const double m_ySouth = 0.;
+    const double m_yNorth = 1.;
+    const double m_zSouth = 0.;
+    const double m_zNorth = 1.;
+};
+
+Cable::Cable(const string &name,
+             const string &coreMaterial,
+             const double &coreRadius,
+             const double &sheathRadius,
+             const double &xSouth, const double &xNorth,
+             const double &ySouth, const double &yNorth,
+             const double &zSouth, const double &zNorth)
+  : m_name(name)
+  , m_coreMaterial(coreMaterial)
+  , m_coreRadius(coreRadius)
+  , m_sheathRadius(sheathRadius)
+  , m_xSouth(xSouth)
+  , m_xNorth(xNorth)
+  , m_ySouth(ySouth)
+  , m_yNorth(yNorth)
+  , m_zSouth(zSouth)
+  , m_zNorth(zNorth)
+{}
+
+const string Cable::get_name() { return m_name; }
+const string Cable::get_coreMaterial() { return m_coreMaterial; }
+const double Cable::get_coreRadius() { return m_coreRadius; }
+const double Cable::get_sheathRadius() { return m_sheathRadius; }
+const double Cable::get_xSouth() { return m_xSouth; }
+const double Cable::get_xNorth() { return m_xNorth; }
+const double Cable::get_ySouth() { return m_ySouth; }
+const double Cable::get_yNorth() { return m_yNorth; }
+const double Cable::get_zSouth() { return m_zSouth; }
+const double Cable::get_zNorth() { return m_zNorth; }
 
 namespace Enable
 {
@@ -98,7 +167,7 @@ namespace G4TrackingService
   int subsysID = 0;
 }  // namespace G4TrackingService
 
-vector<double> get_thickness(ServiceProperties *object)
+vector<double> get_thickness(ServiceStructure *object)
 {
   vector<double> thickness = {(object->get_rad_len_aluminum()/100)*G4TrackingService::materials[0].second
                              ,(object->get_rad_len_carbon()/100)*G4TrackingService::materials[1].second};
@@ -109,7 +178,7 @@ void TrackingServiceInit()
 {
 }
 
-double TrackingServiceCone(ServiceProperties *object, PHG4Reco* g4Reco, double radius)
+double TrackingServiceCone(ServiceStructure *object, PHG4Reco* g4Reco, double radius)
 {
   bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
@@ -117,9 +186,9 @@ double TrackingServiceCone(ServiceProperties *object, PHG4Reco* g4Reco, double r
 
   PHG4ConeSubsystem* cone;
 
-  double innerRadiusSouth = object->get_r_south();
-  double innerRadiusNorth = object->get_r_north();
-  double length = abs(object->get_z_north() - object->get_z_south());
+  double innerRadiusSouth = object->get_rSouth();
+  double innerRadiusNorth = object->get_rNorth();
+  double length = abs(object->get_zNorth() - object->get_zSouth());
   vector<double> thickness = get_thickness(object);
 
   for (int i = 0; i < G4TrackingService::nMaterials; ++i)
@@ -129,7 +198,7 @@ double TrackingServiceCone(ServiceProperties *object, PHG4Reco* g4Reco, double r
     cone->Verbosity(verbosity);
     cone->SetR1(innerRadiusSouth, innerRadiusSouth + thickness[i]);
     cone->SetR2(innerRadiusNorth, innerRadiusNorth + thickness[i]);
-    cone->SetPlaceZ(object->get_z_south() + length/2 + G4TrackingService::GlobalOffset);
+    cone->SetPlaceZ(object->get_zSouth() + length/2 + G4TrackingService::GlobalOffset);
     cone->SetZlength(length/2);
     cone->SetMaterial(G4TrackingService::materials[i].first);
     cone->SuperDetector("TrackingService");
@@ -145,7 +214,7 @@ double TrackingServiceCone(ServiceProperties *object, PHG4Reco* g4Reco, double r
   return radius;
 }
 
-double TrackingServiceCylinder(ServiceProperties *object, PHG4Reco* g4Reco, double radius)
+double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco* g4Reco, double radius)
 {
   bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
@@ -153,8 +222,8 @@ double TrackingServiceCylinder(ServiceProperties *object, PHG4Reco* g4Reco, doub
 
   PHG4CylinderSubsystem* cyl;
 
-  double innerRadius = object->get_r_south();
-  double length = abs(object->get_z_north() - object->get_z_south());
+  double innerRadius = object->get_rSouth();
+  double length = abs(object->get_zNorth() - object->get_zSouth());
   vector<double> thickness = get_thickness(object);
 
   for (int i = 0; i < G4TrackingService::nMaterials; ++i)
@@ -162,7 +231,7 @@ double TrackingServiceCylinder(ServiceProperties *object, PHG4Reco* g4Reco, doub
     if (thickness[i] == 0) continue;
     cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
     cyl->Verbosity(verbosity);
-    cyl->set_double_param("place_z", object->get_z_south() + length/2 + G4TrackingService::GlobalOffset);
+    cyl->set_double_param("place_z", object->get_zSouth() + length/2 + G4TrackingService::GlobalOffset);
     cyl->set_double_param("radius", innerRadius);
     cyl->set_double_param("length", length);
     cyl->set_string_param("material", G4TrackingService::materials[i].first);
@@ -179,33 +248,117 @@ double TrackingServiceCylinder(ServiceProperties *object, PHG4Reco* g4Reco, doub
   return radius;
 }
 
+double CreateCable(Cable *object, PHG4Reco* g4Reco, double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
+  int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
+
+  string cableMaterials[2] = { object->get_coreMaterial(), "G4_POLYETHYLENE" };
+  double IR[2] = { 0, object->get_coreRadius() };
+  double OR[2] = { object->get_coreRadius(), object->get_sheathRadius() };
+
+  double length = abs(object->get_zNorth() - object->get_zSouth());
+  double setX = (object->get_xSouth() + object->get_xNorth())/2;
+  double setY = (object->get_ySouth() + object->get_yNorth())/2;
+  double setZ = (object->get_zSouth() + object->get_zNorth())/2;
+  
+  double radToDeg = 180.0/M_PI;
+  double rotX = tan((object->get_yNorth() - object->get_ySouth())/(object->get_zNorth() - object->get_zSouth()))*radToDeg;
+  double rotY = tan((object->get_xNorth() - object->get_xSouth())/(object->get_zNorth() - object->get_zSouth()))*radToDeg;
+  double rotZ = tan((object->get_xNorth() - object->get_xSouth())/(object->get_yNorth() - object->get_ySouth()))*radToDeg;
+  
+  PHG4CylinderSubsystem* cyl;
+  for (int i = 0; i < 2; ++i)
+  {
+    cyl = new PHG4CylinderSubsystem(object->get_name(), i);
+    cyl->Verbosity(verbosity);
+    cyl->set_string_param("material", cableMaterials[i]);
+    cyl->set_double_param("length", length);
+    cyl->set_double_param("radius", IR[i]);
+    cyl->set_double_param("thickness", OR[i]);
+    cyl->set_double_param("place_x", setX);
+    cyl->set_double_param("place_y", setY);
+    cyl->set_double_param("place_z", setZ);
+    cyl->set_double_param("rot_x", rotX);
+    cyl->set_double_param("rot_y", rotY);
+    cyl->set_double_param("rot_z", rotZ);
+    cyl->SuperDetector("TrackingService");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+    ++G4TrackingService::subsysID;
+  }
+  return OR[1];
+}
+
+double CreateCableBundle(string superName, PHG4Reco* g4Reco, double radius, 
+                         double x1, double x2, double y1, double y2, double z1, double z2)
+{
+  //Set up basic MVTX cable bundle (24 Samtex cables, 1 power cable, 2 cooling cables)
+  double samtecCoreRadius = 0.1275;
+  double samtecSheathRadius = 0.05;
+  double coolingCoreRadius = 0.056;
+  double coolingSheathRadius = 0.08; //?
+
+
+  //Samtec cables (we use 24 as there are 12 twinax)
+  for (unsigned int row = 0; row < 2; ++row)
+  {
+    for (unsigned int col = 0; col < 12; ++ col)
+    {
+      Cable *cable = new Cable(superName + "_samtec", "G4_Cu", samtecCoreRadius, samtecSheathRadius, 
+                               x1 + -1*(col + 1)*samtecSheathRadius, x2 + -1*(col + 1)*samtecSheathRadius,
+                               y1 + -1*(row + 1)*samtecSheathRadius, y2 + -1*(row + 1)*samtecSheathRadius,
+                               z1, z2);
+      radius += CreateCable(cable, g4Reco, radius);
+    }
+  }
+
+  //Cooling Cables
+  for (unsigned int nCool = 0; nCool < 2; ++nCool)
+  {
+    Cable *cable = new Cable(superName + "_cooling", "G4_WATER", coolingCoreRadius, coolingSheathRadius, 
+                             x1 + (nCool + 1)*coolingSheathRadius, x2 + (nCool + 1)*coolingSheathRadius,
+                             y1 + (nCool + 1)*coolingSheathRadius, y2 + (nCool + 1)*coolingSheathRadius,
+                             z1, z2);
+    radius += CreateCable(cable, g4Reco, radius);
+  }
+
+  //Power Cables
+  return radius;
+}
+
 double TrackingService(PHG4Reco* g4Reco, double radius)
 {
-  vector<ServiceProperties*> cylinders, cones;
+  vector<ServiceStructure*> cylinders, cones;
 
   double shellX0 = 100*G4TrackingService::ShellThickness/G4TrackingService::materials[4].second;
   double layerX0 = 100*G4TrackingService::LayerThickness/G4TrackingService::materials[4].second;
   double shellOffset = 18.679;
 
-  cylinders.push_back(new ServiceProperties("MVTXServiceBarrel", 0, shellX0, -1.*(G4TrackingService::ShellLength + shellOffset), -1.*shellOffset , 10.33, 0));
+  cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0, shellX0, -1.*(G4TrackingService::ShellLength + shellOffset), -1.*shellOffset , 10.33, 0));
 
-  cylinders.push_back(new ServiceProperties("L0_1", 0, layerX0, -18.680, -16.579, 5.050, 0));
-  cones.push_back(new ServiceProperties("L0_2", 0, layerX0, -16.579, -9.186, 5.050, 2.997));
-  cylinders.push_back(new ServiceProperties("L0_3", 0, layerX0, -9.186, 0, 2.997, 0));
+  cylinders.push_back(new ServiceStructure("L0_1", 0, layerX0, -18.680, -16.579, 5.050, 0));
+  cones.push_back(new ServiceStructure("L0_2", 0, layerX0, -16.579, -9.186, 5.050, 2.997));
+  cylinders.push_back(new ServiceStructure("L0_3", 0, layerX0, -9.186, 0, 2.997, 0));
 
-  cylinders.push_back(new ServiceProperties("L1_1", 0, layerX0, -17.970, -15.851, 7.338, 0));
-  cones.push_back(new ServiceProperties("L1_2", 9/16, 0, 0.42/16, 0.32/16, layerX0, -15.851, -8.938, 7.338, 3.799));
-  cylinders.push_back(new ServiceProperties("L1_3", 9/16, 0, 0.42/16, 0.32/16, layerX0, -8.938, 0, 3.799, 0));
+  cylinders.push_back(new ServiceStructure("L1_1", 0, layerX0, -17.970, -15.851, 7.338, 0));
+  cones.push_back(new ServiceStructure("L1_2", 0, layerX0, -15.851, -8.938, 7.338, 3.799));
+  cylinders.push_back(new ServiceStructure("L1_3", 0, layerX0, -8.938, 0, 3.799, 0));
 
-  cylinders.push_back(new ServiceProperties("L2_1", 0, layerX0, -22.300, -15.206, 9.650, 0));
-  cones.push_back(new ServiceProperties("L2_2", 0, layerX0, -15.206, -8.538, 9.650, 4.574));
-  cylinders.push_back(new ServiceProperties("L2_3", 0, layerX0, -8.538, 0, 4.574, 0));
+  cylinders.push_back(new ServiceStructure("L2_1", 0, layerX0, -22.300, -15.206, 9.650, 0));
+  cones.push_back(new ServiceStructure("L2_2", 0, layerX0, -15.206, -8.538, 9.650, 4.574));
+  cylinders.push_back(new ServiceStructure("L2_3", 0, layerX0, -8.538, 0, 4.574, 0));
   
 
-  for (ServiceProperties *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius); 
-  for (ServiceProperties *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
+  //for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius); 
+  //for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
+
+  radius += CreateCableBundle("Test", g4Reco, radius, 0, 0, 0, 0, 0, 10);
 
   return radius;
 }
 
 #endif
+

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -271,7 +271,7 @@ double CreateCable(Cable *object, PHG4Reco* g4Reco, double radius)
   PHG4CylinderSubsystem* cyl;
   for (int i = 0; i < 2; ++i)
   {
-    cyl = new PHG4CylinderSubsystem(object->get_name(), i);
+    cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
     cyl->Verbosity(verbosity);
     cyl->set_string_param("material", cableMaterials[i]);
     cyl->set_double_param("length", length);
@@ -295,7 +295,7 @@ double CreateCable(Cable *object, PHG4Reco* g4Reco, double radius)
 double CreateCableBundle(string superName, PHG4Reco* g4Reco, double radius, 
                          double x1, double x2, double y1, double y2, double z1, double z2)
 {
-  //Set up basic MVTX cable bundle (24 Samtex cables, 1 power cable, 2 cooling cables)
+  //Set up basic MVTX cable bundle (24 Samtec cables, 1 power cable, 2 cooling cables)
   double samtecCoreRadius = 0.1275;
   double samtecSheathRadius = 0.05;
   double coolingCoreRadius = 0.056;
@@ -303,24 +303,28 @@ double CreateCableBundle(string superName, PHG4Reco* g4Reco, double radius,
 
 
   //Samtec cables (we use 24 as there are 12 twinax)
-  for (unsigned int row = 0; row < 2; ++row)
+  unsigned int nSamtecWires = 24;
+  unsigned int nRows = 2;
+  unsigned int nCols = nSamtecWires/nRows;
+  for (unsigned int iRow = 0; iRow < 2; ++iRow)
   {
-    for (unsigned int col = 0; col < 12; ++ col)
+    for (unsigned int iCol = 0; iCol < 12; ++ iCol)
     {
-      Cable *cable = new Cable(superName + "_samtec", "G4_Cu", samtecCoreRadius, samtecSheathRadius, 
-                               x1 + -1*(col + 1)*samtecSheathRadius, x2 + -1*(col + 1)*samtecSheathRadius,
-                               y1 + -1*(row + 1)*samtecSheathRadius, y2 + -1*(row + 1)*samtecSheathRadius,
+      Cable *cable = new Cable(format("{}_samtec_{}_{}", superName, iRow, iCol), "G4_Cu", samtecCoreRadius, samtecSheathRadius, 
+                               x1 + -1*(iCol + 1)*samtecSheathRadius, x2 + -1*(iCol + 1)*samtecSheathRadius,
+                               y1 + -1*(iRow + 1)*samtecSheathRadius, y2 + -1*(iRow + 1)*samtecSheathRadius,
                                z1, z2);
       radius += CreateCable(cable, g4Reco, radius);
     }
   }
 
   //Cooling Cables
-  for (unsigned int nCool = 0; nCool < 2; ++nCool)
+  unsigned int nCool = 2;
+  for (unsigned int iCool = 0; iCool < nCool; ++iCool)
   {
-    Cable *cable = new Cable(superName + "_cooling", "G4_WATER", coolingCoreRadius, coolingSheathRadius, 
-                             x1 + (nCool + 1)*coolingSheathRadius, x2 + (nCool + 1)*coolingSheathRadius,
-                             y1 + (nCool + 1)*coolingSheathRadius, y2 + (nCool + 1)*coolingSheathRadius,
+    Cable *cable = new Cable(format("{}_cooling_{}", superName, iCool), "G4_WATER", coolingCoreRadius, coolingSheathRadius, 
+                             x1 + (iCool + 1)*coolingSheathRadius, x2 + (iCool + 1)*coolingSheathRadius,
+                             y1 + (iCool + 1)*coolingSheathRadius, y2 + (iCool + 1)*coolingSheathRadius,
                              z1, z2);
     radius += CreateCable(cable, g4Reco, radius);
   }
@@ -333,8 +337,8 @@ double TrackingService(PHG4Reco* g4Reco, double radius)
 {
   vector<ServiceStructure*> cylinders, cones;
 
-  double shellX0 = 100*G4TrackingService::ShellThickness/G4TrackingService::materials[4].second;
-  double layerX0 = 100*G4TrackingService::LayerThickness/G4TrackingService::materials[4].second;
+  double shellX0 = 100*G4TrackingService::ShellThickness/G4TrackingService::materials[1].second;
+  double layerX0 = 100*G4TrackingService::LayerThickness/G4TrackingService::materials[1].second;
   double shellOffset = 18.679;
 
   cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0, shellX0, -1.*(G4TrackingService::ShellLength + shellOffset), -1.*shellOffset , 10.33, 0));

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -1,0 +1,211 @@
+#ifndef MACRO_G4TrackingService_C
+#define MACRO_G4TrackingService_C
+
+#include <GlobalVariables.C>
+#include <QA.C>
+
+#include <g4detectors/PHG4ConeSubsystem.h>
+#include <g4detectors/PHG4CylinderSubsystem.h>
+#include <g4main/PHG4Reco.h>
+
+#include <qa_modules/QAG4SimulationMvtx.h>
+
+#include <fun4all/Fun4AllServer.h>
+
+#include <cmath>
+#include <vector>
+
+//sPHENIX Tracking Services
+
+using namespace std;
+
+class ServiceProperties
+{
+  public:
+   ServiceProperties();
+
+    explicit ServiceProperties(const string &name,
+                               const double &rad_len_aluminum,
+                               const double &rad_len_carbon,
+                               const double &z_south,
+                               const double &z_north,
+                               const double &r_south,
+                               const double &r_north);
+
+    virtual ~ServiceProperties(){};
+
+    const string get_name();
+    const double get_rad_len_aluminum();
+    const double get_rad_len_carbon();
+    const double get_z_south();
+    const double get_z_north();
+    const double get_r_south();
+    const double get_r_north();
+  
+  private:
+    const string m_name = "service";
+    const double m_rad_len_aluminum = 0.0;
+    const double m_rad_len_carbon = 0.0;
+    const double m_z_south = 0.0;
+    const double m_z_north = 0.0;
+    const double m_r_south = 0.0;
+    const double m_r_north = 0.0;
+};
+
+ServiceProperties::ServiceProperties(const string &name,
+                                     const double &rad_len_aluminum,
+                                     const double &rad_len_carbon,
+                                     const double &z_south,
+                                     const double &z_north,
+                                     const double &r_south,
+                                     const double &r_north)
+  : m_name(name)
+  , m_rad_len_aluminum(rad_len_aluminum)
+  , m_rad_len_carbon(rad_len_carbon)
+  , m_z_south(z_south)
+  , m_z_north(z_north)
+  , m_r_south(r_south)
+  , m_r_north(r_north)
+{}
+
+const string ServiceProperties::get_name() { return m_name; }
+const double ServiceProperties::get_rad_len_aluminum() { return m_rad_len_aluminum; }
+const double ServiceProperties::get_rad_len_carbon() { return m_rad_len_carbon; }
+const double ServiceProperties::get_z_south() { return m_z_south; }
+const double ServiceProperties::get_z_north() { return m_z_north; }
+const double ServiceProperties::get_r_south() { return m_r_south; }
+const double ServiceProperties::get_r_north() { return m_r_north; }
+
+namespace Enable
+{
+  bool TrackingService = false;
+  bool TrackingService_ABSORBER = false;
+  bool TrackingService_OVERLAPCHECK = false;
+  int TrackingService_VERBOSITY = 0;
+
+}  // namespace Enable
+
+namespace G4TrackingService
+{ //List materials and radiation length in cm
+  const int nMaterials = 2;
+  pair<string, double> materials[nMaterials] = { make_pair("G4_Al",  8.897)
+                                               , make_pair("PEEK", 30.00) };
+  
+  double GlobalOffset = -15.0;
+  double ShellThickness = 0.436; //Thickness in cm
+  double LayerThickness = 0.1; //
+  double ShellLength = 121.24; //Length of cylinder in cm
+  int subsysID = 0;
+}  // namespace G4TrackingService
+
+vector<double> get_thickness(ServiceProperties *object)
+{
+  vector<double> thickness = {(object->get_rad_len_aluminum()/100)*G4TrackingService::materials[0].second
+                             ,(object->get_rad_len_carbon()/100)*G4TrackingService::materials[1].second};
+  return thickness;
+}
+
+void TrackingServiceInit()
+{
+}
+
+double TrackingServiceCone(ServiceProperties *object, PHG4Reco* g4Reco, double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
+  int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
+
+  PHG4ConeSubsystem* cone;
+
+  double innerRadiusSouth = object->get_r_south();
+  double innerRadiusNorth = object->get_r_north();
+  double length = abs(object->get_z_north() - object->get_z_south());
+  vector<double> thickness = get_thickness(object);
+
+  for (int i = 0; i < G4TrackingService::nMaterials; ++i)
+  {
+    if (thickness[i] == 0) continue;
+    cone = new PHG4ConeSubsystem(object->get_name(), G4TrackingService::subsysID);
+    cone->Verbosity(verbosity);
+    cone->SetR1(innerRadiusSouth, innerRadiusSouth + thickness[i]);
+    cone->SetR2(innerRadiusNorth, innerRadiusNorth + thickness[i]);
+    cone->SetPlaceZ(object->get_z_south() + length/2 + G4TrackingService::GlobalOffset);
+    cone->SetZlength(length/2);
+    cone->SetMaterial(G4TrackingService::materials[i].first);
+    cone->SuperDetector("TrackingService");
+    if (AbsorberActive) cone->SetActive();
+    cone->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cone);
+    ++G4TrackingService::subsysID;
+    innerRadiusSouth += thickness[i];
+    innerRadiusNorth += thickness[i];
+  }
+  radius = max(innerRadiusSouth, innerRadiusNorth);
+
+  return radius;
+}
+
+double TrackingServiceCylinder(ServiceProperties *object, PHG4Reco* g4Reco, double radius)
+{
+  bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
+  int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
+
+  PHG4CylinderSubsystem* cyl;
+
+  double innerRadius = object->get_r_south();
+  double length = abs(object->get_z_north() - object->get_z_south());
+  vector<double> thickness = get_thickness(object);
+
+  for (int i = 0; i < G4TrackingService::nMaterials; ++i)
+  {
+    if (thickness[i] == 0) continue;
+    cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
+    cyl->Verbosity(verbosity);
+    cyl->set_double_param("place_z", object->get_z_south() + length/2 + G4TrackingService::GlobalOffset);
+    cyl->set_double_param("radius", innerRadius);
+    cyl->set_double_param("length", length);
+    cyl->set_string_param("material", G4TrackingService::materials[i].first);
+    cyl->set_double_param("thickness", thickness[i]);
+    cyl->SuperDetector("TrackingService");
+    if (AbsorberActive) cyl->SetActive();
+    cyl->OverlapCheck(OverlapCheck);
+    g4Reco->registerSubsystem(cyl);
+    ++G4TrackingService::subsysID;
+    innerRadius += thickness[i];
+  }
+  radius = innerRadius;
+
+  return radius;
+}
+
+double TrackingService(PHG4Reco* g4Reco, double radius)
+{
+  vector<ServiceProperties*> cylinders, cones;
+
+  double shellX0 = 100*G4TrackingService::ShellThickness/G4TrackingService::materials[4].second;
+  double layerX0 = 100*G4TrackingService::LayerThickness/G4TrackingService::materials[4].second;
+  double shellOffset = 18.679;
+
+  cylinders.push_back(new ServiceProperties("MVTXServiceBarrel", 0, shellX0, -1.*(G4TrackingService::ShellLength + shellOffset), -1.*shellOffset , 10.33, 0));
+
+  cylinders.push_back(new ServiceProperties("L0_1", 0, layerX0, -18.680, -16.579, 5.050, 0));
+  cones.push_back(new ServiceProperties("L0_2", 0, layerX0, -16.579, -9.186, 5.050, 2.997));
+  cylinders.push_back(new ServiceProperties("L0_3", 0, layerX0, -9.186, 0, 2.997, 0));
+
+  cylinders.push_back(new ServiceProperties("L1_1", 0, layerX0, -17.970, -15.851, 7.338, 0));
+  cones.push_back(new ServiceProperties("L1_2", 9/16, 0, 0.42/16, 0.32/16, layerX0, -15.851, -8.938, 7.338, 3.799));
+  cylinders.push_back(new ServiceProperties("L1_3", 9/16, 0, 0.42/16, 0.32/16, layerX0, -8.938, 0, 3.799, 0));
+
+  cylinders.push_back(new ServiceProperties("L2_1", 0, layerX0, -22.300, -15.206, 9.650, 0));
+  cones.push_back(new ServiceProperties("L2_2", 0, layerX0, -15.206, -8.538, 9.650, 4.574));
+  cylinders.push_back(new ServiceProperties("L2_3", 0, layerX0, -8.538, 0, 4.574, 0));
+  
+
+  for (ServiceProperties *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius); 
+  for (ServiceProperties *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
+
+  return radius;
+}
+
+#endif

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -13,6 +13,10 @@
 #include <fun4all/Fun4AllServer.h>
 
 #include <cmath>
+#include <format>
+#include <iostream>
+#include <string>
+#include <string_view>
 #include <vector>
 
 //sPHENIX Tracking Services
@@ -21,56 +25,57 @@ using namespace std;
 
 class ServiceStructure
 {
-  public:
-   ServiceStructure();
+ public:
+  ServiceStructure();
 
-    explicit ServiceStructure(const string &name,
-                              const double &rad_len_aluminum,
-                              const double &rad_len_carbon,
-                              const double &zSouth,
-                              const double &zNorth,
-                              const double &rSouth,
-                              const double &rNorth);
+  explicit ServiceStructure(const string &name,
+                            const double &thickness_aluminum,
+                            const double &thickness_carbon,
+                            const double &zSouth,
+                            const double &zNorth,
+                            const double &rSouth,
+                            const double &rNorth);
 
-    virtual ~ServiceStructure(){};
+  virtual ~ServiceStructure(){};
 
-    const string get_name();
-    const double get_rad_len_aluminum();
-    const double get_rad_len_carbon();
-    const double get_zSouth();
-    const double get_zNorth();
-    const double get_rSouth();
-    const double get_rNorth();
-  
-  private:
-    const string m_name = "service";
-    const double m_rad_len_aluminum = 0.0;
-    const double m_rad_len_carbon = 0.0;
-    const double m_zSouth = 0.0;
-    const double m_zNorth = 0.0;
-    const double m_rSouth = 0.0;
-    const double m_rNorth = 0.0;
+  const string get_name();
+  const double get_thickness_aluminum();
+  const double get_thickness_carbon();
+  const double get_zSouth();
+  const double get_zNorth();
+  const double get_rSouth();
+  const double get_rNorth();
+
+ private:
+  const string m_name = "service";
+  const double m_thickness_aluminum = 0.0;
+  const double m_thickness_carbon = 0.0;
+  const double m_zSouth = 0.0;
+  const double m_zNorth = 0.0;
+  const double m_rSouth = 0.0;
+  const double m_rNorth = 0.0;
 };
 
 ServiceStructure::ServiceStructure(const string &name,
-                                   const double &rad_len_aluminum,
-                                   const double &rad_len_carbon,
+                                   const double &thickness_aluminum,
+                                   const double &thickness_carbon,
                                    const double &zSouth,
                                    const double &zNorth,
                                    const double &rSouth,
                                    const double &rNorth)
   : m_name(name)
-  , m_rad_len_aluminum(rad_len_aluminum)
-  , m_rad_len_carbon(rad_len_carbon)
+  , m_thickness_aluminum(thickness_aluminum)
+  , m_thickness_carbon(thickness_carbon)
   , m_zSouth(zSouth)
   , m_zNorth(zNorth)
   , m_rSouth(rSouth)
   , m_rNorth(rNorth)
-{}
+{
+}
 
 const string ServiceStructure::get_name() { return m_name; }
-const double ServiceStructure::get_rad_len_aluminum() { return m_rad_len_aluminum; }
-const double ServiceStructure::get_rad_len_carbon() { return m_rad_len_carbon; }
+const double ServiceStructure::get_thickness_aluminum() { return m_thickness_aluminum; }
+const double ServiceStructure::get_thickness_carbon() { return m_thickness_carbon; }
 const double ServiceStructure::get_zSouth() { return m_zSouth; }
 const double ServiceStructure::get_zNorth() { return m_zNorth; }
 const double ServiceStructure::get_rSouth() { return m_rSouth; }
@@ -78,41 +83,41 @@ const double ServiceStructure::get_rNorth() { return m_rNorth; }
 
 class Cable
 {
-  public:
-    Cable();
+ public:
+  Cable();
 
-    explicit Cable(const string &name,
-                   const string &coreMaterial,
-                   const double &coreRadius,
-                   const double &sheathRadius,
-                   const double &xSouth, const double &xNorth,
-                   const double &ySouth, const double &yNorth,
-                   const double &zSouth, const double &zNorth);
+  explicit Cable(const string &name,
+                 const string &coreMaterial,
+                 const double &coreRadius,
+                 const double &sheathRadius,
+                 const double &xSouth, const double &xNorth,
+                 const double &ySouth, const double &yNorth,
+                 const double &zSouth, const double &zNorth);
 
-    virtual ~Cable(){};
+  virtual ~Cable(){};
 
-    const string get_name();
-    const string get_coreMaterial();
-    const double get_coreRadius();
-    const double get_sheathRadius();
-    const double get_xSouth();
-    const double get_xNorth();
-    const double get_ySouth();
-    const double get_yNorth();
-    const double get_zSouth();
-    const double get_zNorth();
-  
-  private:
-    const string m_name = "cable";
-    const string m_coreMaterial = "G4_Cu";
-    const double m_coreRadius = 1;
-    const double m_sheathRadius = 2;
-    const double m_xSouth = 0.;
-    const double m_xNorth = 1.;
-    const double m_ySouth = 0.;
-    const double m_yNorth = 1.;
-    const double m_zSouth = 0.;
-    const double m_zNorth = 1.;
+  const string get_name();
+  const string get_coreMaterial();
+  const double get_coreRadius();
+  const double get_sheathRadius();
+  const double get_xSouth();
+  const double get_xNorth();
+  const double get_ySouth();
+  const double get_yNorth();
+  const double get_zSouth();
+  const double get_zNorth();
+
+ private:
+  const string m_name = "cable";
+  const string m_coreMaterial = "G4_Cu";
+  const double m_coreRadius = 1;
+  const double m_sheathRadius = 2;
+  const double m_xSouth = 0.;
+  const double m_xNorth = 1.;
+  const double m_ySouth = 0.;
+  const double m_yNorth = 1.;
+  const double m_zSouth = 0.;
+  const double m_zNorth = 1.;
 };
 
 Cable::Cable(const string &name,
@@ -132,7 +137,8 @@ Cable::Cable(const string &name,
   , m_yNorth(yNorth)
   , m_zSouth(zSouth)
   , m_zNorth(zNorth)
-{}
+{
+}
 
 const string Cable::get_name() { return m_name; }
 const string Cable::get_coreMaterial() { return m_coreMaterial; }
@@ -155,22 +161,20 @@ namespace Enable
 }  // namespace Enable
 
 namespace G4TrackingService
-{ //List materials and radiation length in cm
+{  //List materials and radiation length in cm
   const int nMaterials = 2;
-  pair<string, double> materials[nMaterials] = { make_pair("G4_Al",  8.897)
-                                               , make_pair("PEEK", 30.00) };
-  
+  string materials[nMaterials] = {"G4_Al", "PEEK"};
+
   double GlobalOffset = -15.0;
-  double ShellThickness = 0.436; //Thickness in cm
-  double LayerThickness = 0.1; //
-  double ShellLength = 121.24; //Length of cylinder in cm
+  double ShellThickness = 0.436;  //Thickness in cm
+  double LayerThickness = 0.1;    //
+  double ShellLength = 121.24;    //Length of cylinder in cm
   int subsysID = 0;
 }  // namespace G4TrackingService
 
 vector<double> get_thickness(ServiceStructure *object)
 {
-  vector<double> thickness = {(object->get_rad_len_aluminum()/100)*G4TrackingService::materials[0].second
-                             ,(object->get_rad_len_carbon()/100)*G4TrackingService::materials[1].second};
+  vector<double> thickness = {object->get_thickness_aluminum(), object->get_thickness_carbon()};
   return thickness;
 }
 
@@ -178,13 +182,13 @@ void TrackingServiceInit()
 {
 }
 
-double TrackingServiceCone(ServiceStructure *object, PHG4Reco* g4Reco, double radius)
+double TrackingServiceCone(ServiceStructure *object, PHG4Reco *g4Reco, double radius)
 {
   bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
   int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
 
-  PHG4ConeSubsystem* cone;
+  PHG4ConeSubsystem *cone;
 
   double innerRadiusSouth = object->get_rSouth();
   double innerRadiusNorth = object->get_rNorth();
@@ -198,9 +202,9 @@ double TrackingServiceCone(ServiceStructure *object, PHG4Reco* g4Reco, double ra
     cone->Verbosity(verbosity);
     cone->SetR1(innerRadiusSouth, innerRadiusSouth + thickness[i]);
     cone->SetR2(innerRadiusNorth, innerRadiusNorth + thickness[i]);
-    cone->SetPlaceZ(object->get_zSouth() + length/2 + G4TrackingService::GlobalOffset);
-    cone->SetZlength(length/2);
-    cone->SetMaterial(G4TrackingService::materials[i].first);
+    cone->SetPlaceZ(object->get_zSouth() + length / 2 + G4TrackingService::GlobalOffset);
+    cone->SetZlength(length / 2);
+    cone->SetMaterial(G4TrackingService::materials[i]);
     cone->SuperDetector("TrackingService");
     if (AbsorberActive) cone->SetActive();
     cone->OverlapCheck(OverlapCheck);
@@ -214,13 +218,13 @@ double TrackingServiceCone(ServiceStructure *object, PHG4Reco* g4Reco, double ra
   return radius;
 }
 
-double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco* g4Reco, double radius)
+double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco *g4Reco, double radius)
 {
   bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
   int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
 
-  PHG4CylinderSubsystem* cyl;
+  PHG4CylinderSubsystem *cyl;
 
   double innerRadius = object->get_rSouth();
   double length = abs(object->get_zNorth() - object->get_zSouth());
@@ -231,10 +235,10 @@ double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco* g4Reco, doubl
     if (thickness[i] == 0) continue;
     cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
     cyl->Verbosity(verbosity);
-    cyl->set_double_param("place_z", object->get_zSouth() + length/2 + G4TrackingService::GlobalOffset);
+    cyl->set_double_param("place_z", object->get_zSouth() + length / 2 + G4TrackingService::GlobalOffset);
     cyl->set_double_param("radius", innerRadius);
     cyl->set_double_param("length", length);
-    cyl->set_string_param("material", G4TrackingService::materials[i].first);
+    cyl->set_string_param("material", G4TrackingService::materials[i]);
     cyl->set_double_param("thickness", thickness[i]);
     cyl->SuperDetector("TrackingService");
     if (AbsorberActive) cyl->SetActive();
@@ -248,27 +252,27 @@ double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco* g4Reco, doubl
   return radius;
 }
 
-double CreateCable(Cable *object, PHG4Reco* g4Reco, double radius)
+double CreateCable(Cable *object, PHG4Reco *g4Reco, double radius)
 {
   bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
   int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
 
-  string cableMaterials[2] = { object->get_coreMaterial(), "G4_POLYETHYLENE" };
-  double IR[2] = { 0, object->get_coreRadius() };
-  double OR[2] = { object->get_coreRadius(), object->get_sheathRadius() };
+  string cableMaterials[2] = {object->get_coreMaterial(), "G4_POLYETHYLENE"};
+  double IR[2] = {0, object->get_coreRadius()};
+  double OR[2] = {object->get_coreRadius(), object->get_sheathRadius()};
 
   double length = abs(object->get_zNorth() - object->get_zSouth());
-  double setX = (object->get_xSouth() + object->get_xNorth())/2;
-  double setY = (object->get_ySouth() + object->get_yNorth())/2;
-  double setZ = (object->get_zSouth() + object->get_zNorth())/2;
-  
-  double radToDeg = 180.0/M_PI;
-  double rotX = tan((object->get_yNorth() - object->get_ySouth())/(object->get_zNorth() - object->get_zSouth()))*radToDeg;
-  double rotY = tan((object->get_xNorth() - object->get_xSouth())/(object->get_zNorth() - object->get_zSouth()))*radToDeg;
-  double rotZ = tan((object->get_xNorth() - object->get_xSouth())/(object->get_yNorth() - object->get_ySouth()))*radToDeg;
-  
-  PHG4CylinderSubsystem* cyl;
+  double setX = (object->get_xSouth() + object->get_xNorth()) / 2;
+  double setY = (object->get_ySouth() + object->get_yNorth()) / 2;
+  double setZ = (object->get_zSouth() + object->get_zNorth()) / 2;
+
+  double radToDeg = 180.0 / M_PI;
+  double rotX = tan((object->get_yNorth() - object->get_ySouth()) / (object->get_zNorth() - object->get_zSouth())) * radToDeg;
+  double rotY = tan((object->get_xNorth() - object->get_xSouth()) / (object->get_zNorth() - object->get_zSouth())) * radToDeg;
+  double rotZ = tan((object->get_xNorth() - object->get_xSouth()) / (object->get_yNorth() - object->get_ySouth())) * radToDeg;
+
+  PHG4CylinderSubsystem *cyl;
   for (int i = 0; i < 2; ++i)
   {
     cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
@@ -292,77 +296,129 @@ double CreateCable(Cable *object, PHG4Reco* g4Reco, double radius)
   return OR[1];
 }
 
-double CreateCableBundle(string superName, PHG4Reco* g4Reco, double radius, 
+double CreateCableBundle(string superName, PHG4Reco *g4Reco, double radius,
+                         bool enableSignal, bool enableCooling, bool enablePower,
                          double x1, double x2, double y1, double y2, double z1, double z2)
 {
   //Set up basic MVTX cable bundle (24 Samtec cables, 1 power cable, 2 cooling cables)
   double samtecCoreRadius = 0.1275;
   double samtecSheathRadius = 0.05;
   double coolingCoreRadius = 0.056;
-  double coolingSheathRadius = 0.08; //?
-
+  double coolingSheathRadius = 0.08;  //?
+  double powerLargeCoreRadius = 0.069;
+  double powerLargeSheathRadius = 0.158;
+  double powerMediumCoreRadius = 0.033;
+  double powerMediumSheathRadius = 0.073;
+  double powerSmallCoreRadius = 0.028;
+  double powerSmallSheathRadius = 0.028;
 
   //Samtec cables (we use 24 as there are 12 twinax)
-  unsigned int nSamtecWires = 24;
-  unsigned int nRows = 2;
-  unsigned int nCols = nSamtecWires/nRows;
-  for (unsigned int iRow = 0; iRow < 2; ++iRow)
+  if (enableSignal)
   {
-    for (unsigned int iCol = 0; iCol < 12; ++ iCol)
+    unsigned int nSamtecWires = 24;
+    unsigned int nRow = 2;
+    unsigned int nCol = nSamtecWires / nRow;
+    for (unsigned int iRow = 0; iRow < nRow; ++iRow)
     {
-      Cable *cable = new Cable(format("{}_samtec_{}_{}", superName, iRow, iCol), "G4_Cu", samtecCoreRadius, samtecSheathRadius, 
-                               x1 + -1*(iCol + 1)*samtecSheathRadius, x2 + -1*(iCol + 1)*samtecSheathRadius,
-                               y1 + -1*(iRow + 1)*samtecSheathRadius, y2 + -1*(iRow + 1)*samtecSheathRadius,
+      for (unsigned int iCol = 0; iCol < nCol; ++iCol)
+      {
+        Cable *cable = new Cable(format("{}_samtec_{}_{}", superName, iRow, iCol), "G4_Cu", samtecCoreRadius, samtecSheathRadius,
+                                 x1 + (iCol + 1) * samtecSheathRadius * 2, x2 + (iCol + 1) * samtecSheathRadius * 2,
+                                 y1 + -1 * (iRow + 1) * samtecSheathRadius * 2, y2 + -1 * (iRow + 1) * samtecSheathRadius * 2,
+                                 z1, z2);
+        radius += CreateCable(cable, g4Reco, radius);
+      }
+    }
+  }
+
+  //Cooling Cables
+  if (enableCooling)
+  {
+    unsigned int nCool = 2;
+    for (unsigned int iCool = 0; iCool < nCool; ++iCool)
+    {
+      Cable *cable = new Cable(format("{}_cooling_{}", superName, iCool), "G4_WATER", coolingCoreRadius, coolingSheathRadius,
+                               x1 + (iCool + 1) * coolingSheathRadius * 2, x2 + (iCool + 1) * coolingSheathRadius * 2,
+                               y1 + (iCool + 1) * coolingSheathRadius * 2, y2 + (iCool + 1) * coolingSheathRadius * 2,
                                z1, z2);
       radius += CreateCable(cable, g4Reco, radius);
     }
   }
 
-  //Cooling Cables
-  unsigned int nCool = 2;
-  for (unsigned int iCool = 0; iCool < nCool; ++iCool)
-  {
-    Cable *cable = new Cable(format("{}_cooling_{}", superName, iCool), "G4_WATER", coolingCoreRadius, coolingSheathRadius, 
-                             x1 + (iCool + 1)*coolingSheathRadius, x2 + (iCool + 1)*coolingSheathRadius,
-                             y1 + (iCool + 1)*coolingSheathRadius, y2 + (iCool + 1)*coolingSheathRadius,
-                             z1, z2);
-    radius += CreateCable(cable, g4Reco, radius);
-  }
-
   //Power Cables
+  if (enablePower)
+  {
+    typedef pair < pair<string, string>, pair<double, double> PowerCableParameters;
+    vector<PowerCableParameters> powerCables;
+
+    powerCables.push_back(make_pair(make_pair(format("{}_digiReturn", superName), "Large"), make_pair(-1 * powerLargeSheathRadius, -1 * powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_digiSupply", superName), "Large"), make_pair(-3 * powerLargeSheathRadius, powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_anaReturn", superName), "Medium"), make_pair(-1 * (powerMediumSheathRadius + 2 * powerLargeSheathRadius), -2 * powerMediumSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_anaSupply", superName), "Medium"), make_pair(-1 * (3 * powerMediumSheathRadius + 2 * powerLargeSheathRadius), -1 * powerMediumSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_digiSense", superName), "Small"), make_pair(-1 * (2 * powerMediumSheathRadius + 4 * powerLargeSheathRadius), powerSmallSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_anaSense", superName), "Small"), make_pair(-4 * powerLargeSheathRadius, 2 * powerSmallSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_bias", superName), "Small"), make_pair(-2 * powerLargeSheathRadius, powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(format("{}_ground", superName), "Small"), make_pair(-1 * powerLargeSheathRadius, powerSmallSheathRadius)));
+
+    for (PowerCableParameters &powerCable : powerCables)
+    {
+      double coreRad, sheathRad;
+      string cableType = powerCable.first.second;
+      switch (cableType)
+      {
+      case "Small":
+        coreRad = powerSmallCoreRadius;
+        sheathRad = powerSmallSheathRadius;
+        break;
+      case "Medium":
+        coreRad = powerMediumCoreRadius;
+        sheathRad = powerMediumSheathRadius;
+        break;
+      case "Large":
+        coreRad = powerLargeCoreRadius;
+        sheathRad = powerLargeSheathRadius;
+        break;
+      default:
+        coreRad = powerSmallCoreRadius;
+        sheathRad = powerSmallSheathRadius;
+      }
+
+      Cable *cable = new Cable(powerCable.first.first, "G4_Cu", coreRad, sheathRad,
+                               x1 + powerCable.second.first, x2 + powerCable.second.first,
+                               y1 + powerCable.second.second, y2 + powerCable.second.second, z1, z2);
+
+      radius += CreateCable(cable, g4Reco, radius);
+    }
+  }
   return radius;
 }
 
-double TrackingService(PHG4Reco* g4Reco, double radius)
+double TrackingService(PHG4Reco *g4Reco, double radius)
 {
-  vector<ServiceStructure*> cylinders, cones;
+  vector<ServiceStructure *> cylinders, cones;
 
-  double shellX0 = 100*G4TrackingService::ShellThickness/G4TrackingService::materials[1].second;
-  double layerX0 = 100*G4TrackingService::LayerThickness/G4TrackingService::materials[1].second;
   double shellOffset = 18.679;
 
-  cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0, shellX0, -1.*(G4TrackingService::ShellLength + shellOffset), -1.*shellOffset , 10.33, 0));
+  cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0, G4TrackingService::ShellThickness, -1. * (G4TrackingService::ShellLength + shellOffset), -1. * shellOffset, 10.33, 0));
 
-  cylinders.push_back(new ServiceStructure("L0_1", 0, layerX0, -18.680, -16.579, 5.050, 0));
-  cones.push_back(new ServiceStructure("L0_2", 0, layerX0, -16.579, -9.186, 5.050, 2.997));
-  cylinders.push_back(new ServiceStructure("L0_3", 0, layerX0, -9.186, 0, 2.997, 0));
+  cylinders.push_back(new ServiceStructure("L0_1", 0, G4TrackingService::LayerThickness, -18.680, -16.579, 5.050, 0));
+  cones.push_back(new ServiceStructure("L0_2", 0, G4TrackingService::LayerThickness, -16.579, -9.186, 5.050, 2.997));
+  cylinders.push_back(new ServiceStructure("L0_3", 0, G4TrackingService::LayerThickness, -9.186, 0, 2.997, 0));
 
-  cylinders.push_back(new ServiceStructure("L1_1", 0, layerX0, -17.970, -15.851, 7.338, 0));
-  cones.push_back(new ServiceStructure("L1_2", 0, layerX0, -15.851, -8.938, 7.338, 3.799));
-  cylinders.push_back(new ServiceStructure("L1_3", 0, layerX0, -8.938, 0, 3.799, 0));
+  cylinders.push_back(new ServiceStructure("L1_1", 0, G4TrackingService::LayerThickness, -17.970, -15.851, 7.338, 0));
+  cones.push_back(new ServiceStructure("L1_2", 0, G4TrackingService::LayerThickness, -15.851, -8.938, 7.338, 3.799));
+  cylinders.push_back(new ServiceStructure("L1_3", 0, G4TrackingService::LayerThickness, -8.938, 0, 3.799, 0));
 
-  cylinders.push_back(new ServiceStructure("L2_1", 0, layerX0, -22.300, -15.206, 9.650, 0));
-  cones.push_back(new ServiceStructure("L2_2", 0, layerX0, -15.206, -8.538, 9.650, 4.574));
-  cylinders.push_back(new ServiceStructure("L2_3", 0, layerX0, -8.538, 0, 4.574, 0));
-  
+  cylinders.push_back(new ServiceStructure("L2_1", 0, G4TrackingService::LayerThickness, -22.300, -15.206, 9.650, 0));
+  cones.push_back(new ServiceStructure("L2_2", 0, G4TrackingService::LayerThickness, -15.206, -8.538, 9.650, 4.574));
+  cylinders.push_back(new ServiceStructure("L2_3", 0, G4TrackingService::LayerThickness, -8.538, 0, 4.574, 0));
 
-  //for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius); 
+  //for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius);
   //for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
 
-  radius += CreateCableBundle("Test", g4Reco, radius, 0, 0, 0, 0, 0, 10);
+  radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, 0, 0, 0, 0, 0, 100);
 
   return radius;
 }
 
 #endif
-

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -12,11 +12,10 @@
 
 #include <fun4all/Fun4AllServer.h>
 
+#include <boost/format.hpp>
 #include <cmath>
-#include <format>
 #include <iostream>
 #include <string>
-#include <string_view>
 #include <vector>
 
 //sPHENIX Tracking Services
@@ -322,7 +321,7 @@ double CreateCableBundle(string superName, PHG4Reco *g4Reco, double radius,
     {
       for (unsigned int iCol = 0; iCol < nCol; ++iCol)
       {
-        Cable *cable = new Cable(format("{}_samtec_{}_{}", superName, iRow, iCol), "G4_Cu", samtecCoreRadius, samtecSheathRadius,
+        Cable *cable = new Cable(boost::format("%1%_samtec_%2%_%3%") % superName % iRow % iCol, "G4_Cu", samtecCoreRadius, samtecSheathRadius,
                                  x1 + (iCol + 1) * samtecSheathRadius * 2, x2 + (iCol + 1) * samtecSheathRadius * 2,
                                  y1 + -1 * (iRow + 1) * samtecSheathRadius * 2, y2 + -1 * (iRow + 1) * samtecSheathRadius * 2,
                                  z1, z2);
@@ -337,7 +336,7 @@ double CreateCableBundle(string superName, PHG4Reco *g4Reco, double radius,
     unsigned int nCool = 2;
     for (unsigned int iCool = 0; iCool < nCool; ++iCool)
     {
-      Cable *cable = new Cable(format("{}_cooling_{}", superName, iCool), "G4_WATER", coolingCoreRadius, coolingSheathRadius,
+      Cable *cable = new Cable(boost::format("%1%_cooling_%2%") % superName % iCool, "G4_WATER", coolingCoreRadius, coolingSheathRadius,
                                x1 + (iCool + 1) * coolingSheathRadius * 2, x2 + (iCool + 1) * coolingSheathRadius * 2,
                                y1 + (iCool + 1) * coolingSheathRadius * 2, y2 + (iCool + 1) * coolingSheathRadius * 2,
                                z1, z2);
@@ -351,14 +350,14 @@ double CreateCableBundle(string superName, PHG4Reco *g4Reco, double radius,
     typedef pair < pair<string, string>, pair<double, double> PowerCableParameters;
     vector<PowerCableParameters> powerCables;
 
-    powerCables.push_back(make_pair(make_pair(format("{}_digiReturn", superName), "Large"), make_pair(-1 * powerLargeSheathRadius, -1 * powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_digiSupply", superName), "Large"), make_pair(-3 * powerLargeSheathRadius, powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_anaReturn", superName), "Medium"), make_pair(-1 * (powerMediumSheathRadius + 2 * powerLargeSheathRadius), -2 * powerMediumSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_anaSupply", superName), "Medium"), make_pair(-1 * (3 * powerMediumSheathRadius + 2 * powerLargeSheathRadius), -1 * powerMediumSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_digiSense", superName), "Small"), make_pair(-1 * (2 * powerMediumSheathRadius + 4 * powerLargeSheathRadius), powerSmallSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_anaSense", superName), "Small"), make_pair(-4 * powerLargeSheathRadius, 2 * powerSmallSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_bias", superName), "Small"), make_pair(-2 * powerLargeSheathRadius, powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(format("{}_ground", superName), "Small"), make_pair(-1 * powerLargeSheathRadius, powerSmallSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_digiReturn") % superName, "Large"), make_pair(-1 * powerLargeSheathRadius, -1 * powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_digiSupply") % superName, "Large"), make_pair(-3 * powerLargeSheathRadius, powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_anaReturn") % superName, "Medium"), make_pair(-1 * (powerMediumSheathRadius + 2 * powerLargeSheathRadius), -2 * powerMediumSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_anaSupply") % superName, "Medium"), make_pair(-1 * (3 * powerMediumSheathRadius + 2 * powerLargeSheathRadius), -1 * powerMediumSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_digiSense", superName, "Small"), make_pair(-1 * (2 * powerMediumSheathRadius + 4 * powerLargeSheathRadius), powerSmallSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_anaSense") % superName, "Small"), make_pair(-4 * powerLargeSheathRadius, 2 * powerSmallSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_bias") % superName, "Small"), make_pair(-2 * powerLargeSheathRadius, powerLargeSheathRadius)));
+    powerCables.push_back(make_pair(make_pair(boost::format("%1%_ground") % superName, "Small"), make_pair(-1 * powerLargeSheathRadius, powerSmallSheathRadius)));
 
     for (PowerCableParameters &powerCable : powerCables)
     {

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -426,8 +426,8 @@ double TrackingService(PHG4Reco *g4Reco, double radius)
   {
     double theta = 360.*i/nSets;
     double r = G4TrackingService::BarrelRadius - 1.;
-    radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta),  -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), -1. * G4TrackingService::BarrelOffset - 5., theta);
-    radius += CreateCableBundle("Test2", g4Reco, radius, true, true, true, r*cos(theta), (r-4)*cos(theta), r*sin(theta), (r-4)*sin(theta), -1. * G4TrackingService::BarrelOffset - 5, -1. * G4TrackingService::BarrelOffset, theta);
+    radius += CreateCableBundle(Form("Test_%d", i), g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta),  -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), -1. * G4TrackingService::BarrelOffset - 5., theta);
+    radius += CreateCableBundle(Form("Test2_%d", i), g4Reco, radius, true, true, true, r*cos(theta), (r-4)*cos(theta), r*sin(theta), (r-4)*sin(theta), -1. * G4TrackingService::BarrelOffset - 5, -1. * G4TrackingService::BarrelOffset, theta);
   }
 
   return radius;

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -28,7 +28,9 @@ class ServiceStructure
   ServiceStructure();
 
   explicit ServiceStructure(const string &name,
-                            const double &thickness_aluminum,
+                            const double &thickness_copper,
+                            const double &thickness_water,
+                            const double &thickness_plastic,
                             const double &thickness_carbon,
                             const double &zSouth,
                             const double &zNorth,
@@ -38,7 +40,9 @@ class ServiceStructure
   virtual ~ServiceStructure(){};
 
   const string get_name();
-  const double get_thickness_aluminum();
+  const double get_thickness_copper();
+  const double get_thickness_water();
+  const double get_thickness_plastic();
   const double get_thickness_carbon();
   const double get_zSouth();
   const double get_zNorth();
@@ -47,7 +51,9 @@ class ServiceStructure
 
  private:
   const string m_name = "service";
-  const double m_thickness_aluminum = 0.0;
+  const double m_thickness_copper = 0.0;
+  const double m_thickness_water = 0.0;
+  const double m_thickness_plastic = 0.0;
   const double m_thickness_carbon = 0.0;
   const double m_zSouth = 0.0;
   const double m_zNorth = 0.0;
@@ -56,14 +62,18 @@ class ServiceStructure
 };
 
 ServiceStructure::ServiceStructure(const string &name,
-                                   const double &thickness_aluminum,
+                                   const double &thickness_copper,
+                                   const double &thickness_water,
+                                   const double &thickness_plastic,
                                    const double &thickness_carbon,
                                    const double &zSouth,
                                    const double &zNorth,
                                    const double &rSouth,
                                    const double &rNorth)
   : m_name(name)
-  , m_thickness_aluminum(thickness_aluminum)
+  , m_thickness_copper(thickness_copper)
+  , m_thickness_water(thickness_water)
+  , m_thickness_plastic(thickness_plastic)
   , m_thickness_carbon(thickness_carbon)
   , m_zSouth(zSouth)
   , m_zNorth(zNorth)
@@ -73,82 +83,14 @@ ServiceStructure::ServiceStructure(const string &name,
 }
 
 const string ServiceStructure::get_name() { return m_name; }
-const double ServiceStructure::get_thickness_aluminum() { return m_thickness_aluminum; }
+const double ServiceStructure::get_thickness_copper() { return m_thickness_copper; }
+const double ServiceStructure::get_thickness_water() { return m_thickness_water; }
+const double ServiceStructure::get_thickness_plastic() { return m_thickness_plastic; }
 const double ServiceStructure::get_thickness_carbon() { return m_thickness_carbon; }
 const double ServiceStructure::get_zSouth() { return m_zSouth; }
 const double ServiceStructure::get_zNorth() { return m_zNorth; }
 const double ServiceStructure::get_rSouth() { return m_rSouth; }
 const double ServiceStructure::get_rNorth() { return m_rNorth; }
-
-class Cable
-{
- public:
-  Cable();
-
-  explicit Cable(const string &name,
-                 const string &coreMaterial,
-                 const double &coreRadius,
-                 const double &sheathRadius,
-                 const double &xSouth, const double &xNorth,
-                 const double &ySouth, const double &yNorth,
-                 const double &zSouth, const double &zNorth);
-
-  virtual ~Cable(){};
-
-  const string get_name();
-  const string get_coreMaterial();
-  const double get_coreRadius();
-  const double get_sheathRadius();
-  const double get_xSouth();
-  const double get_xNorth();
-  const double get_ySouth();
-  const double get_yNorth();
-  const double get_zSouth();
-  const double get_zNorth();
-
- private:
-  const string m_name = "cable";
-  const string m_coreMaterial = "G4_Cu";
-  const double m_coreRadius = 1;
-  const double m_sheathRadius = 2;
-  const double m_xSouth = 0.;
-  const double m_xNorth = 1.;
-  const double m_ySouth = 0.;
-  const double m_yNorth = 1.;
-  const double m_zSouth = 0.;
-  const double m_zNorth = 1.;
-};
-
-Cable::Cable(const string &name,
-             const string &coreMaterial,
-             const double &coreRadius,
-             const double &sheathRadius,
-             const double &xSouth, const double &xNorth,
-             const double &ySouth, const double &yNorth,
-             const double &zSouth, const double &zNorth)
-  : m_name(name)
-  , m_coreMaterial(coreMaterial)
-  , m_coreRadius(coreRadius)
-  , m_sheathRadius(sheathRadius)
-  , m_xSouth(xSouth)
-  , m_xNorth(xNorth)
-  , m_ySouth(ySouth)
-  , m_yNorth(yNorth)
-  , m_zSouth(zSouth)
-  , m_zNorth(zNorth)
-{
-}
-
-const string Cable::get_name() { return m_name; }
-const string Cable::get_coreMaterial() { return m_coreMaterial; }
-const double Cable::get_coreRadius() { return m_coreRadius; }
-const double Cable::get_sheathRadius() { return m_sheathRadius; }
-const double Cable::get_xSouth() { return m_xSouth; }
-const double Cable::get_xNorth() { return m_xNorth; }
-const double Cable::get_ySouth() { return m_ySouth; }
-const double Cable::get_yNorth() { return m_yNorth; }
-const double Cable::get_zSouth() { return m_zSouth; }
-const double Cable::get_zNorth() { return m_zNorth; }
 
 namespace Enable
 {
@@ -161,7 +103,7 @@ namespace Enable
 
 namespace G4TrackingService
 {  //List materials and radiation length in cm
-  string materials[] = {"G4_Al", "PEEK"};
+  string materials[] = {"G4_Cu", "G4_WATER", "G4_POLYETHYLENE", "PEEK"};
   const int nMaterials = sizeof(materials)/sizeof(materials[0]);
 
   double GlobalOffset = -15.0;
@@ -175,7 +117,10 @@ namespace G4TrackingService
 
 vector<double> get_thickness(ServiceStructure *object)
 {
-  vector<double> thickness = {object->get_thickness_aluminum(), object->get_thickness_carbon()};
+  vector<double> thickness = { object->get_thickness_copper()
+                             , object->get_thickness_water()
+                             , object->get_thickness_plastic()
+                             , object->get_thickness_carbon()};
   return thickness;
 }
 
@@ -259,175 +204,27 @@ double TrackingServiceCylinder(ServiceStructure *object, PHG4Reco *g4Reco, doubl
   return radius;
 }
 
-double CreateCable(Cable *object, PHG4Reco *g4Reco, double radius)
-{
-  bool AbsorberActive = Enable::ABSORBER || Enable::TrackingService_ABSORBER;
-  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TrackingService_OVERLAPCHECK;
-  int verbosity = max(Enable::VERBOSITY, Enable::TrackingService_VERBOSITY);
-
-  string cableMaterials[2] = {object->get_coreMaterial(), "G4_POLYETHYLENE"};
-  double IR[2] = {0, object->get_coreRadius()};
-  double OR[2] = {object->get_coreRadius(), object->get_sheathRadius()};
-
-  double length = abs(object->get_zNorth() - object->get_zSouth());
-  double setX = (object->get_xSouth() + object->get_xNorth()) / 2;
-  double setY = (object->get_ySouth() + object->get_yNorth()) / 2;
-  double setZ = (object->get_zSouth() + object->get_zNorth()) / 2 + G4TrackingService::GlobalOffset;
-
-  double radToDeg = 180.0 / M_PI;
-  double rotX = atan((object->get_yNorth() - object->get_ySouth()) / (object->get_zNorth() - object->get_zSouth())) * radToDeg;
-  double rotY = atan((object->get_xNorth() - object->get_xSouth()) / (object->get_zNorth() - object->get_zSouth())) * radToDeg;
-  double rotZ = atan((object->get_xNorth() - object->get_xSouth()) / (object->get_yNorth() - object->get_ySouth())) * radToDeg;
-
-  PHG4CylinderSubsystem *cyl;
-  for (int i = 0; i < 2; ++i)
-  {
-    cyl = new PHG4CylinderSubsystem(object->get_name(), G4TrackingService::subsysID);
-    cyl->Verbosity(verbosity);
-    cyl->set_string_param("material", cableMaterials[i]);
-    cyl->set_double_param("length", length);
-    cyl->set_double_param("radius", IR[i]);
-    cyl->set_double_param("thickness", OR[i]);
-    cyl->set_double_param("place_x", setX);
-    cyl->set_double_param("place_y", setY);
-    cyl->set_double_param("place_z", setZ);
-    cyl->set_double_param("rot_x", rotX);
-    cyl->set_double_param("rot_y", rotY);
-    cyl->set_double_param("rot_z", rotZ);
-    cyl->SuperDetector("TrackingCable");
-    if (AbsorberActive) cyl->SetActive();
-    cyl->OverlapCheck(OverlapCheck);
-    g4Reco->registerSubsystem(cyl);
-    ++G4TrackingService::subsysID;
-  }
-  return OR[1];
-}
-
-double CreateCableBundle(string superName, PHG4Reco *g4Reco, double radius,
-                         bool enableSignal, bool enableCooling, bool enablePower,
-                         double x1, double x2, double y1, double y2, double z1, double z2, double theta)
-{
-  //Set up basic MVTX cable bundle (24 Samtec cables, 1 power cable, 2 cooling cables)
-  double samtecCoreRadius = 0.01275;
-  double samtecSheathRadius = 0.05;
-  double coolingCoreRadius = 0.056;
-  double coolingSheathRadius = 0.08;  //?
-  double powerLargeCoreRadius = 0.069;
-  double powerLargeSheathRadius = 0.158;
-  double powerMediumCoreRadius = 0.033;
-  double powerMediumSheathRadius = 0.073;
-  double powerSmallCoreRadius = 0.028;
-  double powerSmallSheathRadius = 0.058;
-
-  //Samtec cables (we use 24 as there are 12 twinax)
-  if (enableSignal)
-  {
-    unsigned int nSamtecWires = 24;
-    unsigned int nRow = 2;
-    unsigned int nCol = nSamtecWires / nRow;
-    for (unsigned int iRow = 0; iRow < nRow; ++iRow)
-    {
-      for (unsigned int iCol = 0; iCol < nCol; ++iCol)
-      {
-        Cable *cable = new Cable(Form("%s_samtec_%d_%d", superName.c_str(), iRow, iCol), "G4_Cu", samtecCoreRadius, samtecSheathRadius,
-                                 (x1 + (iCol + 1) * samtecSheathRadius * 2)*cos(theta), (x2 + (iCol + 1) * samtecSheathRadius * 2)*cos(theta),
-                                 (y1 - (iRow + 1) * samtecSheathRadius * 2)*sin(theta), (y2 - (iRow + 1) * samtecSheathRadius * 2)*sin(theta),
-                                 z1, z2);
-        radius += CreateCable(cable, g4Reco, radius);
-      }
-    }
-  }
-
-  //Cooling Cables
-  if (enableCooling)
-  {
-    unsigned int nCool = 2;
-    for (unsigned int iCool = 0; iCool < nCool; ++iCool)
-    {
-      Cable *cable = new Cable(Form("%s_cooling_%d", superName.c_str(), iCool), "G4_WATER", coolingCoreRadius, coolingSheathRadius,
-                               (x1 + (iCool + 1) * coolingSheathRadius * 2)*cos(theta), (x2 + (iCool + 1) * coolingSheathRadius * 2)*cos(theta),
-                               (y1 + (iCool + 1) * coolingSheathRadius * 2)*sin(theta), (y2 + (iCool + 1) * coolingSheathRadius * 2)*sin(theta),
-                               z1, z2);
-      radius += CreateCable(cable, g4Reco, radius);
-    }
-  }
-
-  //Power Cables
-  if (enablePower)
-  {
-    typedef pair<pair<string, string>, pair<double, double>> PowerCableParameters;
-    vector<PowerCableParameters> powerCables;
-
-    powerCables.push_back(make_pair(make_pair(Form("%s_digiReturn", superName.c_str()), "Large"), make_pair(-1 * powerLargeSheathRadius, -1 * powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_digiSupply", superName.c_str()), "Large"), make_pair(-3 * powerLargeSheathRadius, powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_anaReturn", superName.c_str()), "Medium"), make_pair(-1 * (powerMediumSheathRadius + 2 * powerLargeSheathRadius), -2 * powerMediumSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_anaSupply", superName.c_str()), "Medium"), make_pair(-1 * (3 * powerMediumSheathRadius + 2 * powerLargeSheathRadius), -1 * powerMediumSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_digiSense", superName.c_str()), "Small"), make_pair(-1 * (2 * powerMediumSheathRadius + 4 * powerLargeSheathRadius), powerSmallSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_anaSense", superName.c_str()), "Small"), make_pair(-4 * powerLargeSheathRadius, 2 * powerSmallSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_bias", superName.c_str()), "Small"), make_pair(-2 * powerLargeSheathRadius, powerLargeSheathRadius)));
-    powerCables.push_back(make_pair(make_pair(Form("%s_ground", superName.c_str()), "Small"), make_pair(-1 * powerLargeSheathRadius, powerSmallSheathRadius)));
-
-    for (PowerCableParameters &powerCable : powerCables)
-    {
-      double coreRad, sheathRad;
-      string cableType = powerCable.first.second;
-      if (cableType == "Small")
-      {
-        coreRad = powerSmallCoreRadius;
-        sheathRad = powerSmallSheathRadius;
-      }
-      else if (cableType == "Medium")
-      {
-        coreRad = powerMediumCoreRadius;
-        sheathRad = powerMediumSheathRadius;
-      }
-      else
-      {
-        coreRad = powerLargeCoreRadius;
-        sheathRad = powerLargeSheathRadius;
-      }
-
-      Cable *cable = new Cable(powerCable.first.first, "G4_Cu", coreRad, sheathRad,
-                               (x1 + powerCable.second.first)*cos(theta), (x2 + powerCable.second.first)*cos(theta),
-                               (y1 + powerCable.second.second)*sin(theta), (y2 + powerCable.second.second)*sin(theta), z1, z2);
-
-      radius += CreateCable(cable, g4Reco, radius);
-    }
-  }
-
-  return radius;
-}
-
 double TrackingService(PHG4Reco *g4Reco, double radius)
 {
   vector<ServiceStructure *> cylinders, cones;
 
-  cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0, G4TrackingService::BarrelThickness, -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), 
+  cylinders.push_back(new ServiceStructure("MVTXServiceBarrel", 0.049946, 0.00724494, 0.313467, G4TrackingService::BarrelThickness, -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), 
                                            -1. * G4TrackingService::BarrelOffset, G4TrackingService::BarrelRadius, 0));
 
-  cylinders.push_back(new ServiceStructure("L0_1", 0, G4TrackingService::LayerThickness, -18.680, -16.579, 5.050, 0));
-  cones.push_back(new ServiceStructure("L0_2", 0, G4TrackingService::LayerThickness, -16.579, -9.186, 5.050, 2.997));
-  cylinders.push_back(new ServiceStructure("L0_3", 0, G4TrackingService::LayerThickness, -9.186, 0, 2.997, 0));
+  cylinders.push_back(new ServiceStructure("L0_1", 0.00463332, 0., 0.0662175, G4TrackingService::LayerThickness, -18.680, -16.579, 5.050, 0));
+  cones.push_back(new ServiceStructure("L0_2", 0.006, 0., 0.088, G4TrackingService::LayerThickness, -16.579, -9.186, 5.050, 2.997));
+  cylinders.push_back(new ServiceStructure("L0_3", 0.00780066, 0., 0.11028, G4TrackingService::LayerThickness, -9.186, 0, 2.997, 0));
 
-  cylinders.push_back(new ServiceStructure("L1_1", 0, G4TrackingService::LayerThickness, -17.970, -15.851, 7.338, 0));
-  cones.push_back(new ServiceStructure("L1_2", 0, G4TrackingService::LayerThickness, -15.851, -8.938, 7.338, 3.799));
-  cylinders.push_back(new ServiceStructure("L1_3", 0, G4TrackingService::LayerThickness, -8.938, 0, 3.799, 0));
+  cylinders.push_back(new ServiceStructure("L1_1", 0.00425224, 0., 0.0609067, G4TrackingService::LayerThickness, -17.970, -15.851, 7.338, 0));
+  cones.push_back(new ServiceStructure("L1_2", 0.006, 0., 0.085, G4TrackingService::LayerThickness, -15.851, -8.938, 7.338, 3.799));
+  cylinders.push_back(new ServiceStructure("L1_3", 0.00820698, 0., 0.116351, G4TrackingService::LayerThickness, -8.938, 0, 3.799, 0));
 
-  cylinders.push_back(new ServiceStructure("L2_1", 0, G4TrackingService::LayerThickness, -22.300, -15.206, 9.650, 0));
-  cones.push_back(new ServiceStructure("L2_2", 0, G4TrackingService::LayerThickness, -15.206, -8.538, 9.650, 4.574));
-  cylinders.push_back(new ServiceStructure("L2_3", 0, G4TrackingService::LayerThickness, -8.538, 0, 4.574, 0));
+  cylinders.push_back(new ServiceStructure("L2_1", 0.00404216, 0., 0.0579591, G4TrackingService::LayerThickness, -22.300, -15.206, 9.650, 0));
+  cones.push_back(new ServiceStructure("L2_2", 0.0062, 0., 0.09, G4TrackingService::LayerThickness, -15.206, -8.538, 9.650, 4.574));
+  cylinders.push_back(new ServiceStructure("L2_3", 0.0085218, 0., 0.121045, G4TrackingService::LayerThickness, -8.538, 0, 4.574, 0));
 
-  //for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius);
-  //for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
-
-  int nSets = 1;
-  for (unsigned int i = 0; i < nSets; ++i)
-  {
-    double theta = 360.*i/nSets;
-    double r = G4TrackingService::BarrelRadius - 1.;
-    //radius += CreateCableBundle(Form("Test_%d", i), g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta),  -1. * (G4TrackingService::BarrelLength + G4TrackingService::BarrelOffset), -1. * G4TrackingService::BarrelOffset - 5., theta);
-    radius += CreateCableBundle(Form("Test2_%d", i), g4Reco, radius, true, true, true, r*cos(theta), (r-4)*cos(theta), r*sin(theta), (r-4)*sin(theta), -1. * G4TrackingService::BarrelOffset - 5, -1. * G4TrackingService::BarrelOffset, theta);
-  }
+  for (ServiceStructure *cylinder : cylinders) radius += TrackingServiceCylinder(cylinder, g4Reco, radius);
+  for (ServiceStructure *cone : cones) radius += TrackingServiceCone(cone, g4Reco, radius);
 
   return radius;
 }

--- a/common/G4_TrackingService.C
+++ b/common/G4_TrackingService.C
@@ -424,7 +424,10 @@ double TrackingService(PHG4Reco *g4Reco, double radius)
   int nSets = 4
   for (unsigned int i = 0; i < nSets; ++i)
   {
-    radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, 0, 0, 0, 0, 0, 100, 360.*i/nSets);
+    double theta = 360.*i/nSets;
+    double r = 10;
+    radius += CreateCableBundle("Test", g4Reco, radius, true, true, true, r*cos(theta), r*cos(theta), r*sin(theta), r*sin(theta), 0, 100, theta);
+    radius += CreateCableBundle("Test2", g4Reco, radius, true, true, true, r*cos(theta), (r+10)*cos(theta), r*sin(theta), (r+10)*sin(theta), -50, 0, theta);
   }
 
   return radius;

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -12,7 +12,7 @@
 #include <G4_HIJetReco.C>
 #include <G4_Input.C>
 #include <G4_Jets.C>
-#include <G4_KFParticle.C>
+//#include <G4_KFParticle.C>
 #include <G4_ParticleFlow.C>
 #include <G4_Production.C>
 #include <G4_TopoClusterReco.C>
@@ -243,7 +243,7 @@ int Fun4All_G4_sPHENIX(
   //======================
 
   // QA, main switch
-  Enable::QA = true;
+  Enable::QA = false;
 
   // Global options (enabled for all enables subsystems - if implemented)
   //  Enable::ABSORBER = true;
@@ -253,21 +253,22 @@ int Fun4All_G4_sPHENIX(
   // Enable::BBC = true;
   Enable::BBCFAKE = true;  // Smeared vtx and t0, use if you don't want real BBC in simulation
 
-  Enable::PIPE = true;
+  Enable::PIPE = false;
   Enable::PIPE_ABSORBER = true;
 
   // central tracking
-  Enable::MVTX = true;
+  Enable::MVTX = false;
   Enable::MVTX_CELL = Enable::MVTX && true;
   Enable::MVTX_CLUSTER = Enable::MVTX_CELL && true;
   Enable::MVTX_QA = Enable::MVTX_CLUSTER and Enable::QA && true;
+  Enable::TrackingService = true;
 
-  Enable::INTT = true;
+  Enable::INTT = false;
   Enable::INTT_CELL = Enable::INTT && true;
   Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
   Enable::INTT_QA = Enable::INTT_CLUSTER and Enable::QA && true;
 
-  Enable::TPC = true;
+  Enable::TPC = false;
   Enable::TPC_ABSORBER = true;
   Enable::TPC_CELL = Enable::TPC && true;
   Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
@@ -277,7 +278,7 @@ int Fun4All_G4_sPHENIX(
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
   Enable::MICROMEGAS_CLUSTER = Enable::MICROMEGAS_CELL && true;
 
-  Enable::TRACKING_TRACK = true;
+  Enable::TRACKING_TRACK = false;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
   Enable::TRACKING_QA = Enable::TRACKING_TRACK and Enable::QA && true;
 
@@ -285,7 +286,7 @@ int Fun4All_G4_sPHENIX(
   //  into the tracking, cannot run together with CEMC
   //  Enable::CEMCALBEDO = true;
 
-  Enable::CEMC = true;
+  Enable::CEMC = false;
   Enable::CEMC_ABSORBER = true;
   Enable::CEMC_CELL = Enable::CEMC && true;
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
@@ -293,7 +294,7 @@ int Fun4All_G4_sPHENIX(
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
   Enable::CEMC_QA = Enable::CEMC_CLUSTER and Enable::QA && true;
 
-  Enable::HCALIN = true;
+  Enable::HCALIN = false;
   Enable::HCALIN_ABSORBER = true;
   Enable::HCALIN_CELL = Enable::HCALIN && true;
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
@@ -301,10 +302,10 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
   Enable::HCALIN_QA = Enable::HCALIN_CLUSTER and Enable::QA && true;
 
-  Enable::MAGNET = true;
+  Enable::MAGNET = false;
   Enable::MAGNET_ABSORBER = true;
 
-  Enable::HCALOUT = true;
+  Enable::HCALOUT = false;
   Enable::HCALOUT_ABSORBER = true;
   Enable::HCALOUT_CELL = Enable::HCALOUT && true;
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
@@ -315,10 +316,10 @@ int Fun4All_G4_sPHENIX(
   Enable::EPD = true;
 
 
-  Enable::BEAMLINE = true;
+  Enable::BEAMLINE = false;
 //  Enable::BEAMLINE_ABSORBER = true;  // makes the beam line magnets sensitive volumes
 //  Enable::BEAMLINE_BLACKHOLE = true; // turns the beamline magnets into black holes
-  Enable::ZDC = true;
+  Enable::ZDC = false;
 //  Enable::ZDC_ABSORBER = true;
 //  Enable::ZDC_SUPPORT = true;
   Enable::ZDC_TOWER = Enable::ZDC && true;
@@ -326,7 +327,7 @@ int Fun4All_G4_sPHENIX(
 
   //! forward flux return plug door. Out of acceptance and off by default.
   //Enable::PLUGDOOR = true;
-  Enable::PLUGDOOR_ABSORBER = true;
+  Enable::PLUGDOOR_ABSORBER = false;
 
   Enable::GLOBAL_RECO = true;
   //Enable::GLOBAL_FASTSIM = true;
@@ -337,7 +338,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::CALOTRIGGER = Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER && false;
 
-  Enable::JETS = true;
+  Enable::JETS = false;
   Enable::JETS_EVAL = Enable::JETS && true;
   Enable::JETS_QA = Enable::JETS and Enable::QA && true;
 
@@ -509,8 +510,8 @@ int Fun4All_G4_sPHENIX(
   //======================
   // Run KFParticle on evt
   //======================
-  if (Enable::KFPARTICLE && Input::UPSILON) KFParticle_Upsilon_Reco();
-  if (Enable::KFPARTICLE && Input::DZERO) KFParticle_D0_Reco();
+  //if (Enable::KFPARTICLE && Input::UPSILON) KFParticle_Upsilon_Reco();
+  //if (Enable::KFPARTICLE && Input::DZERO) KFParticle_D0_Reco();
   //if (Enable::KFPARTICLE && Input::LAMBDAC) KFParticle_Lambdac_Reco();
 
   //----------------------

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -236,14 +236,14 @@ int Fun4All_G4_sPHENIX(
   //  Enable::DSTREADER = true;
 
   // turn the display on (default off)
-  Enable::DISPLAY = false;
+  // Enable::DISPLAY = true;
 
   //======================
   // What to run
   //======================
 
   // QA, main switch
-  Enable::QA = false;
+  Enable::QA = true;
 
   // Global options (enabled for all enables subsystems - if implemented)
   //  Enable::ABSORBER = true;
@@ -254,22 +254,22 @@ int Fun4All_G4_sPHENIX(
   // Enable::BBC_SUPPORT = true; // save hist in bbc support structure
   Enable::BBCFAKE = true;  // Smeared vtx and t0, use if you don't want real BBC in simulation
 
-  Enable::PIPE = false;
+  Enable::PIPE = true;
   Enable::PIPE_ABSORBER = true;
 
   // central tracking
-  Enable::MVTX = false;
+  Enable::MVTX = true;
   Enable::MVTX_CELL = Enable::MVTX && true;
   Enable::MVTX_CLUSTER = Enable::MVTX_CELL && true;
   Enable::MVTX_QA = Enable::MVTX_CLUSTER and Enable::QA && true;
   Enable::TrackingService = true;
 
-  Enable::INTT = false;
+  Enable::INTT = true;
   Enable::INTT_CELL = Enable::INTT && true;
   Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
   Enable::INTT_QA = Enable::INTT_CLUSTER and Enable::QA && true;
 
-  Enable::TPC = false;
+  Enable::TPC = true;
   Enable::TPC_ABSORBER = true;
   Enable::TPC_CELL = Enable::TPC && true;
   Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
@@ -279,7 +279,7 @@ int Fun4All_G4_sPHENIX(
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
   Enable::MICROMEGAS_CLUSTER = Enable::MICROMEGAS_CELL && true;
 
-  Enable::TRACKING_TRACK = false;
+  Enable::TRACKING_TRACK = true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
   Enable::TRACKING_QA = Enable::TRACKING_TRACK and Enable::QA && true;
 
@@ -287,7 +287,7 @@ int Fun4All_G4_sPHENIX(
   //  into the tracking, cannot run together with CEMC
   //  Enable::CEMCALBEDO = true;
 
-  Enable::CEMC = false;
+  Enable::CEMC = true;
   Enable::CEMC_ABSORBER = true;
   Enable::CEMC_CELL = Enable::CEMC && true;
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
@@ -295,7 +295,7 @@ int Fun4All_G4_sPHENIX(
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
   Enable::CEMC_QA = Enable::CEMC_CLUSTER and Enable::QA && true;
 
-  Enable::HCALIN = false;
+  Enable::HCALIN = true;
   Enable::HCALIN_ABSORBER = true;
   Enable::HCALIN_CELL = Enable::HCALIN && true;
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
@@ -303,10 +303,10 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
   Enable::HCALIN_QA = Enable::HCALIN_CLUSTER and Enable::QA && true;
 
-  Enable::MAGNET = false;
+  Enable::MAGNET = true;
   Enable::MAGNET_ABSORBER = true;
 
-  Enable::HCALOUT = false;
+  Enable::HCALOUT = true;
   Enable::HCALOUT_ABSORBER = true;
   Enable::HCALOUT_CELL = Enable::HCALOUT && true;
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
@@ -316,11 +316,10 @@ int Fun4All_G4_sPHENIX(
 
   Enable::EPD = true;
 
-
-  Enable::BEAMLINE = false;
+  Enable::BEAMLINE = true;
 //  Enable::BEAMLINE_ABSORBER = true;  // makes the beam line magnets sensitive volumes
 //  Enable::BEAMLINE_BLACKHOLE = true; // turns the beamline magnets into black holes
-  Enable::ZDC = false;
+  Enable::ZDC = true;
 //  Enable::ZDC_ABSORBER = true;
 //  Enable::ZDC_SUPPORT = true;
   Enable::ZDC_TOWER = Enable::ZDC && true;
@@ -328,7 +327,7 @@ int Fun4All_G4_sPHENIX(
 
   //! forward flux return plug door. Out of acceptance and off by default.
   //Enable::PLUGDOOR = true;
-  Enable::PLUGDOOR_ABSORBER = false;
+  Enable::PLUGDOOR_ABSORBER = true;
 
   Enable::GLOBAL_RECO = true;
   //Enable::GLOBAL_FASTSIM = true;
@@ -339,7 +338,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::CALOTRIGGER = Enable::CEMC_TOWER && Enable::HCALIN_TOWER && Enable::HCALOUT_TOWER && false;
 
-  Enable::JETS = false;
+  Enable::JETS = true;
   Enable::JETS_EVAL = Enable::JETS && true;
   Enable::JETS_QA = Enable::JETS and Enable::QA && true;
 

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -19,6 +19,7 @@
 #include <G4_Pipe.C>
 #include <G4_PlugDoor.C>
 #include <G4_TPC.C>
+#include <G4_TrackingService.C>
 #include <G4_User.C>
 #include <G4_World.C>
 #include <G4_ZDC.C>
@@ -51,6 +52,7 @@ void G4Init()
   // load detector/material macros and execute Init() function
 
   if (Enable::PIPE) PipeInit();
+  if (Enable::TrackingService) TrackingServiceInit();
   if (Enable::MVTX) MvtxInit();
   if (Enable::INTT) InttInit();
   if (Enable::TPC) TPCInit();
@@ -118,6 +120,7 @@ int G4Setup()
   double radius = 0.;
 
   if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  if (Enable::TrackingService) TrackingService(g4Reco, radius);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
   if (Enable::INTT) radius = Intt(g4Reco, radius);
   if (Enable::TPC) radius = TPC(g4Reco, radius);


### PR DESCRIPTION
This PR enables HF QA for D0, Lambda_c and Upsilon decays as well as decay finder triggers for them all. The corresponding HF reco must run first so flags are in place which should ensure this can't crash things.

I'm still working on the full sim of the tracking service (almost there) but I had staged a fast sim without realizing which got pulled into this. I decided to do a little work on this so we can use the fast sim for the MDC2