### PR TITLE
enable tpot

### DIFF
--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -79,7 +79,7 @@ namespace XPLOAD
 
 namespace Enable
 {
-  bool MICROMEGAS = false;
+  bool MICROMEGAS = true;
 }
 
 namespace G4MICROMEGAS


### PR DESCRIPTION
The TPOT is not enabled by default. Is there a reason for this @pinkenburg ? This causes a crash in the tracking over the hits files when looking for the TPOT geometry.