### PR TITLE
increase micromegas radius

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -40,6 +40,10 @@ namespace G4MICROMEGAS
   };
 
   Config CONFIG = CONFIG_BASELINE;
+
+  // radius at which micromegas layers are installed
+  double mm_radius = 85;
+
 }  // namespace G4MICROMEGAS
 
 void MicromegasInit()
@@ -68,7 +72,7 @@ void Micromegas(PHG4Reco* g4Reco)
   auto mm = new PHG4MicromegasSubsystem("MICROMEGAS", mm_layer);
   mm->SetActive();
   mm->set_double_param("mm_length", 220);
-  mm->set_double_param("mm_radius", 82);
+  mm->set_double_param("mm_radius", G4MICROMEGAS::mm_radius);
   g4Reco->registerSubsystem(mm);
 }
 
@@ -79,7 +83,6 @@ void Micromegas_Cells()
   auto reco = new PHG4MicromegasHitReco;
   reco->Verbosity(0);
 
-  static constexpr double radius = 82;
   static constexpr double length = 210;
   static constexpr int nsectors = 12;
   static constexpr double tile_length = 50;
@@ -92,7 +95,7 @@ void Micromegas_Cells()
     // one tile at mid rapidity in front of TPC sector
     std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MINIMAL" << std::endl;
     static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
-    reco->set_tiles({{{phi0, 0, tile_width / radius, tile_length}}});
+    reco->set_tiles({{{phi0, 0, tile_width/CylinderGeomMicromegas::reference_radius, tile_length}}});
     break;
   }
 
@@ -103,7 +106,7 @@ void Micromegas_Cells()
     MicromegasTile::List tiles;
     for (int i = 0; i < nsectors; ++i)
     {
-      tiles.emplace_back(2. * M_PI * (0.5 + i) / nsectors, 0, tile_width / radius, tile_length);
+      tiles.emplace_back(2. * M_PI * (0.5 + i) / nsectors, 0, tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
     }
     reco->set_tiles(tiles);
     break;
@@ -118,7 +121,7 @@ void Micromegas_Cells()
     static constexpr int ntiles = 4;
     for (int i = 0; i < ntiles; ++i)
     {
-      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles - 0.5), tile_width / radius, tile_length);
+      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
     }
     reco->set_tiles(tiles);
     break;
@@ -134,7 +137,7 @@ void Micromegas_Cells()
     static constexpr int ntiles_z = 4;
     for (int i = 0; i < ntiles_z; ++i)
     {
-      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles_z - 0.5), tile_width / radius, tile_length);
+      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles_z - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
     }
 
     // for the other sectors we put two tiles on either side of the central membrane
@@ -142,8 +145,8 @@ void Micromegas_Cells()
     for (int i = 1; i < nsectors; ++i)
     {
       const double phi = phi0 + 2.*M_PI*i/nsectors;
-      tiles.emplace_back( phi, length*(1.5/4-0.5) - zoffset, tile_width/radius, tile_length );
-      tiles.emplace_back( phi, length*(2.5/4-0.5) + zoffset, tile_width/radius, tile_length );
+      tiles.emplace_back( phi, length*(1.5/4-0.5) - zoffset, tile_width/CylinderGeomMicromegas::reference_radius, tile_length );
+      tiles.emplace_back( phi, length*(2.5/4-0.5) + zoffset, tile_width/CylinderGeomMicromegas::reference_radius, tile_length );
     }
     reco->set_tiles(tiles);
     break;
@@ -161,7 +164,7 @@ void Micromegas_Cells()
       const double phi = 2. * M_PI * (0.5 + iphi) / nsectors;
       for (int iz = 0; iz < ntiles_z; ++iz)
       {
-        tiles.emplace_back(phi, length * ((0.5 + iz) / ntiles_z - 0.5), tile_width / radius, tile_length);
+        tiles.emplace_back(phi, length * ((0.5 + iz) / ntiles_z - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
       }
     }
     reco->set_tiles(tiles);


### PR DESCRIPTION
- Allow to configure micromegas radius position from calling macro
- increase micromegas radius from 82 to 85cm to leave room for TPC supporting rods
This is a temporary solution to avoid Geant4 conflicts in https://github.com/sPHENIX-Collaboration/coresoftware/pull/1364 and while waiting for a more permanent Micromegas implementation
