### PR TITLE
Adjust order of high level truth table building

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -390,6 +390,13 @@ void Tracking_Eval(const std::string& outputfile)
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
+  // this module builds high level truth track association table.
+  // If this module is used, this table should be called before any evaluator calls.
+  // Removing this module, evaluation will still work but trace truth association through the layers of G4-hit-cluster
+  SvtxTruthRecoTableEval *tables = new SvtxTruthRecoTableEval();
+  tables->Verbosity(verbosity);
+  se->registerSubsystem(tables);
+
   //----------------
   // Tracking evaluation
   //----------------
@@ -410,10 +417,6 @@ void Tracking_Eval(const std::string& outputfile)
   eval->scan_for_primaries(true);  // defaults to only thrown particles for ntp_gtrack
   eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
-
-  SvtxTruthRecoTableEval *tables = new SvtxTruthRecoTableEval();
-  tables->Verbosity(verbosity);
-  se->registerSubsystem(tables);
 
   return;
 }


### PR DESCRIPTION
From https://github.com/sPHENIX-Collaboration/coresoftware/pull/1490 , it will require evaluator to use the high level truth tracking association table, if the table is present on the truth tree. A consequence is that `SvtxTruthRecoTableEval` need to be called before any evaluator calls. As the order is reversed in the default macro, evaluator output lack the track association output. 

This pull request make a quick work around on the macro level: just disable the `SvtxTruthRecoTableEva`, in which case evaluation will still work but trace truth association will analyze through the full reco layers of G4Particle-G4hit-hit-cluster-track

In addition, if `SvtxTruthRecoTableEval` is used, this table should be called before any evaluator calls, as reflected in the order changes. 

To make the system more robust, another longer term fix is needed on the `coresoftware` side to let truth tracking association table to differentiate two states: 1) Not yet been processed 2) processed but no truth matching produced (e.g. in low multiplicity events). @osbornjd  is working on this. During the work, there appears to be more problem in `SvtxTruthRecoTableEva`. Disable it for now in macros as mentioned above. 

Tested to having track matching back in the evaluator ntuple output. 

 

