### PR TITLE
adding in HCal support rings

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -241,7 +241,6 @@ void HCALInner_Towers()
     if (Enable::HCALIN_OLD)
     {
       G4HCALIN::phistart = 0.0328877688; // offet in phi (from zero) extracted from geantinos
-      G4HCALIN::tower_energy_source = HcalRawTowerBuilder::kRawLightYield; //the mephi maps are kinda weird for the old HCal
     }
     else
     {

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -33,8 +33,6 @@ R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4ihcal.so)
 R__LOAD_LIBRARY(libqa_modules.so)
 
-//void HCalInner_SupportRing(PHG4Reco *g4Reco);
-
 namespace Enable
 {
   bool HCALIN = false;
@@ -53,10 +51,10 @@ namespace Enable
 namespace G4HCALIN
 {
   double inch = 2.54;
-  double support_ring_outer_radius = 177.323; //actual radius is 74.061 inches but truncated to not overlap with outer HCal envelope
-  //double support_ring_outer_radius = 74.061 * inch;
+  double support_ring_outer_radius = 177.323; 
   double support_ring_z = 175.375 * inch / 2;
   double dz = 4. * inch;
+
   double phistart = NAN;
   double tower_emin = NAN;
   int light_scint_model = -1;
@@ -205,47 +203,6 @@ double HCalInner(PHG4Reco *g4Reco,
   radius += no_overlapp;
   return radius;
 }
-
-//! A rough version of the inner HCal support ring, updated Jan 2023
-/*void HCalInner_SupportRing(PHG4Reco *g4Reco)
-{
-  bool AbsorberActive = Enable::SUPPORT || Enable::HCALIN_SUPPORT;
-  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALIN_OVERLAPCHECK;
-
-  const double innerradius_sphenix = 56.188 * G4HCALIN::inch;
-  const double innerradius_ephenix_hadronside = 138.;
-  const double z_rings[] =
-    {-G4HCALIN::support_ring_z, G4HCALIN::support_ring_z};
-  const double length = 4. * G4HCALIN::inch;
-
-  PHG4CylinderSubsystem *cyl;
-
-  for (int i = 0; i < 2; i++)
-  {
-    double innerradius = innerradius_sphenix;
-    if (z_rings[i] > 0 && G4HCALIN::inner_hcal_eic == 1)
-    {
-      innerradius = innerradius_ephenix_hadronside;
-    }
-    cyl = new PHG4CylinderSubsystem("HCALIN_SPT_N1", i);
-    cyl->set_double_param("place_z", z_rings[i]);
-    cyl->SuperDetector("HCALIN_SPT");
-    cyl->set_double_param("radius", innerradius);
-    cyl->set_int_param("lengthviarapidity", 0);
-    cyl->set_double_param("length", G4HCALIN::dz);
-    cyl->set_string_param("material", "G4_Al");
-    cyl->set_double_param("thickness", G4HCALIN::support_ring_outer_radius - innerradius);
-    cyl->OverlapCheck(Enable::OVERLAPCHECK);
-    if (AbsorberActive)
-    {
-      cyl->SetActive();
-    }
-    cyl->OverlapCheck(OverlapCheck);
-    g4Reco->registerSubsystem(cyl);
-  }
-
-  return;
-  }*/
 
 void HCALInner_Cells()
 {

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -52,9 +52,10 @@ namespace Enable
 
 namespace G4HCALIN
 {
-  double support_ring_outer_radius = 178.0 - 0.001;
-  double support_ring_z_ring2 = (2150 + 2175) / 2. / 10.;
-  double dz = 25. / 10.;
+  double inch = 2.54;
+  double support_ring_outer_radius = 74.061 * inch - 15;
+  double support_ring_z = 175.375 * inch / 2;
+  double dz = 4. * inch;
   double phistart = NAN;
   double tower_emin = NAN;
   int light_scint_model = -1;
@@ -93,8 +94,8 @@ namespace G4HCALIN
 void HCalInnerInit(const int iflag = 0)
 {
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4HCALIN::support_ring_outer_radius);
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4HCALIN::support_ring_z_ring2 + G4HCALIN::dz / 2.);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4HCALIN::support_ring_z_ring2 - G4HCALIN::dz / 2.);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4HCALIN::support_ring_z + G4HCALIN::dz / 2.);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -G4HCALIN::support_ring_z - G4HCALIN::dz / 2.);
   if (iflag == 1)
   {
     G4HCALIN::inner_hcal_eic = 1;
@@ -198,27 +199,27 @@ double HCalInner(PHG4Reco *g4Reco,
 
   radius = hcal->get_double_param("outer_radius");
 
-  // HCalInner_SupportRing(g4Reco);
+  HCalInner_SupportRing(g4Reco);
 
   radius += no_overlapp;
   return radius;
 }
 
-//! A rough version of the inner HCal support ring, from Richie's CAD drawing. - Jin
+//! A rough version of the inner HCal support ring, updated Jan 2023
 void HCalInner_SupportRing(PHG4Reco *g4Reco)
 {
   bool AbsorberActive = Enable::SUPPORT || Enable::HCALIN_SUPPORT;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALIN_OVERLAPCHECK;
 
-  const double z_ring1 = (2025 + 2050) / 2. / 10.;
-  const double innerradius_sphenix = 116.;
+  const double innerradius_sphenix = 56.188 * G4HCALIN::inch;
   const double innerradius_ephenix_hadronside = 138.;
   const double z_rings[] =
-      {-G4HCALIN::support_ring_z_ring2, -z_ring1, z_ring1, G4HCALIN::support_ring_z_ring2};
+    {-G4HCALIN::support_ring_z, G4HCALIN::support_ring_z};
+  const double length = 4. * G4HCALIN::inch;
 
   PHG4CylinderSubsystem *cyl;
 
-  for (int i = 0; i < 4; i++)
+  for (int i = 0; i < 2; i++)
   {
     double innerradius = innerradius_sphenix;
     if (z_rings[i] > 0 && G4HCALIN::inner_hcal_eic == 1)
@@ -231,7 +232,7 @@ void HCalInner_SupportRing(PHG4Reco *g4Reco)
     cyl->set_double_param("radius", innerradius);
     cyl->set_int_param("lengthviarapidity", 0);
     cyl->set_double_param("length", G4HCALIN::dz);
-    cyl->set_string_param("material", "SS310");
+    cyl->set_string_param("material", "G4_Al");
     cyl->set_double_param("thickness", G4HCALIN::support_ring_outer_radius - innerradius);
     cyl->OverlapCheck(Enable::OVERLAPCHECK);
     if (AbsorberActive)
@@ -282,6 +283,7 @@ void HCALInner_Towers()
     if (Enable::HCALIN_OLD)
     {
       G4HCALIN::phistart = 0.0328877688; // offet in phi (from zero) extracted from geantinos
+      G4HCALIN::tower_energy_source = HcalRawTowerBuilder::kRawLightYield; //the mephi maps are kinda weird for the old HCal
     }
     else
     {

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -33,7 +33,7 @@ R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libg4ihcal.so)
 R__LOAD_LIBRARY(libqa_modules.so)
 
-void HCalInner_SupportRing(PHG4Reco *g4Reco);
+//void HCalInner_SupportRing(PHG4Reco *g4Reco);
 
 namespace Enable
 {
@@ -53,7 +53,8 @@ namespace Enable
 namespace G4HCALIN
 {
   double inch = 2.54;
-  double support_ring_outer_radius = 74.061 * inch - 15;
+  double support_ring_outer_radius = 177.323; //actual radius is 74.061 inches but truncated to not overlap with outer HCal envelope
+  //double support_ring_outer_radius = 74.061 * inch;
   double support_ring_z = 175.375 * inch / 2;
   double dz = 4. * inch;
   double phistart = NAN;
@@ -199,14 +200,14 @@ double HCalInner(PHG4Reco *g4Reco,
 
   radius = hcal->get_double_param("outer_radius");
 
-  HCalInner_SupportRing(g4Reco);
+  //HCalInner_SupportRing(g4Reco);
 
   radius += no_overlapp;
   return radius;
 }
 
 //! A rough version of the inner HCal support ring, updated Jan 2023
-void HCalInner_SupportRing(PHG4Reco *g4Reco)
+/*void HCalInner_SupportRing(PHG4Reco *g4Reco)
 {
   bool AbsorberActive = Enable::SUPPORT || Enable::HCALIN_SUPPORT;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::HCALIN_OVERLAPCHECK;
@@ -244,7 +245,7 @@ void HCalInner_SupportRing(PHG4Reco *g4Reco)
   }
 
   return;
-}
+  }*/
 
 void HCALInner_Cells()
 {

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -146,7 +146,24 @@ double HCalOuter(PHG4Reco *g4Reco,
     hcal->set_string_param("GDMPath",hcaltiles);
     hcal->set_string_param("IronFieldMapPath", G4MAGNET::magfield_OHCAL_steel);
     hcal->set_double_param("IronFieldMapScale", G4MAGNET::magfield_rescale);
+  }
 
+  if (G4HCALOUT::light_scint_model >= 0)
+  {
+    hcal->set_int_param("light_scint_model", G4HCALOUT::light_scint_model);
+  }
+  // hcal->set_int_param("field_check", 1); // for validating the field in HCal
+  hcal->SetActive();
+  hcal->SuperDetector("HCALOUT");
+  if (AbsorberActive)
+  {
+    hcal->SetAbsorberActive();
+  }
+  hcal->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(hcal);
+
+  if (!Enable::HCALOUT_OLD)
+  {
     //HCal support rings, approximated as solid rings
     //note there is only one ring on either side, but to allow part of the ring inside the HCal envelope two rings are used
     const double inch = 2.54;
@@ -176,7 +193,6 @@ double HCalOuter(PHG4Reco *g4Reco,
 	  {
 	    cyl->SetActive();
 	  }
-	cyl->OverlapCheck(OverlapCheck);
 	g4Reco->registerSubsystem(cyl);
 
 	//rings inside outer HCal envelope
@@ -188,30 +204,15 @@ double HCalOuter(PHG4Reco *g4Reco,
         cylout->set_double_param("length", support_ring_dz);
         cylout->set_string_param("material", "G4_Al");
         cylout->set_double_param("thickness", support_ring_outer_radius - (hcal_envelope_radius + 0.1));
-        cylout->OverlapCheck(Enable::OVERLAPCHECK);
         if (AbsorberActive)
           {
             cylout->SetActive();
           }
-	//cylout->SetMotherSubsystem(hcal);
+	cylout->SetMotherSubsystem(hcal);
         cylout->OverlapCheck(OverlapCheck);
         g4Reco->registerSubsystem(cylout);
       }
   }
-
-  if (G4HCALOUT::light_scint_model >= 0)
-  {
-    hcal->set_int_param("light_scint_model", G4HCALOUT::light_scint_model);
-  }
-  // hcal->set_int_param("field_check", 1); // for validating the field in HCal
-  hcal->SetActive();
-  hcal->SuperDetector("HCALOUT");
-  if (AbsorberActive)
-  {
-    hcal->SetAbsorberActive();
-  }
-  hcal->OverlapCheck(OverlapCheck);
-  g4Reco->registerSubsystem(hcal);
 
   radius = hcal->get_double_param("outer_radius");
 

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -188,6 +188,8 @@ double HCalOuter(PHG4Reco *g4Reco,
 	cyl->set_double_param("length", support_ring_dz);
 	cyl->set_string_param("material", "G4_Al");
 	cyl->set_double_param("thickness", hcal_envelope_radius - 0.1 - innerradius);
+	cyl->set_double_param("start_phi_rad",1.867);
+	cyl->set_double_param("delta_phi_rad",5.692);
 	cyl->OverlapCheck(Enable::OVERLAPCHECK);
 	if (AbsorberActive)
 	  {
@@ -204,7 +206,9 @@ double HCalOuter(PHG4Reco *g4Reco,
         cylout->set_double_param("length", support_ring_dz);
         cylout->set_string_param("material", "G4_Al");
         cylout->set_double_param("thickness", support_ring_outer_radius - (hcal_envelope_radius + 0.1));
-        if (AbsorberActive)
+        cylout->set_double_param("start_phi_rad",1.867);
+	cylout->set_double_param("delta_phi_rad",5.692);
+	if (AbsorberActive)
           {
             cylout->SetActive();
           }

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -142,10 +142,61 @@ double HCalOuter(PHG4Reco *g4Reco,
   else
   {
     hcal = new PHG4OHCalSubsystem("HCALOUT");
-std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml";
+    std::string hcaltiles = std::string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml";
     hcal->set_string_param("GDMPath",hcaltiles);
     hcal->set_string_param("IronFieldMapPath", G4MAGNET::magfield_OHCAL_steel);
     hcal->set_double_param("IronFieldMapScale", G4MAGNET::magfield_rescale);
+
+    //HCal support rings, approximated as solid rings
+    //note there is only one ring on either side, but to allow part of the ring inside the HCal envelope two rings are used
+    const double inch = 2.54;
+    const double support_ring_outer_radius = 74.061 * inch;
+    const double innerradius = 56.188 * inch;
+    const double hcal_envelope_radius = 182.423 - 5.;
+    const double support_ring_z = 175.375 * inch / 2.;
+    const double support_ring_dz = 4. * inch;
+    const double z_rings[] =
+      {-support_ring_z, support_ring_z};
+    PHG4CylinderSubsystem *cyl;
+    PHG4CylinderSubsystem *cylout;
+
+    for (int i = 0; i < 2; i++)
+      {
+	//rings outside of HCal envelope
+	cyl = new PHG4CylinderSubsystem("HCAL_SPT_N1", i);
+	cyl->set_double_param("place_z", z_rings[i]);
+	cyl->SuperDetector("HCALIN_SPT");
+	cyl->set_double_param("radius", innerradius);
+	cyl->set_int_param("lengthviarapidity", 0);
+	cyl->set_double_param("length", support_ring_dz);
+	cyl->set_string_param("material", "G4_Al");
+	cyl->set_double_param("thickness", hcal_envelope_radius - 0.1 - innerradius);
+	cyl->OverlapCheck(Enable::OVERLAPCHECK);
+	if (AbsorberActive)
+	  {
+	    cyl->SetActive();
+	  }
+	cyl->OverlapCheck(OverlapCheck);
+	g4Reco->registerSubsystem(cyl);
+
+	//rings inside outer HCal envelope
+        cylout = new PHG4CylinderSubsystem("HCAL_SPT_N1", i+2);
+        cylout->set_double_param("place_z", z_rings[i]);
+        cylout->SuperDetector("HCALIN_SPT");
+        cylout->set_double_param("radius", hcal_envelope_radius + 0.1); //add a mm to avoid overlaps
+        cylout->set_int_param("lengthviarapidity", 0);
+        cylout->set_double_param("length", support_ring_dz);
+        cylout->set_string_param("material", "G4_Al");
+        cylout->set_double_param("thickness", support_ring_outer_radius - (hcal_envelope_radius + 0.1));
+        cylout->OverlapCheck(Enable::OVERLAPCHECK);
+        if (AbsorberActive)
+          {
+            cylout->SetActive();
+          }
+	//cylout->SetMotherSubsystem(hcal);
+        cylout->OverlapCheck(OverlapCheck);
+        g4Reco->registerSubsystem(cylout);
+      }
   }
 
   if (G4HCALOUT::light_scint_model >= 0)


### PR DESCRIPTION
Adding in an approximation of the HCal support rings to the simulation. Old versions of the support (currently commented out) have been moved from G4_HcalIn_ref.C to G4_HcalOut_ref.C and updated with dimensions from actual support used in the detector.

The support rings in the detector are aluminum partial rings:
<img width="797" alt="Screen Shot 2023-01-26 at 6 17 25 PM" src="https://user-images.githubusercontent.com/22035827/214972034-03669321-8006-41c9-873e-5c3e71325517.png">

These are approximated as solid rings in the simulation:
<img width="746" alt="Screen Shot 2023-01-26 at 6 22 40 PM" src="https://user-images.githubusercontent.com/22035827/214972730-8ed97cee-c405-4268-a4ec-e0b0fadaaa17.png">

A cut out at the top of each ring is done to approximate that in the real detector, based on the phi value where the largest part of the ring ends in the real detector (the 43.17 inch gap shown in the model below).
![image_2023_01_27T02_01_52_104Z](https://user-images.githubusercontent.com/22035827/215166856-f50e8377-7116-4e80-9ff8-981de3f7f0f3.png)

The rings on each side are implemented as two separate PHG4CylinderSubsystem due to part of the ring being inside the outer HCal envelope and requiring special treatement to avoid overlaps between the ring and the envelope.
<img width="803" alt="Screen Shot 2023-01-27 at 1 24 03 PM" src="https://user-images.githubusercontent.com/22035827/215166942-db9954d1-76bd-4c0b-b7d2-f37af7f746e5.png">





