### PR TITLE
Gdml hcals

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -46,7 +46,7 @@ namespace Enable
   bool HCALIN_EVAL = false;
   bool HCALIN_QA = false;
   bool HCALIN_SUPPORT = false;
-  bool HCALIN_OLD = true;
+  bool HCALIN_OLD = false;
   int HCALIN_VERBOSITY = 0;
 }  // namespace Enable
 

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -41,7 +41,7 @@ namespace Enable
   bool HCALOUT_CLUSTER = false;
   bool HCALOUT_EVAL = false;
   bool HCALOUT_QA = false;
-  bool HCALOUT_OLD = true;
+  bool HCALOUT_OLD = false;
   int HCALOUT_VERBOSITY = 0;
 }  // namespace Enable
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -305,7 +305,7 @@ int Fun4All_G4_sPHENIX(
   Enable::MICROMEGAS_CLUSTER = Enable::MICROMEGAS_CELL && true;
   Enable::MICROMEGAS_QA = Enable::MICROMEGAS_CLUSTER && Enable::QA && true;
 
-  Enable::TRACKING_TRACK = true;
+  Enable::TRACKING_TRACK = (Enable::MICROMEGAS_CLUSTER && Enable::TPC_CLUSTER && Enable::INTT_CLUSTER && Enable::MVTX_CLUSTER) && true;
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
   Enable::TRACKING_QA = Enable::TRACKING_TRACK && Enable::QA && true;
 


### PR DESCRIPTION
This PR makes the gdml based hcals the default The old geometry based hcals can be run by setting
ENABLE::HCALIN_OLD = true;
ENABLE::HCALOUT_OLD = true;
in the Fun4All_G4_sPHENIX.C macro
