### PR TITLE
Add MvtxHitPruner to G4_Mvtx.C.

### DIFF
--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -12,6 +12,7 @@
 
 #include <g4main/PHG4Reco.h>
 
+#include <mvtx/MvtxHitPruner.h>
 #include <mvtx/MvtxClusterizer.h>
 #include <qa_modules/QAG4SimulationMvtx.h>
 
@@ -113,6 +114,11 @@ void Mvtx_Clustering()
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
+ // prune the extra MVTX hits due to multiple strobes per hit
+  MvtxHitPruner* mvtxhitpruner = new MvtxHitPruner();
+  mvtxhitpruner->Verbosity(verbosity);
+  se->registerSubsystem(mvtxhitpruner);
+    
   // For the Mvtx layers
   //================
   MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");


### PR DESCRIPTION
This macros PR implements MvtxHitPruner. It accompanies coresoftware PR#1606. 

It should not be merged until after PR#1606 has been merged.