### PR TITLE
start EmbedId = 2 if Input::EMBED is set

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -241,6 +241,13 @@ namespace INPUTMANAGER
 
 void InputInit()
 {
+  // for pileup sims embed id is 1, to distinguish particles
+  // which will be embedded (when Input::EMBED = true) into pileup sims
+  // we need to start at embedid = 2
+  if (Input::EMBED)
+  {
+    Input::EmbedId = 2;
+  }
   // first consistency checks - not all input generators play nice
   // with each other
   if (Input::READHITS && Input::EMBED)


### PR DESCRIPTION
This PR tries that again. Having a default embedding id of 0 is too disruptive and interferes with the pileup analysis. Now the embedid starts at 2 if Enable::EMBED is set to true so the embedded particles can be distinguished from the underlying event