### PR TITLE
Tpot new geometry

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -34,9 +34,6 @@ namespace G4MICROMEGAS
 
   // number of micromegas layers
   int n_micromegas_layer = 2;
-
-  // radius at which micromegas layers are installed
-  double mm_radius = 85;
   
 }  // namespace G4MICROMEGAS
 
@@ -66,8 +63,6 @@ void Micromegas(PHG4Reco* g4Reco)
   auto mm = new PHG4MicromegasSubsystem("MICROMEGAS", mm_layer);
   mm->OverlapCheck( Enable::OVERLAPCHECK );
   mm->SetActive();
-  mm->set_double_param("mm_length", 220);
-  mm->set_double_param("mm_radius", G4MICROMEGAS::mm_radius);
   g4Reco->registerSubsystem(mm);
 }
 

--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -31,21 +31,13 @@ namespace Enable
 
 namespace G4MICROMEGAS
 {
-  int n_micromegas_layer = 2;
-  enum Config
-  {
-    CONFIG_MINIMAL,
-    CONFIG_PHI_ONE_RING,
-    CONFIG_Z_ONE_SECTOR,
-    CONFIG_BASELINE,
-    CONFIG_MAXIMAL
-  };
 
-  Config CONFIG = CONFIG_BASELINE;
+  // number of micromegas layers
+  int n_micromegas_layer = 2;
 
   // radius at which micromegas layers are installed
   double mm_radius = 85;
-
+  
 }  // namespace G4MICROMEGAS
 
 void MicromegasInit()
@@ -63,7 +55,7 @@ void MicromegasInit()
   {
     G4TPC::n_gas_layer = 0;
   }
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 83.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 86.);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 220. / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -220. / 2.);
 }
@@ -85,96 +77,6 @@ void Micromegas_Cells()
   // micromegas
   auto reco = new PHG4MicromegasHitReco;
   reco->Verbosity(0);
-
-  static constexpr double length = 210;
-  static constexpr int nsectors = 12;
-  static constexpr double tile_length = 50;
-  static constexpr double tile_width = 25;
-
-  switch (G4MICROMEGAS::CONFIG)
-  {
-  case G4MICROMEGAS::CONFIG_MINIMAL:
-  {
-    // one tile at mid rapidity in front of TPC sector
-    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MINIMAL" << std::endl;
-    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
-    reco->set_tiles({{{phi0, 0, tile_width/CylinderGeomMicromegas::reference_radius, tile_length}}});
-    break;
-  }
-
-  case G4MICROMEGAS::CONFIG_PHI_ONE_RING:
-  {
-    // 12 tiles at mid rapidity, one in front of each TPC sector
-    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_PHI_ONE_RING" << std::endl;
-    MicromegasTile::List tiles;
-    for (int i = 0; i < nsectors; ++i)
-    {
-      tiles.emplace_back(2. * M_PI * (0.5 + i) / nsectors, 0, tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
-    }
-    reco->set_tiles(tiles);
-    break;
-  }
-
-  case G4MICROMEGAS::CONFIG_Z_ONE_SECTOR:
-  {
-    // 4 tiles with full z coverage in front of one TPC sector
-    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_Z_ONE_SECTOR" << std::endl;
-    MicromegasTile::List tiles;
-    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
-    static constexpr int ntiles = 4;
-    for (int i = 0; i < ntiles; ++i)
-    {
-      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
-    }
-    reco->set_tiles(tiles);
-    break;
-  }
-
-  case G4MICROMEGAS::CONFIG_BASELINE:
-  {
-    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_BASELINE" << std::endl;
-    MicromegasTile::List tiles;
-
-    // for the first sector we put 4 tiles with full z coverage
-    static constexpr double phi0 = M_PI * (0.5 + 1. / nsectors);
-    static constexpr int ntiles_z = 4;
-    for (int i = 0; i < ntiles_z; ++i)
-    {
-      tiles.emplace_back(phi0, length * ((0.5 + i) / ntiles_z - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
-    }
-
-    // for the other sectors we put two tiles on either side of the central membrane
-    static constexpr double zoffset = 7;
-    for (int i = 1; i < nsectors; ++i)
-    {
-      const double phi = phi0 + 2.*M_PI*i/nsectors;
-      tiles.emplace_back( phi, length*(1.5/4-0.5) - zoffset, tile_width/CylinderGeomMicromegas::reference_radius, tile_length );
-      tiles.emplace_back( phi, length*(2.5/4-0.5) + zoffset, tile_width/CylinderGeomMicromegas::reference_radius, tile_length );
-    }
-    reco->set_tiles(tiles);
-    break;
-  }
-
-  case G4MICROMEGAS::CONFIG_MAXIMAL:
-  {
-    std::cout << "Micromegas_Cells - Tiles configuration: CONFIG_MAXIMAL" << std::endl;
-    MicromegasTile::List tiles;
-
-    // 4 tiles with full z coverage in front of each TPC sector
-    static constexpr int ntiles_z = 4;
-    for (int iphi = 0; iphi < nsectors; ++iphi)
-    {
-      const double phi = 2. * M_PI * (0.5 + iphi) / nsectors;
-      for (int iz = 0; iz < ntiles_z; ++iz)
-      {
-        tiles.emplace_back(phi, length * ((0.5 + iz) / ntiles_z - 0.5), tile_width/CylinderGeomMicromegas::reference_radius, tile_length);
-      }
-    }
-    reco->set_tiles(tiles);
-    break;
-  }
-  }
-
   se->registerSubsystem(reco);
 
   se->registerSubsystem(new PHG4MicromegasDigitizer);

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -101,6 +101,7 @@ void TrackingInit()
   geom->setMagField(G4MAGNET::magfield);
   geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
   geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
+  geom->build_mm_surfaces(Enable::MICROMEGAS);
   se->registerSubsystem(geom);
 }
 


### PR DESCRIPTION
This PR removes all the TPOT/Micromegas configuration options, tile definitions and parameters, as all will be hardcoded in the new geometry implementation. 
Depends on https://github.com/sPHENIX-Collaboration/coresoftware/pull/1400 to run
Is necessary for the coming coresoftware changes to the TPOT geometry