### PR TITLE
load libqa_kfparticle.so and libdecayfinder.so to resolve macro content

### DIFF
--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -11,6 +11,8 @@
 #include <fun4all/Fun4AllServer.h>
 
 R__LOAD_LIBRARY(libkfparticle_sphenix.so)
+R__LOAD_LIBRARY(libqa_kfparticle.so)
+R__LOAD_LIBRARY(libdecayfinder.so)
 
 namespace Enable
 {


### PR DESCRIPTION
at least with root 6.24.06 the missing load generated warnings