### PR TITLE
Return check for geometry building

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -22,7 +22,13 @@ namespace ACTSGEOM
 {
   void ActsGeomInit()
   {
-  
+    static bool wasCalled = false;
+    if (wasCalled)
+    {
+      return;
+    }
+    wasCalled = true;
+
     if (!Enable::MICROMEGAS)
     {
       G4MICROMEGAS::n_micromegas_layer = 0;


### PR DESCRIPTION
Return the static check for building of acts geometry, so that we don't run it more than we need to.