### PR TITLE
Seeding overhaul window settings

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -153,7 +153,7 @@ void Tracking_Reco_TrackSeed()
       }
       seeder->Verbosity(verbosity);
       seeder->SetLayerRange(7, 55);
-      seeder->SetSearchWindow(0.01, 0.02);  // (eta width, phi width)
+      seeder->SetSearchWindow(1.5, 0.05);  // (z width, phi width)
       seeder->SetMinHitsPerCluster(0);
       seeder->SetMinClustersPerTrack(3);
       seeder->useConstBField(false);


### PR DESCRIPTION
Switching from a delta-eta to a delta-z window in TPC seeding requires a change to the default search window parameters in common/G4_Tracking.C. 