### PR TITLE
Removed default to truth seeding in pp

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -98,9 +98,6 @@ void TrackingInit()
 
 void Tracking_Reco_TrackSeed()
 {
-  // !!!! THIS IS TEMPORARY, UNTIL CA SEEDER CAN HANDLE TRACKS FROM LARGE Z !!!!!
-  if(TRACKING::pp_mode) G4TRACKING::use_truth_tpc_seeding = true;  
-  
   // set up verbosity
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
   


### PR DESCRIPTION
Now that the CA seeder works in pp collisions, this removes the switch that defaulted to truth seeding in pp collisions.