### PR TITLE
Add commissioning flag to fitter

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -308,6 +308,7 @@ void Tracking_Reco_TrackFit()
   // perform final track fit with ACTS
   auto actsFit = new PHActsTrkFitter;
   actsFit->Verbosity(verbosity);
+  actsFit->commissioning(G4TRACKING::use_commissioning_seeding);
   actsFit->set_cluster_version(G4TRACKING::cluster_version);
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);


### PR DESCRIPTION
Add a commissioning flag to the fitter to produce alignment information. Off by default.