### PR TITLE
Embed repeat

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -194,6 +194,7 @@ namespace INPUTEMBED
 {
   map<unsigned int, std::string> filename;
   map<unsigned int, std::string> listfile;
+  bool REPEAT = true;
 }  // namespace INPUTEMBED
 
 namespace PYTHIA6
@@ -523,7 +524,10 @@ void InputManagers()
       Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
       hitsin->fileopen(iter->second);
       hitsin->Verbosity(Input::VERBOSITY);
-      hitsin->Repeat();
+      if (INPUTEMBED::REPEAT)
+      {
+        hitsin->Repeat();
+      }
       se->registerInputManager(hitsin);
     }
     for (auto iter = INPUTEMBED::listfile.begin(); iter != INPUTEMBED::listfile.end(); ++iter)
@@ -532,7 +536,10 @@ void InputManagers()
       Fun4AllInputManager *hitsin = new Fun4AllDstInputManager(mgrname);
       hitsin->AddListFile(iter->second);
       hitsin->Verbosity(Input::VERBOSITY);
-      hitsin->Repeat();
+      if (INPUTEMBED::REPEAT)
+      {
+        hitsin->Repeat();
+      }
       se->registerInputManager(hitsin);
     }
   }

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -605,7 +605,8 @@ int Fun4All_G4_sPHENIX(
     return 0;
   }
   // if we run the particle generator and use 0 it'll run forever
-  if (nEvents == 0 && !Input::HEPMC && !Input::READHITS)
+  // for embedding it runs forever if the repeat flag is set
+  if (nEvents == 0 && !Input::HEPMC && !Input::READHITS && INPUTEMBED::REPEAT)
   {
     cout << "using 0 for number of events is a bad idea when using particle generators" << endl;
     cout << "it will run forever, so I just return without running anything" << endl;


### PR DESCRIPTION
This PR makes the input manager repeat flag accessible from the outside. By default it is set to true so one never runs out of embedding events (the input manager will just repeat the files it read). If one wants to run till the embedding file is exhausted (e.g. embedding pythia8 generated events into a hijing background file), one sets this to false and the number of events to run to 0. This will then process events until the embeddign file is exhausted