### PR TITLE
Added event modulo to CM hit generation

### DIFF
--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -193,6 +193,7 @@ void TPC_Cells()
   {
     auto centralMembrane = new PHG4TpcCentralMembrane;
     centralMembrane->setCentralMembraneDelay(0);
+    centralMembrane->setCentralMembraneEventModulo(10);
     se->registerSubsystem(centralMembrane);
   }
 


### PR DESCRIPTION
Added macro call to function which changes modulo for CM hit generation. Call sets modulo to 10 so that CM hits will only be generated every 10th event. Corresponding pull request to coresoftware will be submitted shortly. 