### PR TITLE
Enable field map in the HCal steel

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -100,7 +100,7 @@ CEmc_2DProjectiveSpacal(PHG4Reco *g4Reco, double radius, const int crossings)
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::CEMC_OVERLAPCHECK;
 
   double emc_inner_radius = 92;  // emc inner radius from engineering drawing
-  double cemcthickness = 24.00000 - no_overlapp;
+  double cemcthickness = 22.50000 - no_overlapp;
 
   //max radius is 116 cm;
   double emc_outer_radius = emc_inner_radius + cemcthickness;  // outer radius

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -285,7 +285,7 @@ void HCALInner_Towers()
     }
     else
     {
-      G4HCALIN::phistart = 0.0295080867; // extracted from geantinos
+      G4HCALIN::phistart = M_PI ; // // reset phi angle start after HCal coordinate system correction
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALIN::phistart);

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -198,7 +198,7 @@ double HCalInner(PHG4Reco *g4Reco,
 
   radius = hcal->get_double_param("outer_radius");
 
-  HCalInner_SupportRing(g4Reco);
+  // HCalInner_SupportRing(g4Reco);
 
   radius += no_overlapp;
   return radius;
@@ -233,6 +233,7 @@ void HCalInner_SupportRing(PHG4Reco *g4Reco)
     cyl->set_double_param("length", G4HCALIN::dz);
     cyl->set_string_param("material", "SS310");
     cyl->set_double_param("thickness", G4HCALIN::support_ring_outer_radius - innerradius);
+    cyl->OverlapCheck(Enable::OVERLAPCHECK);
     if (AbsorberActive)
     {
       cyl->SetActive();

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -47,8 +47,8 @@ namespace Enable
 
 namespace G4HCALOUT
 {
-  double outer_radius = 264.71;
-  double size_z = 304.91 * 2;
+  double outer_radius = 269.317  + 5;
+  double size_z = 639.240 + 10;
   double phistart = NAN;
   double tower_emin = NAN;
   int light_scint_model = -1;
@@ -152,6 +152,7 @@ std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/Outer
   {
     hcal->set_int_param("light_scint_model", G4HCALOUT::light_scint_model);
   }
+  // hcal->set_int_param("field_check", 1); // for validating the field in HCal
   hcal->SetActive();
   hcal->SuperDetector("HCALOUT");
   if (AbsorberActive)
@@ -209,7 +210,7 @@ void HCALOuter_Towers()
     }
     else
     {
-      G4HCALOUT::phistart = -0.024960211; // offet in phi (from zero) extracted from geantinos
+      G4HCALOUT::phistart = M_PI ; // reset phi angle start after HCal coordinate system correction
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALOUT::phistart);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -144,6 +144,8 @@ double HCalOuter(PHG4Reco *g4Reco,
     hcal = new PHG4OHCalSubsystem("HCALOUT");
 std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
+    hcal->set_string_param("IronFieldMapPath", G4MAGNET::magfield_OHCAL_steel);
+    hcal->set_double_param("IronFieldMapScale", G4MAGNET::magfield_rescale);
   }
 
   if (G4HCALOUT::light_scint_model >= 0)

--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -32,7 +32,8 @@ void MagnetFieldInit()
   }
   if (G4MAGNET::magfield.empty())
   {
-    G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz.root");
+    G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz_gap_rebuild.root");
+    G4MAGNET::magfield_OHCAL_steel = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz_steel_rebuild.root");
   }
 }
 

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -68,6 +68,7 @@ namespace G4MAGNET
   // like in the tracking - those need to be set in the Fun4All macro
   double magfield_rescale = NAN;
   std::string magfield;
+  std::string magfield_OHCAL_steel;
 }  // namespace G4MAGNET
 
 namespace XPLOAD


### PR DESCRIPTION
Follow up to https://github.com/sPHENIX-Collaboration/coresoftware/pull/1679, enabling field map in the HCal steel

Changes also include: 
* EMCal geometry update to be consistent with inner HCal envelope
* Hcal envelopes adjustment
* Reset HCal sector0 phi angle, which require another geantinos scan 