### PR TITLE
Updated with EVETGENDECAYER class to customized user defined decay files

### DIFF
--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -2,6 +2,7 @@
 #define MACRO_GLOBALVARIABLES_C
 
 #include <g4decayer/EDecayType.hh>
+
 #include <set>
 
 double no_overlapp = 0.0001;
@@ -108,6 +109,12 @@ namespace G4TRACKING
 {
   bool init_acts_magfield = true;
   int cluster_version = 4;
+}
+
+namespace EVTGENDECAYER
+{
+   std::string DecayFile = ""; //The default is no need to force decay anything and use the default file DECAY.DEC from the official EvtGen software
+							   //DECAY.DEC is located at: https://gitlab.cern.ch/evtgen/evtgen/-/blob/master/DECAY.DEC
 }
 
 

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -87,10 +87,13 @@ int G4Setup()
   PHG4Reco *g4Reco = new PHG4Reco();
   g4Reco->set_rapidity_coverage(1.1);  // according to drawings
   WorldInit(g4Reco);
+  //PYTHIA 6
   if (G4P6DECAYER::decayType != EDecayType::kAll)
   {
     g4Reco->set_force_decay(G4P6DECAYER::decayType);
   }
+  //EvtGen 
+  g4Reco->CustomizeEvtGenDecay(EVTGENDECAYER::DecayFile); 
 
   double fieldstrength;
   istringstream stringline(G4MAGNET::magfield);


### PR DESCRIPTION
In order to properly interface the macros with the EvtGen for the [newly merged pull request](https://github.com/sPHENIX-Collaboration/coresoftware/pull/1833) to the sPHENIX coresoftware, we create this pull request for the sPHENIX macros.

We add the EVTGENDECAYER class in GlobalVariables.C, which is similar to G4P6DECAYER, to set user defined decay file to customize the EvtGen decay. Also, we add the line 

g4Reco->CustomizeEvtGenDecay(EVTGENDECAYER::DecayFile); 

in the G4Setup_sPHENIX.C to call the user define decay file.

The default value of the DecayFile is an empty string, which means the EvtGen will use the DECAY.DEC from the official EvtGen software. We can find the official EvtGen Decay Table here: 

https://gitlab.cern.ch/evtgen/evtgen/-/blob/master/DECAY.DEC 

User can change the line to setup their customized decay file. 

https://github.com/MYOMAO/macros/blob/master/common/GlobalVariables.C#L116