### PR TITLE
Add BbcSimReco if BBCRECO flag is enabled

### DIFF
--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -5,11 +5,12 @@
 
 #include <g4detectors/PHG4BbcSubsystem.h>
 
+#include <g4bbc/BbcSimReco.h>
 #include <g4bbc/BbcVertexFastSimReco.h>
+
 #include <g4main/PHG4Reco.h>
 
 #include <fun4all/Fun4AllServer.h>
-
 
 R__LOAD_LIBRARY(libg4bbc.so)
 R__LOAD_LIBRARY(libg4detectors.so)
@@ -18,8 +19,9 @@ namespace Enable
 {
   bool BBC = false;          // Actual BBC detector
   bool BBC_SUPPORT = false;  // BBC Supports
-  bool BBCFAKE = false;     // Just generate fake bbc vtx, t0
-  int  BBC_VERBOSITY = 0;
+  bool BBCRECO = false;      // run Bbc reconstruction
+  bool BBCFAKE = false;      // Just generate fake bbc vtx, t0
+  int BBC_VERBOSITY = 0;
 }  // namespace Enable
 
 namespace G4BBC
@@ -51,7 +53,7 @@ void Bbc(PHG4Reco* g4Reco)
   {
     PHG4BbcSubsystem* bbc = new PHG4BbcSubsystem("BBC");
     bbc->SuperDetector("BBC");
-    bbc->OverlapCheck( Enable::OVERLAPCHECK );
+    bbc->OverlapCheck(Enable::OVERLAPCHECK);
     bbc->SetActive();
     if (SupportActive)
     {
@@ -72,6 +74,12 @@ void Bbc_Reco()
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
+  if (Enable::BBCFAKE && Enable::BBCRECO)
+  {
+    cout << "Enable::BBCFAKE and Enable::BBCRECO cannot be enabled together" << endl;
+    gSystem->Exit(1);
+  }
+
   if (Enable::BBCFAKE)
   {
     if (verbosity > 0)
@@ -84,7 +92,11 @@ void Bbc_Reco()
     bbcvertex->set_t_smearing(G4BBC::t_smearing);
     se->registerSubsystem(bbcvertex);
   }
-
+  if (Enable::BBCRECO)
+  {
+    BbcSimReco* bbcrec = new BbcSimReco();
+    se->registerSubsystem(bbcrec);
+  }
   return;
 }
 #endif


### PR DESCRIPTION
This PR adds the bbc sim reco to G4_Bbc.C. It still needs to be enabled in the Fun4All macro, so this should not have any effect on our standard running