### PR TITLE
adjust the outer radius for envelope to new supports

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -60,7 +60,7 @@ namespace G4INTT
 
 void InttInit()
 {
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 16.85 + 0.6);  // rail radius + rail outer radius
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 20.);  // estimated from display, can be made smaller but good enough
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 410. / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -410. / 2.);
   // the mvtx is not called if disabled but the default number of layers is set to 3, so we need to set it


### PR DESCRIPTION
The Intt had an overlap with the surrounding black hole when running standalone. The outer envelope had changed with the new support structures, This PR increases the outer radius from ~17.4 to 20 cm. This was read off the display, it can be made a bit smaller but this should be good enough