### PR TITLE
Update with no fake surface call

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -22,12 +22,7 @@ namespace ACTSGEOM
 {
   void ActsGeomInit()
   {
-    static bool wasCalled = false;
-    if (wasCalled)
-    {
-      return;
-    }
-    wasCalled = true;
+  
     if (!Enable::MICROMEGAS)
     {
       G4MICROMEGAS::n_micromegas_layer = 0;
@@ -45,7 +40,6 @@ namespace ACTSGEOM
     geom->loadMagField(G4TRACKING::init_acts_magfield);
     geom->setMagField(G4MAGNET::magfield);
     geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
-    geom->add_fake_surfaces(G4TRACKING::add_fake_surfaces);
     geom->build_mm_surfaces(Enable::MICROMEGAS);
     se->registerSubsystem(geom);
   }

--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -66,11 +66,6 @@ namespace G4TRACKING
 
   // Vertexing
   bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
-
-  // set to false to disable adding fake surfaces (TPC, Micromegas) to MakeActsGeom
-// now declared in GlobalVariables.C
-  // bool add_fake_surfaces = true;
-  // bool init_acts_magfield = true;
   
   // Truth seeding options for diagnostics (can use any or all)
   bool use_truth_silicon_seeding = false;     // if true runs truth silicon seeding instead of acts silicon seeding


### PR DESCRIPTION
This PR removes the fake surface setter function as a forthcoming coresoftware PR will do this check automatically