### PR TITLE
adjust phistart for fixed outer hcal from gdml

### DIFF
--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -200,7 +200,7 @@ void HCALOuter_Towers()
     }
     else
     {
-      G4HCALOUT::phistart = -0.0248462127; // offet in phi (from zero) extracted from geantinos
+      G4HCALOUT::phistart = -0.024960211; // offet in phi (from zero) extracted from geantinos
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALOUT::phistart);


### PR DESCRIPTION
This PR makes a minute adjustment for phistart for the outer hcal from gdml to center the tower phi around the geantinos (straight line from vertex)