### PR TITLE
phi offset from geantinos for gdml hcals

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -285,7 +285,7 @@ void HCALInner_Towers()
     }
     else
     {
-      G4HCALIN::phistart = 0. ; // // reset phi angle start after HCal coordinate system correction
+      G4HCALIN::phistart = 0.0445549893; // offet in phi (from zero) extracted from geantinos
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALIN::phistart);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -210,7 +210,7 @@ void HCALOuter_Towers()
     }
     else
     {
-      G4HCALOUT::phistart = 0. ; // reset phi angle start after HCal coordinate system correction
+      G4HCALOUT::phistart = 0.0240615415; // offet in phi (from zero) extracted from geantinos
     }
   }
   TowerBuilder->set_double_param("phistart",G4HCALOUT::phistart);


### PR DESCRIPTION
This should take care of the small phi shift. It is based on geantinos. To work properly it needs the hcal PR in the coresoftware