### PR TITLE
Embedid

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -274,9 +274,9 @@ void InputInit()
 
     if (Input::EMBED)
     {
-    INPUTGENERATOR::Pythia6->set_embedding_id(Input::EmbedId);
-    Input::PYTHIA6_EmbedId = Input::EmbedId;
-    Input::EmbedId++;
+      INPUTGENERATOR::Pythia6->set_embedding_id(Input::EmbedId);
+      Input::PYTHIA6_EmbedId = Input::EmbedId;
+      Input::EmbedId++;
     }
   }
   if (Input::PYTHIA8)
@@ -287,9 +287,9 @@ void InputInit()
 
     if (Input::EMBED)
     {
-    INPUTGENERATOR::Pythia8->set_embedding_id(Input::EmbedId);
-    Input::PYTHIA8_EmbedId = Input::EmbedId;
-    Input::EmbedId++;
+      INPUTGENERATOR::Pythia8->set_embedding_id(Input::EmbedId);
+      Input::PYTHIA8_EmbedId = Input::EmbedId;
+      Input::EmbedId++;
     }
   }
   if (Input::SARTRE)
@@ -306,9 +306,9 @@ void InputInit()
 
     if (Input::EMBED)
     {
-    INPUTGENERATOR::Sartre->set_embedding_id(Input::EmbedId);
-    Input::SARTRE_EmbedId = Input::EmbedId;
-    Input::EmbedId++;
+      INPUTGENERATOR::Sartre->set_embedding_id(Input::EmbedId);
+      Input::SARTRE_EmbedId = Input::EmbedId;
+      Input::EmbedId++;
     }
   }
   // single particle generators
@@ -318,12 +318,12 @@ void InputInit()
     {
       std::string name = "DZERO_" + std::to_string(i);
       PHG4ParticleGeneratorD0 *dzero = new PHG4ParticleGeneratorD0(name);
-    if (Input::EMBED)
-    {
-      dzero->Embed(Input::EmbedId);
-      Input::DZERO_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        dzero->Embed(Input::EmbedId);
+        Input::DZERO_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::DZeroMesonGenerator.push_back(dzero);
     }
   }
@@ -333,12 +333,12 @@ void InputInit()
     {
       std::string name = "GUN_" + std::to_string(i);
       PHG4ParticleGun *gun = new PHG4ParticleGun(name);
-    if (Input::EMBED)
-    {
-      gun->Embed(Input::EmbedId);
-      Input::GUN_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        gun->Embed(Input::EmbedId);
+        Input::GUN_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::Gun.push_back(gun);
     }
   }
@@ -348,12 +348,12 @@ void InputInit()
     {
       std::string name = "IONGUN_" + std::to_string(i);
       PHG4IonGun *iongun = new PHG4IonGun(name);
-    if (Input::EMBED)
-    {
-      iongun->Embed(Input::EmbedId);
-      Input::IONGUN_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        iongun->Embed(Input::EmbedId);
+        Input::IONGUN_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::IonGun.push_back(iongun);
     }
   }
@@ -363,12 +363,12 @@ void InputInit()
     {
       std::string name = "PGEN_" + std::to_string(i);
       PHG4ParticleGenerator *pgen = new PHG4ParticleGenerator(name);
-    if (Input::EMBED)
-    {
-      pgen->Embed(Input::EmbedId);
-      Input::PGEN_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        pgen->Embed(Input::EmbedId);
+        Input::PGEN_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::ParticleGenerator.push_back(pgen);
     }
   }
@@ -378,12 +378,12 @@ void InputInit()
     {
       std::string name = "EVTGENERATOR_" + std::to_string(i);
       PHG4SimpleEventGenerator *simple = new PHG4SimpleEventGenerator(name);
-    if (Input::EMBED)
-    {
-      simple->Embed(Input::EmbedId);
-      Input::PGEN_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        simple->Embed(Input::EmbedId);
+        Input::PGEN_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::SimpleEventGenerator.push_back(simple);
     }
   }
@@ -393,12 +393,12 @@ void InputInit()
     {
       std::string name = "UPSILON_" + std::to_string(i);
       PHG4ParticleGeneratorVectorMeson *upsilon = new PHG4ParticleGeneratorVectorMeson(name);
-    if (Input::EMBED)
-    {
-      upsilon->Embed(Input::EmbedId);
-      Input::UPSILON_EmbedIds.insert(Input::EmbedId);
-      Input::EmbedId++;
-    }
+      if (Input::EMBED)
+      {
+        upsilon->Embed(Input::EmbedId);
+        Input::UPSILON_EmbedIds.insert(Input::EmbedId);
+        Input::EmbedId++;
+      }
       INPUTGENERATOR::VectorMesonGenerator.push_back(upsilon);
     }
   }

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -272,9 +272,12 @@ void InputInit()
     INPUTGENERATOR::Pythia6 = new PHPythia6();
     INPUTGENERATOR::Pythia6->set_config_file(PYTHIA6::config_file);
 
