### PR TITLE
Run without INTT Dead Map

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -124,29 +124,30 @@ void Intt_Cells()
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  // Load pre-defined deadmaps
-  PHG4InttDeadMapLoader * deadMapINTT = new PHG4InttDeadMapLoader("INTT");
-
-  for (int i = 0; i < G4INTT::n_intt_layer; i++) { 
-    string DeadMapConfigName = Form("intt_layer%d/", i);
-
-    if (G4INTT::InttDeadMapOption == G4INTT::kInttDeadMap) {
-      string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap/"); 
-      //string DeadMapPath = "/sphenix/u/wxie/sphnx_software/INTT" + string("/DeadMap/"); 
-
-      DeadMapPath +=  DeadMapConfigName;
-
-      deadMapINTT->deadMapPath(G4MVTX::n_maps_layer + i, DeadMapPath);
-    } else {
-      cout <<"Tracking_Reco - fatal error - invalid InttDeadMapOption = "<<G4INTT::InttDeadMapOption<<endl;
-      exit(1);
+  if(G4INTT::InttDeadMapOption != G4INTT::kInttNoDeadMap) {
+    // Load pre-defined deadmaps
+    PHG4InttDeadMapLoader * deadMapINTT = new PHG4InttDeadMapLoader("INTT");
+    
+    for (int i = 0; i < G4INTT::n_intt_layer; i++) { 
+      string DeadMapConfigName = Form("intt_layer%d/", i);
+      
+      if (G4INTT::InttDeadMapOption == G4INTT::kInttDeadMap) {
+	string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap/"); 
+	//string DeadMapPath = "/sphenix/u/wxie/sphnx_software/INTT" + string("/DeadMap/"); 
+	
+	DeadMapPath +=  DeadMapConfigName;
+	
+	deadMapINTT->deadMapPath(G4MVTX::n_maps_layer + i, DeadMapPath);
+      } else {
+	cout <<"Tracking_Reco - fatal error - invalid InttDeadMapOption = "<<G4INTT::InttDeadMapOption<<endl;
+	exit(1);
+      }
     }
+    
+    deadMapINTT -> Verbosity(verbosity);
+    //deadMapINTT -> Verbosity(1);
+    se->registerSubsystem(deadMapINTT);
   }
-
-  deadMapINTT -> Verbosity(verbosity);
-  //deadMapINTT -> Verbosity(1);
-  se->registerSubsystem(deadMapINTT);
-
   // new storage containers
   PHG4InttHitReco* reco = new PHG4InttHitReco();
   // The timing windows are hard-coded in the INTT ladder model, they can be overridden here

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -6,9 +6,9 @@
 
 #include <G4_Mvtx.C>
 
+#include <g4intt/PHG4InttDeadMapLoader.h>
 #include <g4intt/PHG4InttDefs.h>
 #include <g4intt/PHG4InttDigitizer.h>
-#include <g4intt/PHG4InttDeadMapLoader.h>
 #include <g4intt/PHG4InttHitReco.h>
 #include <g4intt/PHG4InttSubsystem.h>
 
@@ -26,7 +26,7 @@ R__LOAD_LIBRARY(libg4intt.so)
 R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libqa_modules.so)
 
-  namespace Enable
+namespace Enable
 {
   bool INTT = false;
   bool INTT_OVERLAPCHECK = false;
@@ -41,9 +41,9 @@ namespace G4INTT
   int n_intt_layer = 4;           // must be 4 or 0, setting to zero removes INTT completely
   double intt_radius_max = 140.;  // including stagger radius (mm)
   int laddertype[4] = {PHG4InttDefs::SEGMENTATION_PHI,
-    PHG4InttDefs::SEGMENTATION_PHI,
-    PHG4InttDefs::SEGMENTATION_PHI,
-    PHG4InttDefs::SEGMENTATION_PHI};
+                       PHG4InttDefs::SEGMENTATION_PHI,
+                       PHG4InttDefs::SEGMENTATION_PHI,
+                       PHG4InttDefs::SEGMENTATION_PHI};
   int nladder[4] = {12, 12, 16, 16};
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
@@ -51,8 +51,8 @@ namespace G4INTT
 
   enum enu_InttDeadMapType  // Dead map options for INTT
   {
-    kInttNoDeadMap = 0,        // All channel in Intt is alive
-    kInttDeadMap = 1,  // with dead channel
+    kInttNoDeadMap = 0,  // All channel in Intt is alive
+    kInttDeadMap = 1,    // with dead channel
   };
   //enu_InttDeadMapType InttDeadMapOption = kInttNoDeadMap;  // Choose Intt deadmap here
   enu_InttDeadMapType InttDeadMapOption = kInttDeadMap;  // Choose Intt deadmap here
@@ -73,7 +73,7 @@ void InttInit()
 }
 
 double Intt(PHG4Reco* g4Reco, double radius,
-    const int absorberactive = 0)
+            const int absorberactive = 0)
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   bool intt_overlapcheck = Enable::OVERLAPCHECK || Enable::INTT_OVERLAPCHECK;
@@ -106,7 +106,7 @@ double Intt(PHG4Reco* g4Reco, double radius,
   for (int i = 0; i < G4INTT::n_intt_layer; i++)
   {
     cout << " Intt layer " << i << " laddertype " << G4INTT::laddertype[i] << " nladders " << G4INTT::nladder[i]
-      << " sensor radius " << G4INTT::sensor_radius[i] << " offsetphi " << G4INTT::offsetphi[i] << endl;
+         << " sensor radius " << G4INTT::sensor_radius[i] << " offsetphi " << G4INTT::offsetphi[i] << endl;
     sitrack->set_int_param(i, "laddertype", G4INTT::laddertype[i]);
     sitrack->set_int_param(i, "nladder", G4INTT::nladder[i]);
     sitrack->set_double_param(i, "sensor_radius", G4INTT::sensor_radius[i]);  // expecting cm
@@ -124,27 +124,32 @@ void Intt_Cells()
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  if(G4INTT::InttDeadMapOption != G4INTT::kInttNoDeadMap) {
+  if (G4INTT::InttDeadMapOption != G4INTT::kInttNoDeadMap)
+  {
     // Load pre-defined deadmaps
-    PHG4InttDeadMapLoader * deadMapINTT = new PHG4InttDeadMapLoader("INTT");
-    
-    for (int i = 0; i < G4INTT::n_intt_layer; i++) { 
+    PHG4InttDeadMapLoader* deadMapINTT = new PHG4InttDeadMapLoader("INTT");
+
+    for (int i = 0; i < G4INTT::n_intt_layer; i++)
+    {
       string DeadMapConfigName = Form("intt_layer%d/", i);
-      
-      if (G4INTT::InttDeadMapOption == G4INTT::kInttDeadMap) {
-	string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap/"); 
-	//string DeadMapPath = "/sphenix/u/wxie/sphnx_software/INTT" + string("/DeadMap/"); 
-	
-	DeadMapPath +=  DeadMapConfigName;
-	
-	deadMapINTT->deadMapPath(G4MVTX::n_maps_layer + i, DeadMapPath);
-      } else {
-	cout <<"Tracking_Reco - fatal error - invalid InttDeadMapOption = "<<G4INTT::InttDeadMapOption<<endl;
-	exit(1);
+
+      if (G4INTT::InttDeadMapOption == G4INTT::kInttDeadMap)
+      {
+        string DeadMapPath = string(getenv("CALIBRATIONROOT")) + string("/Tracking/INTT/DeadMap/");
+        //string DeadMapPath = "/sphenix/u/wxie/sphnx_software/INTT" + string("/DeadMap/");
+
+        DeadMapPath += DeadMapConfigName;
+
+        deadMapINTT->deadMapPath(G4MVTX::n_maps_layer + i, DeadMapPath);
+      }
+      else
+      {
+        cout << "G4_Intt.C - fatal error - invalid InttDeadMapOption = " << G4INTT::InttDeadMapOption << endl;
+        exit(1);
       }
     }
-    
-    deadMapINTT -> Verbosity(verbosity);
+
+    deadMapINTT->Verbosity(verbosity);
     //deadMapINTT -> Verbosity(1);
     se->registerSubsystem(deadMapINTT);
   }
@@ -191,8 +196,8 @@ void Intt_Cells()
 
   // new containers
   PHG4InttDigitizer* digiintt = new PHG4InttDigitizer();
-  digiintt->Verbosity(verbosity); 
-  //digiintt->Verbosity(3); 
+  digiintt->Verbosity(verbosity);
+  //digiintt->Verbosity(3);
   for (int i = 0; i < G4INTT::n_intt_layer; i++)
   {
     digiintt->set_adc_scale(G4MVTX::n_maps_layer + i, userrange);
@@ -210,7 +215,7 @@ void Intt_Clustering()
   InttClusterizer* inttclusterizer = new InttClusterizer("InttClusterizer", G4MVTX::n_maps_layer, G4MVTX::n_maps_layer + G4INTT::n_intt_layer - 1);
   inttclusterizer->Verbosity(verbosity);
   // no Z clustering for Intt type 1 layers (we DO want Z clustering for type 0 layers)
-  // turning off phi clustering for type 0 layers is not necessary, there is only one strip 
+  // turning off phi clustering for type 0 layers is not necessary, there is only one strip
   // per sensor in phi
   for (int i = G4MVTX::n_maps_layer; i < G4MVTX::n_maps_layer + G4INTT::n_intt_layer; i++)
   {
@@ -221,7 +226,6 @@ void Intt_Clustering()
   }
   se->registerSubsystem(inttclusterizer);
 }
-
 
 void Intt_QA()
 {


### PR DESCRIPTION
Currently if you try to run without the new INTT dead map the macro just exits. This PR adds an if statement to check if the INTT dead map loader should be run at all based on the setting of the `G4INTT::InttDeadMapOption` enum.

Note that this PR does not change the default behavior of running with the dead map enabled, it simply allows one to choose to not run with the dead map if they would like to.