### PR TITLE
Added event modulo to CM hit generation

### DIFF
--- a/common/G4_TPC.C
+++ b/common/G4_TPC.C
@@ -193,6 +193,7 @@ void TPC_Cells()
   {
     auto centralMembrane = new PHG4TpcCentralMembrane;
     centralMembrane->setCentralMembraneDelay(0);
+    centralMembrane->setCentralMembraneEventModulo(1);
     se->registerSubsystem(centralMembrane);
   }
 


### PR DESCRIPTION
Added macro call to function which changes modulo for CM hit generation. Call sets modulo to 1 so that CM hits will only be generated every event. Corresponding pull request to coresoftware will be submitted shortly. (previously submitted PR on wrong github account, closed that request and resubmitting)
 