### PR TITLE
Moved loading distortion corrections from G4_TPC to G4_Tracking

### DIFF
--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -26,7 +26,6 @@
 #pragma GCC diagnostic pop
 
 #include <tpc/TpcClusterCleaner.h>
-#include <tpc/TpcLoadDistortionCorrection.h>
 
 #include <tpccalib/TpcDirectLaserReconstruction.h>
 
@@ -88,6 +87,9 @@ namespace G4TPC
   // save histograms
   bool DIRECT_LASER_SAVEHISTOGRAMS = false;
 
+  // do cluster <-> hit association
+  bool DO_HIT_ASSOCIATION = true;
+  
   // space charge calibration output file
   std::string DIRECT_LASER_ROOTOUTPUT_FILENAME = "TpcSpaceChargeMatrices.root";
   std::string DIRECT_LASER_HISTOGRAMOUTPUT_FILENAME = "TpcDirectLaserReconstruction.root"; 
@@ -276,6 +278,7 @@ void TPC_Clustering()
     auto tpcclusterizer = new TpcClusterizer;
     tpcclusterizer->set_drift_velocity_scale(G4TPC::drift_velocity_scale);
     tpcclusterizer->Verbosity(verbosity);
+    tpcclusterizer->set_do_hit_association( G4TPC::DO_HIT_ASSOCIATION );
     se->registerSubsystem(tpcclusterizer);
 
   }
@@ -285,14 +288,6 @@ void TPC_Clustering()
     auto tpcclustercleaner = new TpcClusterCleaner;
     tpcclustercleaner->Verbosity(verbosity);
     se->registerSubsystem(tpcclustercleaner);
-  }
-  
-  // space charge correction
-  if( G4TPC::ENABLE_CORRECTIONS )
-  {
-    auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
-    tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
-    se->registerSubsystem(tpcLoadDistortionCorrection);
   }
 
   // direct laser reconstruction

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -38,6 +38,7 @@ R__LOAD_LIBRARY(libqa_modules.so)
 #include <trackreco/PHTruthTrackSeeding.h>
 #include <trackreco/PHTruthVertexing.h>
 
+#include <tpc/TpcLoadDistortionCorrection.h>
 #include <tpccalib/PHTpcResiduals.h>
 
 #include <qa_modules/QAG4SimulationTracking.h>
@@ -69,7 +70,8 @@ namespace G4TRACKING
 
   // set to false to disable adding fake surfaces (TPC, Micromegas) to MakeActsGeom
   bool add_fake_surfaces = true;
-
+  bool init_acts_magfield = true;
+  
   // Truth seeding options for diagnostics (can use any or all)
   bool use_truth_silicon_seeding = false;     // if true runs truth silicon seeding instead of acts silicon seeding
   bool use_truth_tpc_seeding = false;         // if true runs truth silicon seeding instead of reco TPC seeding
@@ -88,17 +90,20 @@ void TrackingInit()
   }
 
   /// Build the Acts geometry
-  Fun4AllServer* se = Fun4AllServer::instance();
+  auto se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
   /// Geometry must be built before any Acts modules
   MakeActsGeometry* geom = new MakeActsGeometry();
   geom->Verbosity(verbosity);
+  
+  geom->loadMagField(G4TRACKING::init_acts_magfield);
   geom->setMagField(G4MAGNET::magfield);
   geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
   geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
   geom->build_mm_surfaces(Enable::MICROMEGAS);
   se->registerSubsystem(geom);
+  
 }
 
 void Tracking_Reco()
@@ -106,6 +111,16 @@ void Tracking_Reco()
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
+  // space charge correction
+  /* corrections are applied in the track finding, and via PHTpcClusterMover before the final track fit */
+  if( G4TPC::ENABLE_CORRECTIONS )
+  {
+    auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
+    tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
+    se->registerSubsystem(tpcLoadDistortionCorrection);
+  }
+
+  
   // Assemble silicon clusters into track stubs - needed for initial vertex finding
   //============================================================
   if (G4TRACKING::use_truth_silicon_seeding)


### PR DESCRIPTION
Moved loading distortion corrections from G4_TPC::TPC_Clustering to G4_Tracking::Tracking_Reco

The reason is that the distortion corrections are actually irrelevant to TPC clustering and relevant for the tracking.
This is particularily important if we split the clustering and the tracking to two different macros
Also added a flag to disable TPC hit_to_cluster association from the steering macro
And a flag to disable initializing the ACTS magnetic field
Both are needed to simplify the clusterize_only macro