### PR TITLE
resetting hcal phi starts to zero to be compatible with new hcal mapping

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -285,7 +285,7 @@ void HCALInner_Towers()
     }
     else
     {
-      G4HCALIN::phistart = M_PI ; // // reset phi angle start after HCal coordinate system correction
+      G4HCALIN::phistart = 0. ; // // reset phi angle start after HCal coordinate system correction
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALIN::phistart);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -210,7 +210,7 @@ void HCALOuter_Towers()
     }
     else
     {
-      G4HCALOUT::phistart = M_PI ; // reset phi angle start after HCal coordinate system correction
+      G4HCALOUT::phistart = 0. ; // reset phi angle start after HCal coordinate system correction
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALOUT::phistart);


### PR DESCRIPTION
This is needed for the fix to the HCal mapping after rotating the detector.