### PR TITLE
Hcal updates

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -110,6 +110,16 @@ double HCalInner(PHG4Reco *g4Reco,
   int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
 
   PHG4DetectorSubsystem *hcal;
+  //  Mephi Maps
+  //  Maps are different for old/new but how to set is identical
+  //  here are the ones for the gdml based inner hcal
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
+  //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
+  //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
+
   // all sizes are in cm!
   if (Enable::HCALIN_OLD)
   {
@@ -171,9 +181,6 @@ double HCalInner(PHG4Reco *g4Reco,
     hcal = new PHG4IHCalSubsystem("HCALIN");
     std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/InnerHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
-    //  use hcal->set_string_param("MapFileName",""); to disable map
-    //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
-    //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
   }
   if (G4HCALIN::light_scint_model >= 0)
   {

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -171,6 +171,9 @@ double HCalInner(PHG4Reco *g4Reco,
     hcal = new PHG4IHCalSubsystem("HCALIN");
     std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/InnerHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
+    //  use hcal->set_string_param("MapFileName",""); to disable map
+    //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALIN/tilemap/ihcalgdmlmap09212022.root");
+    //  hcal->set_string_param("MapHistoName","ihcalcombinedgdmlnormtbyt");
   }
   if (G4HCALIN::light_scint_model >= 0)
   {
@@ -198,6 +201,7 @@ double HCalInner(PHG4Reco *g4Reco,
 void HCalInner_SupportRing(PHG4Reco *g4Reco)
 {
   bool AbsorberActive = Enable::SUPPORT || Enable::HCALIN_SUPPORT;
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALIN_OVERLAPCHECK;
 
   const double z_ring1 = (2025 + 2050) / 2. / 10.;
   const double innerradius_sphenix = 116.;
@@ -226,6 +230,7 @@ void HCalInner_SupportRing(PHG4Reco *g4Reco)
     {
       cyl->SetActive();
     }
+    cyl->OverlapCheck(OverlapCheck);
     g4Reco->registerSubsystem(cyl);
   }
 

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -92,6 +92,13 @@ double HCalOuter(PHG4Reco *g4Reco,
   int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
 
   PHG4DetectorSubsystem *hcal;
+  //  Mephi Maps
+  //  Maps are different for old/new but how to set is identical
+  //  here are the ones for the old outer hcal since the new maps do not exist yet
+  //  use hcal->set_string_param("MapFileName",""); to disable map
+  //  hcal->set_string_param("MapFileName",std::string(getenv("CALIBRATIONROOT")) + "/HCALOUT/tilemap/oHCALMaps092021.root");
+  //  hcal->set_string_param("MapHistoName","hCombinedMap");
+
   if (Enable::HCALOUT_OLD)
   {
     hcal = new PHG4OuterHcalSubsystem("HCALOUT");


### PR DESCRIPTION
This PR adds examples how to change the mephi maps in the macros after they are changed from hardcoded to PHParameters. Added the overlap check option to the inner hcal support rings (let's see how this goes)