### PR TITLE
Add common modules

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -114,10 +114,6 @@ double HCalInner(PHG4Reco *g4Reco,
   if (Enable::HCALIN_OLD)
   {
     hcal = new PHG4InnerHcalSubsystem("HCALIN");
-    if (! isfinite(G4HCALIN::phistart))
-    {
-      G4HCALIN::phistart = 0.0328877688; // offet in phi (from zero) extracted from geantinos
-    }
     // these are the parameters you can change with their default settings
     // hcal->set_string_param("material","SS310");
     if (G4HCALIN::inner_hcal_material_Al)
@@ -175,10 +171,6 @@ double HCalInner(PHG4Reco *g4Reco,
     hcal = new PHG4IHCalSubsystem("HCALIN");
     std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/InnerHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
-    if (! isfinite(G4HCALIN::phistart))
-    {
-      G4HCALIN::phistart = 0.0295080867; // extracted from geantinos
-    }
   }
   if (G4HCALIN::light_scint_model >= 0)
   {
@@ -272,6 +264,17 @@ void HCALInner_Towers()
   HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalInRawTowerBuilder");
   TowerBuilder->Detector("HCALIN");
   TowerBuilder->set_sim_tower_node_prefix("SIM");
+  if (! isfinite(G4HCALIN::phistart))
+  {
+    if (Enable::HCALIN_OLD)
+    {
+      G4HCALIN::phistart = 0.0328877688; // offet in phi (from zero) extracted from geantinos
+    }
+    else
+    {
+      G4HCALIN::phistart = 0.0295080867; // extracted from geantinos
+    }
+  }
   TowerBuilder->set_double_param("phistart",G4HCALIN::phistart);
   if (isfinite(G4HCALIN::tower_emin))
   {

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -49,7 +49,7 @@ namespace G4HCALOUT
 {
   double outer_radius = 264.71;
   double size_z = 304.91 * 2;
-  double phistart = 0.026598397;
+  double phistart = NAN;
   double tower_emin = NAN;
   int light_scint_model = -1;
   int tower_energy_source = -1;
@@ -95,11 +95,6 @@ double HCalOuter(PHG4Reco *g4Reco,
   if (Enable::HCALOUT_OLD)
   {
     hcal = new PHG4OuterHcalSubsystem("HCALOUT");
-    if (! isfinite(G4HCALOUT::phistart))
-    {
-      G4HCALOUT::phistart = 0.026598397; // offet in phi (from zero) extracted from geantinos
-    }
-    
     // hcal->set_double_param("inner_radius", 183.3);
     //-----------------------------------------
     // the light correction can be set in a single call
@@ -142,11 +137,6 @@ double HCalOuter(PHG4Reco *g4Reco,
     hcal = new PHG4OHCalSubsystem("HCALOUT");
 std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
-    if (! isfinite(G4HCALOUT::phistart))
-    {
-      G4HCALOUT::phistart = -0.0248462127; // offet in phi (from zero) extracted from geantinos
-    }
-
   }
 
   if (G4HCALOUT::light_scint_model >= 0)
@@ -202,6 +192,17 @@ void HCALOuter_Towers()
   HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalOutRawTowerBuilder");
   TowerBuilder->Detector("HCALOUT");
   TowerBuilder->set_sim_tower_node_prefix("SIM");
+  if (! isfinite(G4HCALOUT::phistart))
+  {
+    if (Enable::HCALOUT_OLD)
+    {
+      G4HCALOUT::phistart = 0.026598397; // offet in phi (from zero) extracted from geantinos
+    }
+    else
+    {
+      G4HCALOUT::phistart = -0.0248462127; // offet in phi (from zero) extracted from geantinos
+    }
+  }
   TowerBuilder->set_double_param("phistart",G4HCALOUT::phistart);
   if (isfinite(G4HCALOUT::tower_emin))
   {

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -21,6 +21,11 @@
 #include <G4_User.C>
 #include <QA.C>
 
+#include <ffamodules/FlagHandler.h>
+#include <ffamodules/HeadReco.h>
+#include <ffamodules/SyncReco.h>
+#include <ffamodules/XploadInterface.h>
+
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllOutputManager.h>
 #include <fun4all/Fun4AllServer.h>
@@ -29,6 +34,7 @@
 #include <phool/recoConsts.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
 
 // For HepMC Hijing
 // try inputFile = /sphenix/sim/sim01/sphnxpro/sHijing_HepMC/sHijing_0-12fm.dat
@@ -221,6 +227,22 @@ int Fun4All_G4_sPHENIX(
   }
   // register all input generators with Fun4All
   InputRegister();
+
+  if (! Input::READHITS)
+  {
+    rc->set_IntFlag("RUNNUMBER",1);
+
+    SyncReco *sync = new SyncReco();
+    se->registerSubsystem(sync);
+
+    HeadReco *head = new HeadReco();
+    se->registerSubsystem(head);
+  }
+// Flag Handler is always needed to read flags from input (if used)
+// and update our rc flags with them. At the end it saves all flags
+// again on the DST in the Flags node under the RUN node
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
 
   // set up production relatedstuff
   //   Enable::PRODUCTION = true;


### PR DESCRIPTION
This PR adds the SyncReco, HeadReco and FlagHandler to the Fun4All_G4_sPHENIX.C macro. The runnumber is set to 1, SyncReco and HeadReco are only called for sims, not when reading from a file. The FlagHandler should always be registered, it reads the flags from the DST (if they exist) and adds them to the recoConst flags. At the End() it saves the flags on the DST (removed flags are discarded).
Fixes a problem in the G4_HcalIn_ref.C/G4_HcalOut_ref.C where phistart was set during the G4 simulation setup. If reading from a DST this is skipped, leading to NAN's in phi of the inner hcal and the phistart value for the old outer hcal in the outer hcal. Now this is set right before the tower reco is set up. 