### PR TITLE
initialize acts geometry via common function

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -6,6 +6,7 @@
 #include <G4_Intt.C>
 #include <G4_Mvtx.C>
 #include <G4_TPC.C>
+#include <G4_Tracking.C>
 
 #include <g4micromegas/PHG4MicromegasDigitizer.h>
 #include <g4micromegas/PHG4MicromegasHitReco.h>
@@ -21,21 +22,17 @@
 R__LOAD_LIBRARY(libmicromegas.so)
 R__LOAD_LIBRARY(libg4micromegas.so)
 
+// some of the micromegas variables have been moved to GlobalVariables.C:
+// bool MICROMEGAS = false; // moved to GlobalVariables.C
+// int n_micromegas_layer = 2;
+// because they are also needed in other macros
+
 namespace Enable
 {
-  bool MICROMEGAS = false;
   bool MICROMEGAS_CELL = false;
   bool MICROMEGAS_CLUSTER = false;
   bool MICROMEGAS_QA = false;
 }  // namespace Enable
-
-namespace G4MICROMEGAS
-{
-
-  // number of micromegas layers
-  int n_micromegas_layer = 2;
-  
-}  // namespace G4MICROMEGAS
 
 void MicromegasInit()
 {
@@ -68,6 +65,8 @@ void Micromegas(PHG4Reco* g4Reco)
 
 void Micromegas_Cells()
 {
+// the acts geometry needs to go here since it will be used by the PHG4MicromegasHitReco
+  G4TRACKING::ActsGeomInit();
   auto se = Fun4AllServer::instance();
   // micromegas
   auto reco = new PHG4MicromegasHitReco;

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -82,10 +82,15 @@ namespace G4TRACKING
   // use of the various evaluation tools already available
   bool convert_seeds_to_svtxtracks = false;
 
-}  // namespace G4TRACKING
 
-void TrackingInit()
+void ActsGeomInit()
 {
+  static bool wasCalled = false;
+  if (wasCalled)
+  {
+    return;
+  }
+  wasCalled = true;
   if (!Enable::MICROMEGAS)
   {
     G4MICROMEGAS::n_micromegas_layer = 0;
@@ -106,11 +111,17 @@ void TrackingInit()
   geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
   geom->build_mm_surfaces(Enable::MICROMEGAS);
   se->registerSubsystem(geom);
+}
+}  // namespace G4TRACKING
 
+void TrackingInit()
+{
+  G4TRACKING::ActsGeomInit();
   // space charge correction
   /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit */
   if( G4TPC::ENABLE_CORRECTIONS )
   {
+    auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
     se->registerSubsystem(tpcLoadDistortionCorrection);

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -73,5 +73,17 @@ namespace XPLOAD
   std::string config = "sPHENIX_cdb";
   std::string tag = "TEST";
   uint64_t timestamp = 12345678912345;
+}  // namespace XPLOAD
+
+namespace Enable
+{
+  bool MICROMEGAS = false;
 }
+
+namespace G4MICROMEGAS
+{
+  // number of micromegas layers
+  int n_micromegas_layer = 2;
+}  // namespace G4MICROMEGAS
+
 #endif


### PR DESCRIPTION
This PR moves the module which creates the ACTS geometry into its own function. It is also used by the micromegas so it makes sure it's just called once. Some micromegas variables had to move to GlobalVariables to make this work. No changes in the top level macros are needed