### PR TITLE
surrounding black hole cylinder radius needs a 2cm increase

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -52,7 +52,7 @@ void MicromegasInit()
   {
     G4TPC::n_gas_layer = 0;
   }
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 86.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 88.);
   BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 220. / 2.);
   BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -220. / 2.);
 }


### PR DESCRIPTION
This PR increases the radius of the surrounding black hole by 2 cm. This is only relevant if the micromegas is running standalone otherwise the black hole radius is determined by the outermost detector (outer hcal)