### PR TITLE
Set time windows for AuAu or pp running with a single flag

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -605,7 +605,10 @@ void InputManagers()
     INPUTMANAGER::HepMCPileupInputManager->AddFile(PILEUP::pileupfile);
     INPUTMANAGER::HepMCPileupInputManager->set_collision_rate(Input::PILEUPRATE);
     double time_window = 105.5 / PILEUP::TpcDriftVelocity;
-    INPUTMANAGER::HepMCPileupInputManager->set_time_window(-time_window, time_window);
+    double extended_readout_time = 0.0;
+    if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+    INPUTMANAGER::HepMCPileupInputManager->set_time_window(-time_window, time_window + extended_readout_time);
+    cout << "Pileup window is from " << -time_window << " to " <<  time_window + extended_readout_time << endl;
     se->registerInputManager(INPUTMANAGER::HepMCPileupInputManager);
   }
 }

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -165,9 +165,13 @@ void Intt_Cells()
   }
   // new storage containers
   PHG4InttHitReco* reco = new PHG4InttHitReco();
-  // The timing windows are hard-coded in the INTT ladder model, they can be overridden here
-  //reco->set_double_param("tmax",80.0);
-  //reco->set_double_param("tmin",-20.0);
+
+  // The timing window defaults are set in the INTT ladder model, they can be overridden here
+  double extended_readout_time = 0.0;
+  if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  reco->set_double_param("tmax", 80.0 + extended_readout_time);
+  reco->set_double_param("tmin", -20.0);
+  std::cout << "INTT readout window is set to -20 to " << 80.0 + extended_readout_time << std::endl;
   reco->Verbosity(verbosity);
   se->registerSubsystem(reco);
 

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -101,7 +101,7 @@ void Mvtx_Cells()
     // override the default timing window for this layer - default is +/- 5000 ns
     maps_hits->set_timing_window(ilayer, -maps_readout_window, maps_readout_window + extended_readout_time);
   }
-  std::cout << "MVTX readout window is from " << -maps_readout_window << " to " <<  maps_readout_window + extended_readout_time << std::endl;
+  std::cout << "PHG4MvtxHitReco: readout window is from " << -maps_readout_window << " to " <<  maps_readout_window + extended_readout_time << std::endl;
   se->registerSubsystem(maps_hits);
 
   PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -97,11 +97,10 @@ void Mvtx_Cells()
   double maps_readout_window = 5000.0;  // ns
   double extended_readout_time = 0.0;
   if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
-  for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
-  {
-    // override the default timing window for this layer - default is +/- 5000 ns
-    maps_hits->set_timing_window(ilayer, -maps_readout_window, maps_readout_window + extended_readout_time);
-  }
+  // override the default timing window - default is +/- 5000 ns
+  maps_hits->set_double_param("mvtx_tmin",  -maps_readout_window);
+  maps_hits->set_double_param("mvtx_tmax",  maps_readout_window + extended_readout_time);
+
   std::cout << "PHG4MvtxHitReco: readout window is from " << -maps_readout_window << " to " <<  maps_readout_window + extended_readout_time << std::endl;
   se->registerSubsystem(maps_hits);
 

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -92,11 +92,16 @@ void Mvtx_Cells()
   // new storage containers
   PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
   maps_hits->Verbosity(verbosity);
+
+  double maps_readout_window = 5000.0;  // ns
+  double extended_readout_time = 0.0;
+  if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
   {
     // override the default timing window for this layer - default is +/- 5000 ns
-    maps_hits->set_timing_window(ilayer, -5000, 5000);
+    maps_hits->set_timing_window(ilayer, -maps_readout_window, maps_readout_window + extended_readout_time);
   }
+  std::cout << "MVTX readout window is from " << -maps_readout_window << " to " <<  maps_readout_window + extended_readout_time << std::endl;
   se->registerSubsystem(maps_hits);
 
   PHG4MvtxDigitizer* digimvtx = new PHG4MvtxDigitizer();

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -234,11 +234,11 @@ void TPC_Cells()
     edrift->setTpcDistortion( distortionMap );
   }
 
-  double tpc_readout_time = 13200;  // ns
+  double tpc_readout_time = 105.5/ G4TPC::tpc_drift_velocity_sim;  // ns
   double extended_readout_time = 0.0;
   if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   edrift->set_double_param("max_time", tpc_readout_time + extended_readout_time);
-  std::cout << "TPC readout window is from 0 to " <<  tpc_readout_time + extended_readout_time << std::endl;
+  std::cout << "PHG4TpcElectronDrift readout window is from 0 to " <<  tpc_readout_time + extended_readout_time << std::endl;
 
   // override the default drift velocity parameter specification
   edrift->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -234,6 +234,12 @@ void TPC_Cells()
     edrift->setTpcDistortion( distortionMap );
   }
 
