### PR TITLE
fix bbc black hole overlap

### DIFF
--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -40,7 +40,7 @@ void BbcInit()
   {
     BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 300.);
     BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -300.);
-    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 15.0);
+    BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 125.0);
   }
 }
 


### PR DESCRIPTION
This PR fixes the overlap of the bbc cables with the surrounding black hole. The cables stick out 120cm upwards, the black hole radius was adjusted accordingly. If run with other (larger radius) detectors (e.g. sPHENIX) this doesn't matter