+    if (Input::EMBED)
+    {
     INPUTGENERATOR::Pythia6->set_embedding_id(Input::EmbedId);
     Input::PYTHIA6_EmbedId = Input::EmbedId;
     Input::EmbedId++;
+    }
   }
   if (Input::PYTHIA8)
   {
@@ -282,9 +285,12 @@ void InputInit()
     // see coresoftware/generators/PHPythia8 for example config
     INPUTGENERATOR::Pythia8->set_config_file(PYTHIA8::config_file);
 
+    if (Input::EMBED)
+    {
     INPUTGENERATOR::Pythia8->set_embedding_id(Input::EmbedId);
     Input::PYTHIA8_EmbedId = Input::EmbedId;
     Input::EmbedId++;
+    }
   }
   if (Input::SARTRE)
   {
@@ -298,9 +304,12 @@ void InputInit()
     INPUTGENERATOR::SartreTrigger->SetEtaHighLow(1.0, -1.1);  // central arm
     INPUTGENERATOR::SartreTrigger->PrintConfig();
 
+    if (Input::EMBED)
+    {
     INPUTGENERATOR::Sartre->set_embedding_id(Input::EmbedId);
     Input::SARTRE_EmbedId = Input::EmbedId;
     Input::EmbedId++;
+    }
   }
   // single particle generators
   if (Input::DZERO)
@@ -309,9 +318,12 @@ void InputInit()
     {
       std::string name = "DZERO_" + std::to_string(i);
       PHG4ParticleGeneratorD0 *dzero = new PHG4ParticleGeneratorD0(name);
+    if (Input::EMBED)
+    {
       dzero->Embed(Input::EmbedId);
       Input::DZERO_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::DZeroMesonGenerator.push_back(dzero);
     }
   }
@@ -321,9 +333,12 @@ void InputInit()
     {
       std::string name = "GUN_" + std::to_string(i);
       PHG4ParticleGun *gun = new PHG4ParticleGun(name);
+    if (Input::EMBED)
+    {
       gun->Embed(Input::EmbedId);
       Input::GUN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::Gun.push_back(gun);
     }
   }
@@ -333,9 +348,12 @@ void InputInit()
     {
       std::string name = "IONGUN_" + std::to_string(i);
       PHG4IonGun *iongun = new PHG4IonGun(name);
+    if (Input::EMBED)
+    {
       iongun->Embed(Input::EmbedId);
       Input::IONGUN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::IonGun.push_back(iongun);
     }
   }
@@ -345,9 +363,12 @@ void InputInit()
     {
       std::string name = "PGEN_" + std::to_string(i);
       PHG4ParticleGenerator *pgen = new PHG4ParticleGenerator(name);
+    if (Input::EMBED)
+    {
       pgen->Embed(Input::EmbedId);
       Input::PGEN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::ParticleGenerator.push_back(pgen);
     }
   }
@@ -357,9 +378,12 @@ void InputInit()
     {
       std::string name = "EVTGENERATOR_" + std::to_string(i);
       PHG4SimpleEventGenerator *simple = new PHG4SimpleEventGenerator(name);
+    if (Input::EMBED)
+    {
       simple->Embed(Input::EmbedId);
       Input::PGEN_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::SimpleEventGenerator.push_back(simple);
     }
   }
@@ -369,9 +393,12 @@ void InputInit()
     {
       std::string name = "UPSILON_" + std::to_string(i);
       PHG4ParticleGeneratorVectorMeson *upsilon = new PHG4ParticleGeneratorVectorMeson(name);
+    if (Input::EMBED)
+    {
       upsilon->Embed(Input::EmbedId);
       Input::UPSILON_EmbedIds.insert(Input::EmbedId);
       Input::EmbedId++;
+    }
       INPUTGENERATOR::VectorMesonGenerator.push_back(upsilon);
     }
   }


### PR DESCRIPTION
This PR changes the embedding id handling in G4_Input.C Up to now the embed id was set to 1 for every input generator even when running non embedding. If embedding was run with the resulting DSTs the embedded particles also had embedid = 1 which made them indistinguishable from the background event. This PR sets the embedding id only if Input::EMBED is true so regular running does not set it (saving some memory since the embedding list stays empty). If Input::EMBED = true , the first input generator gets embedid = 1, the next embedid = 2 just like before.
Thanks to David Stewart to help finding this problem