### PR TITLE
Separate acts geom

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -1,0 +1,54 @@
+#ifndef MACRO_G4ACTSGEOM_C
+#define MACRO_G4ACTSGEOM_C
+
+R__LOAD_LIBRARY(libg4eval.so)
+R__LOAD_LIBRARY(libtrack_reco.so)
+R__LOAD_LIBRARY(libtpccalib.so)
+R__LOAD_LIBRARY(libqa_modules.so)
+
+#include <GlobalVariables.C>
+
+#include <G4_Magnet.C>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundefined-internal"
+#include <trackreco/MakeActsGeometry.h>
+#pragma GCC diagnostic pop
+
+#include <fun4all/Fun4AllServer.h>
+
+
+namespace ACTSGEOM
+{
+  void ActsGeomInit()
+  {
+    static bool wasCalled = false;
+    if (wasCalled)
+    {
+      return;
+    }
+    wasCalled = true;
+    if (!Enable::MICROMEGAS)
+    {
+      G4MICROMEGAS::n_micromegas_layer = 0;
+    }
+
+    // Build the Acts geometry
+    auto se = Fun4AllServer::instance();
+    int verbosity = Enable::VERBOSITY;
+
+    // Geometry must be built before any Acts modules
+    MakeActsGeometry* geom = new MakeActsGeometry();
+    geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
+    geom->Verbosity(verbosity);
+  
+    geom->loadMagField(G4TRACKING::init_acts_magfield);
+    geom->setMagField(G4MAGNET::magfield);
+    geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
+    geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
+    geom->build_mm_surfaces(Enable::MICROMEGAS);
+    se->registerSubsystem(geom);
+  }
+}  // namespace ACTSGEOM
+
+#endif

--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -3,6 +3,7 @@
 
 #include <GlobalVariables.C>
 
+#include <G4_ActsGeom.C>
 #include <G4_Intt.C>
 #include <G4_Mvtx.C>
 #include <G4_TPC.C>
@@ -66,7 +67,7 @@ void Micromegas(PHG4Reco* g4Reco)
 void Micromegas_Cells()
 {
 // the acts geometry needs to go here since it will be used by the PHG4MicromegasHitReco
-  G4TRACKING::ActsGeomInit();
+  ACTSGEOM::ActsGeomInit();
   auto se = Fun4AllServer::instance();
   // micromegas
   auto reco = new PHG4MicromegasHitReco;

--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -2,10 +2,11 @@
 #define MACRO_G4TPC_C
 
 #include <GlobalVariables.C>
-#include <QA.C>
 
+#include <G4_ActsGeom.C>
 #include <G4_Intt.C>
 #include <G4_Mvtx.C>
+#include <QA.C>
 
 #include <g4tpc/PHG4TpcCentralMembrane.h>
 #include <g4tpc/PHG4TpcDigitizer.h>
@@ -66,7 +67,8 @@ namespace G4TPC
 
   // drift velocity is set here for all relevant modules
   double tpc_drift_velocity_sim= 8.0 / 1000.0;  // cm/ns   // this is the Ne version of the gas
-  double tpc_drift_velocity_reco= 8.0 / 1000.0;  // cm/ns   // this is the Ne version of the gas
+//  double tpc_drift_velocity_reco now set in GlobalVariables.C
+//  double tpc_drift_velocity_reco= 8.0 / 1000.0;  // cm/ns   // this is the Ne version of the gas
 
   // use simple clusterizer
   bool USE_SIMPLE_CLUSTERIZER = false;
@@ -276,7 +278,7 @@ void TPC_Cells()
 void TPC_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
-
+  ACTSGEOM::ActsGeomInit();
   Fun4AllServer* se = Fun4AllServer::instance();
 
   //-------------

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -8,6 +8,7 @@ R__LOAD_LIBRARY(libqa_modules.so)
 
 #include <GlobalVariables.C>
 
+#include <G4_ActsGeom.C>
 #include <G4_Intt.C>
 #include <G4_Micromegas.C>
 #include <G4_Mvtx.C>
@@ -67,8 +68,9 @@ namespace G4TRACKING
   bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
 
   // set to false to disable adding fake surfaces (TPC, Micromegas) to MakeActsGeom
-  bool add_fake_surfaces = true;
-  bool init_acts_magfield = true;
+// now declared in GlobalVariables.C
+  // bool add_fake_surfaces = true;
+  // bool init_acts_magfield = true;
   
   // Truth seeding options for diagnostics (can use any or all)
   bool use_truth_silicon_seeding = false;     // if true runs truth silicon seeding instead of acts silicon seeding
@@ -82,41 +84,11 @@ namespace G4TRACKING
   // use of the various evaluation tools already available
   bool convert_seeds_to_svtxtracks = false;
 
-
-void ActsGeomInit()
-{
-  static bool wasCalled = false;
-  if (wasCalled)
-  {
-    return;
-  }
-  wasCalled = true;
-  if (!Enable::MICROMEGAS)
-  {
-    G4MICROMEGAS::n_micromegas_layer = 0;
-  }
-
-  // Build the Acts geometry
-  auto se = Fun4AllServer::instance();
-  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
-
-  // Geometry must be built before any Acts modules
-  MakeActsGeometry* geom = new MakeActsGeometry();
-  geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
-  geom->Verbosity(verbosity);
-  
-  geom->loadMagField(G4TRACKING::init_acts_magfield);
-  geom->setMagField(G4MAGNET::magfield);
-  geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-  geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
-  geom->build_mm_surfaces(Enable::MICROMEGAS);
-  se->registerSubsystem(geom);
-}
 }  // namespace G4TRACKING
 
 void TrackingInit()
 {
-  G4TRACKING::ActsGeomInit();
+  ACTSGEOM::ActsGeomInit();
   // space charge correction
   /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit */
   if( G4TPC::ENABLE_CORRECTIONS )

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -88,4 +88,17 @@ namespace G4MICROMEGAS
   int n_micromegas_layer = 2;
 }  // namespace G4MICROMEGAS
 
+namespace G4TPC
+{
+ double tpc_drift_velocity_reco= 8.0 / 1000.0;  // cm/ns   // this is the Ne version of the gas
+}
+
+namespace G4TRACKING
+{
+  // set to false to disable adding fake surfaces (TPC, Micromegas) to MakeActsGeom
+  bool add_fake_surfaces = true;
+  bool init_acts_magfield = true;
+}
+
+
 #endif


### PR DESCRIPTION
This PR separates the ActsGeomInit() into its own macro. Variables which are used by more than one macro were moved to GlobalVariables.C so macros can be included in random order. That should take care of the observed problems like:
https://chat.sdcc.bnl.gov/sphenix/pl/edugauo5ujd5uytf3fq5rdrxxw