### PR TITLE
Suppress cling warning

### DIFF
--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -19,7 +19,11 @@
 
 #include <g4main/PHG4Reco.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundefined-internal"
 #include <tpc/TpcClusterizer.h>
+#pragma GCC diagnostic pop
+
 #include <tpc/TpcClusterCleaner.h>
 #include <tpc/TpcLoadDistortionCorrection.h>
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -271,19 +271,19 @@ int Fun4All_G4_sPHENIX(
   Enable::MVTX = true;
   Enable::MVTX_CELL = Enable::MVTX && true;
   Enable::MVTX_CLUSTER = Enable::MVTX_CELL && true;
-  Enable::MVTX_QA = Enable::MVTX_CLUSTER and Enable::QA && true;
+  Enable::MVTX_QA = Enable::MVTX_CLUSTER && Enable::QA && true;
   Enable::TrackingService = true;
 
   Enable::INTT = true;
   Enable::INTT_CELL = Enable::INTT && true;
   Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
-  Enable::INTT_QA = Enable::INTT_CLUSTER and Enable::QA && true;
+  Enable::INTT_QA = Enable::INTT_CLUSTER && Enable::QA && true;
 
   Enable::TPC = true;
   Enable::TPC_ABSORBER = true;
   Enable::TPC_CELL = Enable::TPC && true;
   Enable::TPC_CLUSTER = Enable::TPC_CELL && true;
-  Enable::TPC_QA = Enable::TPC_CLUSTER and Enable::QA && true;
+  Enable::TPC_QA = Enable::TPC_CLUSTER && Enable::QA && true;
 
   Enable::MICROMEGAS = true;
   Enable::MICROMEGAS_CELL = Enable::MICROMEGAS && true;
@@ -292,7 +292,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::TRACKING_TRACK = true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
-  Enable::TRACKING_QA = Enable::TRACKING_TRACK and Enable::QA && true;
+  Enable::TRACKING_QA = Enable::TRACKING_TRACK && Enable::QA && true;
 
   //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
   //  into the tracking, cannot run together with CEMC
@@ -304,7 +304,7 @@ int Fun4All_G4_sPHENIX(
   Enable::CEMC_TOWER = Enable::CEMC_CELL && true;
   Enable::CEMC_CLUSTER = Enable::CEMC_TOWER && true;
   Enable::CEMC_EVAL = Enable::CEMC_CLUSTER && true;
-  Enable::CEMC_QA = Enable::CEMC_CLUSTER and Enable::QA && true;
+  Enable::CEMC_QA = Enable::CEMC_CLUSTER && Enable::QA && true;
 
   Enable::HCALIN = true;
   Enable::HCALIN_ABSORBER = true;
@@ -312,7 +312,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALIN_TOWER = Enable::HCALIN_CELL && true;
   Enable::HCALIN_CLUSTER = Enable::HCALIN_TOWER && true;
   Enable::HCALIN_EVAL = Enable::HCALIN_CLUSTER && true;
-  Enable::HCALIN_QA = Enable::HCALIN_CLUSTER and Enable::QA && true;
+  Enable::HCALIN_QA = Enable::HCALIN_CLUSTER && Enable::QA && true;
 
   Enable::MAGNET = true;
   Enable::MAGNET_ABSORBER = true;
@@ -323,7 +323,7 @@ int Fun4All_G4_sPHENIX(
   Enable::HCALOUT_TOWER = Enable::HCALOUT_CELL && true;
   Enable::HCALOUT_CLUSTER = Enable::HCALOUT_TOWER && true;
   Enable::HCALOUT_EVAL = Enable::HCALOUT_CLUSTER && true;
-  Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER and Enable::QA && true;
+  Enable::HCALOUT_QA = Enable::HCALOUT_CLUSTER && Enable::QA && true;
 
   Enable::EPD = true;
 
@@ -351,7 +351,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::JETS = true;
   Enable::JETS_EVAL = Enable::JETS && true;
-  Enable::JETS_QA = Enable::JETS and Enable::QA && true;
+  Enable::JETS_QA = Enable::JETS && Enable::QA && true;
 
   // HI Jet Reco for p+Au / Au+Au collisions (default is false for
   // single particle / p+p-only simulations, or for p+Au / Au+Au
@@ -551,7 +551,7 @@ int Fun4All_G4_sPHENIX(
   if (Enable::MICROMEGAS_QA) Micromegas_QA();
   if (Enable::TRACKING_QA) Tracking_QA();
 
-  if (Enable::TRACKING_QA and Enable::CEMC_QA and Enable::HCALIN_QA and Enable::HCALOUT_QA) QA_G4CaloTracking();
+  if (Enable::TRACKING_QA && Enable::CEMC_QA && Enable::HCALIN_QA && Enable::HCALOUT_QA) QA_G4CaloTracking();
 
   //--------------
   // Set up Input Managers


### PR DESCRIPTION
root 6.24.06 generates a warning. Since this warning does not exist for gcc it is hard to suppress in the include itself. The underlying includes are from acts which will change with the next acts version. Then we can look for a more permanent solution dealing with this in the acts includes
In file included from ./G4_TPC.C:24:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/tpc/TpcClusterizer.h:7:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/trackbase/ActsTrackingGeometry.h:5:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Acts/Utilities/BinnedArray.hpp:14:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Acts/Utilities/BinUtility.hpp:10:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Acts/Utilities/BinningData.hpp:14:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Acts/Utilities//Definitions.hpp:18:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Eigen/Dense:1:
In file included from /cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Eigen/Core:167:
/cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Eigen/src/Core/util/IntegralConstant.h:189:36: warning: variable 'Eigen::fix<1>' has internal linkage but is not defined [-Wundefined-internal]
static const internal::FixedInt<N> fix{};
                                   ^
/cvmfs/sphenix.sdcc.bnl.gov/gcc-8.3/release/release_play/play.4/include/Eigen/src/Core/util/IndexedViewHelper.h:57:147: note: used here
static const symbolic::AddExpr<symbolic::SymbolExpr<internal::symbolic_last_tag>,symbolic::ValueExpr<Eigen::internal::FixedInt<1> > > lastp1(last+fix<1>());
