### PR TITLE
Update to macros to work with PR1902 in coresoftware

### DIFF
--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -11,6 +11,7 @@
 #include <g4intt/PHG4InttDigitizer.h>
 #include <g4intt/PHG4InttHitReco.h>
 #include <g4intt/PHG4InttSubsystem.h>
+#include <g4intt/PHG4InttTruthClusterizer.h>
 
 #include <g4main/PHG4Reco.h>
 
@@ -23,6 +24,7 @@
 #include <vector>
 
 R__LOAD_LIBRARY(libg4intt.so)
+R__LOAD_LIBRARY(libg4tracking_io.so)
 R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libqa_modules.so)
 
@@ -223,7 +225,6 @@ void Intt_Cells()
   PHG4InttHitReco* hitreco = (PHG4InttHitReco*) se->getSubsysReco("PHG4InttHitReco");
   if (hitreco) {
     PHG4InttTruthClusterizer* digitruth = hitreco->get_truth_clusterizer();
-    digitruth->say_hi();
     for (int i = 0; i < G4INTT::n_intt_layer; i++)
     {
       digitruth->set_adc_scale(G4MVTX::n_maps_layer + i, userrange);

--- a/common/G4_Intt.C
+++ b/common/G4_Intt.C
@@ -218,6 +218,18 @@ void Intt_Cells()
   }
   se->registerSubsystem(digiintt);
 
+
+  // also set the values for the clusterizer for the embedded tracks
+  PHG4InttHitReco* hitreco = (PHG4InttHitReco*) se->getSubsysReco("PHG4InttHitReco");
+  if (hitreco) {
+    PHG4InttTruthClusterizer* digitruth = hitreco->get_truth_clusterizer();
+    digitruth->say_hi();
+    for (int i = 0; i < G4INTT::n_intt_layer; i++)
+    {
+      digitruth->set_adc_scale(G4MVTX::n_maps_layer + i, userrange);
+    }
+  }
+
   return;
 }
 


### PR DESCRIPTION
PR1902 in core software pulls in functionality also in PHG4InttDigitizer to PHG4InttTruthClusteriser (to use locally for the clusters for Truth Tracks). It therefore needs the G4_Intt.C macro to set the adc scales. This PR is needed to successfully run the code in PR1902 in coresoftware.