+  double tpc_readout_time = 13200;  // ns
+  double extended_readout_time = 0.0;
+  if(TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  edrift->set_double_param("max_time", tpc_readout_time + extended_readout_time);
+  std::cout << "TPC readout window is from 0 to " <<  tpc_readout_time + extended_readout_time << std::endl;
+
   // override the default drift velocity parameter specification
   edrift->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
   padplane->SetDriftVelocity(G4TPC::tpc_drift_velocity_sim);

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -184,7 +184,7 @@ void Tracking_Reco_TrackSeed()
       {
         seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
       }
-      seeder->Verbosity(0);
+      seeder->Verbosity(verbosity);
       seeder->SetLayerRange(7, 55);
       seeder->SetSearchWindow(0.01, 0.02);  // (eta width, phi width)
       seeder->SetMinHitsPerCluster(0);
@@ -220,7 +220,7 @@ void Tracking_Reco_TrackSeed()
       // The normal silicon association methods
       // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
       auto silicon_match = new PHSiliconTpcTrackMatching;
-      silicon_match->Verbosity(1);
+      silicon_match->Verbosity(verbosity);
       silicon_match->set_field(G4MAGNET::magfield);
       silicon_match->set_field_dir(G4MAGNET::magfield_rescale);
       silicon_match->set_pp_mode(TRACKING::pp_mode);
@@ -310,13 +310,13 @@ void Tracking_Reco_TrackFit()
 
   // correct clusters for particle propagation in TPC
   auto deltazcorr = new PHTpcDeltaZCorrection;
-  deltazcorr->Verbosity(1);
+  deltazcorr->Verbosity(verbosity);
   se->registerSubsystem(deltazcorr);
   
 
   // perform final track fit with ACTS
   auto actsFit = new PHActsTrkFitter;
-  actsFit->Verbosity(2);
+  actsFit->Verbosity(verbosity);
   
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
@@ -349,7 +349,7 @@ void Tracking_Reco_TrackFit()
       // Choose the best silicon matched track for each TPC track seed
       /* this breaks in truth_track seeding mode because there is no TpcSeed */
       auto cleaner = new PHTrackCleaner;
-      cleaner->Verbosity(5);
+      cleaner->Verbosity(verbosity);
       se->registerSubsystem(cleaner);
     }
     
@@ -437,7 +437,7 @@ void Tracking_Eval(const std::string& outputfile)
   eval->scan_for_embedded(embed_scan);   // take all tracks if false - take only embedded tracks if true
   eval->scan_for_primaries(embed_scan);  // defaults to only thrown particles for ntp_gtrack
   std::cout << "SvtxEvaluator: pp_mode set to " << TRACKING::pp_mode << " and scan_for_embedded set to " << embed_scan << std::endl;
-  eval->Verbosity(1);
+  eval->Verbosity(verbosity);
   se->registerSubsystem(eval);
 
   return;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -57,6 +57,8 @@ namespace G4P6DECAYER
 namespace TRACKING
 {
   std::string TrackNodeName = "SvtxTrackMap";
+  double pp_mode = true;
+  double pp_extended_readout_time = 7000.0;  // ns
 }
 
 namespace G4MAGNET

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -57,7 +57,7 @@ namespace G4P6DECAYER
 namespace TRACKING
 {
   std::string TrackNodeName = "SvtxTrackMap";
-  double pp_mode = true;
+  double pp_mode = false;
   double pp_extended_readout_time = 7000.0;  // ns
 }
 


### PR DESCRIPTION
This PR sets a single flag, "TRACKING::pp_mode", in GlobalVariables.C that selects either AuAu or pp running with extended readout. Depending on whether that flag is true or false, the subsystem macros automatically set the pileup time window and the g4hit time windows in the tracking HitReco modules. 

During reconstruction, if the pp flag is set to true, the silicon-TPC track matching takes all bunch crossings. If it is set to false, it takes only crossing zero - the triggered crossing. Temporarily, if the pp-mode flag is set to true, the truth TPC seeding is selected because the CA seeder at the moment does not find seeds that point to large absolute z values - cutting out crossings beyond about 2 microseconds from the triggered crossing. This will be fixed when the CA seeding is updated to be track-z agnostic.

The "TRACKING::pp_mode" flag is set to false (i.e. to AuAu running) by default. For pp running the extended readout time is set to a default of 7 microseconds, otherwise it is zero. 

