### PR TITLE
Fix overlap

### DIFF
--- a/common/G4_BeamLine.C
+++ b/common/G4_BeamLine.C
@@ -38,7 +38,7 @@ namespace G4BEAMLINE
   // the beampipes seem to add 2 no_overlaps - needs to be looked at
   // but this z position takes care of our current overlap issues
   double starting_z =  G4PIPE::max_z + 2*no_overlapp;
-  double enclosure_z_max = 2050. + (700-starting_z);
+  double enclosure_z_max = 2050. + (800-starting_z);
   double enclosure_r_max = 30.;  // 30cm radius to cover magnets
   double enclosure_center = 0.5 * (starting_z + enclosure_z_max);
   double skin_thickness = 0.; // if center of magnet iron is black hole - thickness of Fe surrounding it

--- a/common/G4_EPD.C
+++ b/common/G4_EPD.C
@@ -16,12 +16,18 @@ namespace Enable
   bool EPD_OVERLAPCHECK = false;
 }  // namespace Enable
 
+namespace G4EPD
+{
+  double dz = 6.;
+  double place_z = 316.;
+}
+
 void EPDInit()
 {
-  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 90.);
+  BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 91.);
   // using default z-position and add 10 cm for tile thickness
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -310.);
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 310.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4EPD::place_z - G4EPD::dz/2. - no_overlapp);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4EPD::place_z + G4EPD::dz/2. + no_overlapp);
 }
 
 void EPD(PHG4Reco* g4Reco)

--- a/common/G4_Mvtx.C
+++ b/common/G4_Mvtx.C
@@ -68,14 +68,14 @@ double Mvtx(PHG4Reco* g4Reco, double radius,
   for (int ilayer = 0; ilayer < G4MVTX::n_maps_layer; ilayer++)
   {
     double radius_lyr = PHG4MvtxDefs::mvtxdat[ilayer][PHG4MvtxDefs::kRmd];
-    mvtx->set_double_param(ilayer, "layer_z_offset", G4MVTXAlignment::z_offset[ilayer]);
+//    mvtx->set_double_param(ilayer, "layer_z_offset", G4MVTXAlignment::z_offset[ilayer]);
     if (verbosity)
     {
       cout << "Create Maps layer " << ilayer << " with radius " << radius_lyr << " mm." << endl;
     }
     radius = radius_lyr / 10.;
   }
-  mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "alignment_path",  G4MVTXAlignment::alignment_path);
+//  mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "alignment_path",  G4MVTXAlignment::alignment_path);
   mvtx->set_string_param(PHG4MvtxDefs::GLOBAL, "stave_geometry_file", string(getenv("CALIBRATIONROOT")) + string("/Tracking/geometry/mvtx_stave_v1.gdml"));
 
   mvtx->SetActive();

--- a/common/G4_Pipe.C
+++ b/common/G4_Pipe.C
@@ -40,7 +40,8 @@ namespace G4PIPE
   double outer_pipe_thickness = 0.1397;             // 1.397 mm or 0.055"
   double outer_pipe_cone_length = 38.1;
   double outer_pipe_ext_radius = 3.81;    // past the cone
-  double outer_pipe_ext_length = 67.087;    // extension beyond conical part
+//  double outer_pipe_ext_length = 67.087;    // extension beyond conical part
+  double outer_pipe_ext_length = 100.;    // extension beyond conical part through epd
 
   // maximum extent of the central part of beampipe (the forward regions are implemented in G4_Beamline.C)
   double max_z = be_pipe_zshift + be_pipe_length / 2. + al_pipe_north_length + al_pipe_north_ext_length +
@@ -57,7 +58,6 @@ void PipeInit()
 
 double Pipe(PHG4Reco* g4Reco, double radius)
 {
-cout << "**** STAR PIPE ***************" << endl;
   bool AbsorberActive = Enable::ABSORBER || Enable::PIPE_ABSORBER;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::PIPE_OVERLAPCHECK;
   int verbosity = std::max(Enable::VERBOSITY, Enable::PIPE_VERBOSITY);


### PR DESCRIPTION
This PR takes care of the overlap between the epd and the non physical forward/backward vacuum volume. It extends the implemented beampipe through the epd so the vacuum voume only starts behind the epds