### PR TITLE
Remove truth efficiency from PF

### DIFF
--- a/common/G4_ParticleFlow.C
+++ b/common/G4_ParticleFlow.C
@@ -33,7 +33,6 @@ void ParticleFlow()
   // note: assumes topoCluster input already configured
   ParticleFlowReco *pfr = new ParticleFlowReco();
   pfr->set_energy_match_Nsigma(1.5);
-  pfr->set_emulated_efficiency(1.0);
   pfr->Verbosity(verbosity);
   se->registerSubsystem(pfr);
 


### PR DESCRIPTION
This PR removes the truth efficiency setter from the particle flow algorithm in conjunction with the change to using reconstructed tracks.