### PR TITLE
Revert "The phi offset of the INTT barrel changed"

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -49,7 +49,7 @@ namespace G4INTT
   int nladder[4] = {12, 12, 16, 16};
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
-  double offsetphi[4] = {-0.5 * 360.0 / nladder[0], 0.0, -0.5 * 360.0 / nladder[2], 0.0 };
+  double offsetphi[4] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3]};
 
   enum enu_InttDeadMapType  // Dead map options for INTT
   {


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/macros#532
This crashes our evaluator - it needs further investigation before we can use that