### PR TITLE
Intt support

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -29,10 +29,12 @@ R__LOAD_LIBRARY(libqa_modules.so)
 namespace Enable
 {
   bool INTT = false;
+  bool INTT_ABSORBER = false;
   bool INTT_OVERLAPCHECK = false;
   bool INTT_CELL = false;
   bool INTT_CLUSTER = false;
   bool INTT_QA = false;
+  bool INTT_SUPPORT = false;
   int INTT_VERBOSITY = 0;
 }  // namespace Enable
 
@@ -98,6 +100,14 @@ double Intt(PHG4Reco* g4Reco, double radius,
   sitrack->Verbosity(verbosity);
   sitrack->SetActive(1);
   sitrack->OverlapCheck(intt_overlapcheck);
+  if (Enable::INTT_ABSORBER)
+  {
+    sitrack->SetAbsorberActive();
+  }
+  if (Enable::INTT_SUPPORT)
+  {
+    sitrack->set_int_param(PHG4InttDefs::SUPPORTPARAMS, "supportactive", 1);
+  }
   g4Reco->registerSubsystem(sitrack);
 
   // Set the laddertype and ladder spacing configuration

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -50,9 +50,9 @@ namespace G4MVTXAlignment
 
 void MvtxInit()
 {
-  //BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 5);
-  //BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -20);
-  //BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 25.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 12.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -165.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 24.);
 }
 
 double Mvtx(PHG4Reco* g4Reco, double radius,

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -277,6 +277,8 @@ int Fun4All_G4_sPHENIX(
   Enable::TrackingService = false;
 
   Enable::INTT = true;
+//  Enable::INTT_ABSORBER = true; // enables layerwise support structure readout
+//  Enable::INTT_SUPPORT = true; // enable global support structure readout
   Enable::INTT_CELL = Enable::INTT && true;
   Enable::INTT_CLUSTER = Enable::INTT_CELL && true;
   Enable::INTT_QA = Enable::INTT_CLUSTER && Enable::QA && true;
@@ -344,6 +346,7 @@ int Fun4All_G4_sPHENIX(
 
   Enable::GLOBAL_RECO = true;
   //Enable::GLOBAL_FASTSIM = true;
+
   //Enable::KFPARTICLE = true;
   //Enable::KFPARTICLE_VERBOSITY = 1;
   //Enable::KFPARTICLE_TRUTH_MATCH = true;
@@ -387,7 +390,7 @@ int Fun4All_G4_sPHENIX(
 
   //  G4MAGNET::magfield =  string(getenv("CALIBRATIONROOT"))+ string("/Field/Map/sphenix3dbigmapxyz.root");  // default map from the calibration database
   //  G4MAGNET::magfield = "1.5"; // alternatively to specify a constant magnetic field, give a float number, which will be translated to solenoidal field in T, if string use as fieldmap name (including path)
-  G4MAGNET::magfield_rescale = 1.;  // make consistent with expected Babar field strength of 1.4T
+//  G4MAGNET::magfield_rescale = 1.;  // make consistent with expected Babar field strength of 1.4T
 
   //---------------
   // Pythia Decayer


### PR DESCRIPTION
This PR puts the readout of the intt support and absorber (layer wise support structures) into the ENABLE namespace.
Also adjusted and put the envelope Black hole dimensions back into the MVTX. Please adjust them next time the dimensions change and not just comment this out to "fix overlaps". If they are commented out you cannot run the detector standalone (the black hole envelope is created inside the detector so no particle will reach it).