### PR TITLE
Unifying beam parameter configuration selections for pp/pA/AA collisions

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -81,27 +81,71 @@ namespace Input
   int VERBOSITY = 0;
   int EmbedId = 1;
 
-  //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+  //! apply reference sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2022-001 and past RHIC experience
   //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, ReadEICFiles
-  void ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen)
+  //! \param[in] collision_type select the beam configuration with Input::BeamConfiguration
+  void ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen, const Input::BeamConfiguration & beam_config)
   {
     if (HepMCGen == nullptr)
     {
-      std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
+      std::cout << "ApplysPHENIXBeamParameter_pp(): Fatal Error - null input pointer HepMCGen" << std::endl;
       exit(1);
     }
-    HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2020-001
+    HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2022-001
 
-    HepMCGen->set_vertex_distribution_width(
-        100e-4,         // approximation from past RICH data
-        100e-4,         // approximation from past RICH data
-        7,              // sPH-TRG-2020-001. Fig 3.2
-        20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+    switch (beam_config)
+    {
+    case AA_COLLISION:
+      // heavy ion mode
+
+      HepMCGen->set_vertex_distribution_width(
+          100e-4,         // approximation from past STAR/Run16 AuAu data
+          100e-4,         // approximation from past STAR/Run16 AuAu data
+          7,              // sPH-TRG-2022-001. Fig B.2
+          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+
+      break;
+    case pA_COLLISION:
+
+      // pA mode
+
+      HepMCGen->set_vertex_distribution_width(
+          100e-4,         // set to be similar to AA
+          100e-4,         // set to be similar to AA
+          8,              // sPH-TRG-2022-001. Fig B.4
+          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+
+      break;
+    case pp_COLLISION:
+
+      // pp mode
+
+      HepMCGen->set_vertex_distribution_width(
+          120e-4,         // approximation from past PHENIX data
+          120e-4,         // approximation from past PHENIX data
+          10,              // sPH-TRG-2022-001. Fig B.3
+          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+
+      break;
+    default:
+      std::cout <<"ApplysPHENIXBeamParameter: invalid beam_config = "<<beam_config<<std::endl;
+
+      exit(1);
+
+    }
+
     HepMCGen->set_vertex_distribution_function(
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus,
         PHHepMCGenHelper::Gaus);
+  }
+
+  //! apply sPHENIX nominal beam parameter according to the beam collision setting of Input::IS_PP_COLLISION
+  //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, ReadEICFiles
+  void ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen)
+  {
+    ApplysPHENIXBeamParameter(HepMCGen, Input::BEAM_CONFIGURATION);
   }
 
   //! apply EIC beam parameter to any HepMC generator following EIC CDR,

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -88,7 +88,7 @@ namespace Input
   {
     if (HepMCGen == nullptr)
     {
-      std::cout << "ApplysPHENIXBeamParameter_pp(): Fatal Error - null input pointer HepMCGen" << std::endl;
+      std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
       exit(1);
     }
     HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2022-001

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -16,6 +16,16 @@ namespace Input
 
   bool UPSILON = false;
   std::set<int> UPSILON_EmbedIds;
+
+  //! nominal beam parameter configuration choices for BEAM_CONFIGURATION
+  enum BeamConfiguration
+  {
+    AA_COLLISION = 0,
+    pA_COLLISION,
+    pp_COLLISION
+  };
+
+  BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;
 }  // namespace Input
 
 namespace DstOut

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -185,15 +185,13 @@ int Fun4All_G4_sPHENIX(
   // pythia6
   if (Input::PYTHIA6)
   {
-    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
-    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
+    //! Nominal collision geometry is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia6);
   }
   // pythia8
   if (Input::PYTHIA8)
   {
-    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
-    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
+    //! Nominal collision geometry is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia8);
   }
 
@@ -204,8 +202,7 @@ int Fun4All_G4_sPHENIX(
 
   if (Input::HEPMC)
   {
-    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
-    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
+    //! Nominal collision geometry is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCInputManager);
 
     // optional overriding beam parameters
@@ -228,8 +225,7 @@ int Fun4All_G4_sPHENIX(
   }
   if (Input::PILEUPRATE > 0)
   {
-    //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
-    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
+    //! Nominal collision geometry is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCPileupInputManager);
   }
   // register all input generators with Fun4All

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -95,6 +95,9 @@ int Fun4All_G4_sPHENIX(
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
   // Input::SIMPLE_VERBOSITY = 1;
 
+  // Enable this is emulating the nominal pp/pA/AA collision vertex distribution
+  // Input::BEAM_CONFIGURATION = AA_COLLISION; // AA_COLLISION (default), pA_COLLISION, pp_COLLISION
+
   //  Input::PYTHIA6 = true;
 
   // Input::PYTHIA8 = true;
@@ -183,12 +186,14 @@ int Fun4All_G4_sPHENIX(
   if (Input::PYTHIA6)
   {
     //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia6);
   }
   // pythia8
   if (Input::PYTHIA8)
   {
     //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTGENERATOR::Pythia8);
   }
 
@@ -200,6 +205,7 @@ int Fun4All_G4_sPHENIX(
   if (Input::HEPMC)
   {
     //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCInputManager);
 
     // optional overriding beam parameters
@@ -223,6 +229,7 @@ int Fun4All_G4_sPHENIX(
   if (Input::PILEUPRATE > 0)
   {
     //! apply sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2020-001
+    //! Nominal collision species is selected by Input::BEAM_CONFIGURATION
     Input::ApplysPHENIXBeamParameter(INPUTMANAGER::HepMCPileupInputManager);
   }
   // register all input generators with Fun4All

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -96,7 +96,7 @@ int Fun4All_G4_sPHENIX(
   // Input::SIMPLE_VERBOSITY = 1;
 
   // Enable this is emulating the nominal pp/pA/AA collision vertex distribution
-  // Input::BEAM_CONFIGURATION = AA_COLLISION; // AA_COLLISION (default), pA_COLLISION, pp_COLLISION
+  // Input::BEAM_CONFIGURATION = Input::AA_COLLISION; // Input::AA_COLLISION (default), Input::pA_COLLISION, Input::pp_COLLISION
 
   //  Input::PYTHIA6 = true;
 


### PR DESCRIPTION
Follow up to last software meeting discussion: unifying beam parameter configuration selections for pp/pA/AA collisions: 

* Explicitly select the nominal pp/pA/AA collision beam parameter configurations with `Input::BEAM_CONFIGURATION` in the main macro
* The same parameter is applied to event generator, hepmc inputs and pile ups, while it is possible to override for special studies
* Should be compatible with older user macros which default to emulate the nominal AuAu collision beam parameter configuration 
* The QA macro branches may need a sync update after merge to resolve merge conflicts