### PR TITLE
Settable calibrator factors

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -20,6 +20,12 @@ R__LOAD_LIBRARY(libqa_modules.so)
 
 namespace ACTSGEOM
 {
+
+  unsigned int mvtxMisalignment = 1;
+  unsigned int inttMisalignment = 1;
+  unsigned int tpcMisalignment = 1;
+  unsigned int tpotMisalignment = 1;
+
   void ActsGeomInit()
   {
     static bool wasCalled = false;
@@ -42,7 +48,12 @@ namespace ACTSGEOM
     MakeActsGeometry* geom = new MakeActsGeometry();
     geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
     geom->Verbosity(verbosity);
-  
+     
+    geom->misalignmentFactor(TrkrDefs::TrkrId::mvtxId, ACTSGEOM::mvtxMisalignment);
+    geom->misalignmentFactor(TrkrDefs::TrkrId::inttId, ACTSGEOM::inttMisalignment);
+    geom->misalignmentFactor(TrkrDefs::TrkrId::tpcId, ACTSGEOM::tpcMisalignment);
+    geom->misalignmentFactor(TrkrDefs::TrkrId::micromegasId, ACTSGEOM::tpotMisalignment);
+    
     geom->loadMagField(G4TRACKING::init_acts_magfield);
     geom->setMagField(G4MAGNET::magfield);
     geom->setMagFieldRescale(G4MAGNET::magfield_rescale);


### PR DESCRIPTION
This PR adds settable (from the main macro) parameters for arbitrarily blowing up cluster covariances in the alignment scheme. This is needed for testing an actual alignment workflow.