### PR TITLE
Add xpload

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -434,6 +434,10 @@ void CEMC_Clusters()
     ClusterBuilder->set_threshold_energy(0.030);  // This threshold should be the same as in CEMCprof_Thresh**.root file below
     std::string emc_prof = getenv("CALIBRATIONROOT");
     emc_prof += "/EmcProfile/CEMCprof_Thresh30MeV.root";
+    if (Enable::XPLOAD)
+    {
+      emc_prof = "CDB";
+    }
     ClusterBuilder->LoadProfile(emc_prof);
     se->registerSubsystem(ClusterBuilder);
   }

--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -32,7 +32,14 @@ void MagnetFieldInit()
   }
   if (G4MAGNET::magfield.empty())
   {
-    G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");
+    if (Enable::XPLOAD)
+    {
+      G4MAGNET::magfield = "CDB";
+    }
+    else
+    {
+      G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");
+    }
   }
 }
 

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -20,8 +20,8 @@ namespace Input
 
 namespace DstOut
 {
-  string OutputDir = ".";
-  string OutputFile = "test.root";
+  std::string OutputDir = ".";
+  std::string OutputFile = "test.root";
 }  // namespace DstOut
 
 // Global settings affecting multiple subsystems
@@ -32,6 +32,7 @@ namespace Enable
   bool DSTOUT_COMPRESS = false;
   bool OVERLAPCHECK = false;
   bool SUPPORT = false;
+  bool XPLOAD = false;
   int VERBOSITY = 0;
 }  // namespace Enable
 
@@ -55,7 +56,7 @@ namespace G4P6DECAYER
 // our various tracking macro
 namespace TRACKING
 {
-  string TrackNodeName = "SvtxTrackMap";
+  std::string TrackNodeName = "SvtxTrackMap";
 }
 
 namespace G4MAGNET
@@ -64,6 +65,13 @@ namespace G4MAGNET
   // MagnetInit() functions. If used standalone (without the G4_Magnet include)
   // like in the tracking - those need to be set in the Fun4All macro
   double magfield_rescale = NAN;
-  string magfield;
+  std::string magfield;
 }  // namespace G4MAGNET
+
+namespace XPLOAD
+{
+  std::string config = "sPHENIX_cdb";
+  std::string tag = "TEST";
+  uint64_t timestamp = 12345678912345;
+}
 #endif

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -59,16 +59,6 @@ int Fun4All_G4_sPHENIX(
   // or set it to a fixed value so you can debug your code
   //  rc->set_IntFlag("RANDOMSEED", 12345);
 
-  //===============
-  // conditions DB flags
-  //===============
-  // tag
-  rc->set_StringFlag("XPLOAD_TAG","sPHENIX_ExampleGT_1");
-  // database config
-  rc->set_StringFlag("XPLOAD_CONFIG","sPHENIX_cdb");
-  // 64 bit timestamp
-  rc->set_uint64Flag("TIMESTAMP",12345678912345);
-
 
   //===============
   // Input options
@@ -377,6 +367,17 @@ int Fun4All_G4_sPHENIX(
 
   // run user provided code (from local G4_User.C)
   //Enable::USER = true;
+
+  //===============
+  // conditions DB flags
+  //===============
+  //Enable::XPLOAD = true;
+  // tag
+  rc->set_StringFlag("XPLOAD_TAG",XPLOAD::tag);
+  // database config
+  rc->set_StringFlag("XPLOAD_CONFIG",XPLOAD::config);
+  // 64 bit timestamp
+  rc->set_uint64Flag("TIMESTAMP",XPLOAD::timestamp);
 
   //---------------
   // World Settings


### PR DESCRIPTION
This PR adds Enable::XPLOAD which will enable reading from our conditions DB. The necessary parameters (tag, config, timestamp) are in the XPLOAD namespace. By default all is off. In our code (until we have a better idea), if a filename is set to CDB it will request the files from the conditions DB. That's so far only implemented for our big fieldmap in the sims and for the cemc profile thesholds