### PR TITLE
propagate cluster version to PHTpcResiduals

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -330,6 +330,7 @@ void Tracking_Reco_TrackFit()
     * store in dedicated structure for distortion correction
     */
     auto residuals = new PHTpcResiduals;
+    residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
     residuals->setSavehistograms( G4TRACKING::SC_SAVEHISTOGRAMS );
     residuals->setHistogramOutputfile( G4TRACKING::SC_HISTOGRAMOUTPUT_FILENAME );


### PR DESCRIPTION
one line fix so that PHTpcResiduals uses the "globla" cluster version (currently v5)