### PR TITLE
propagate verbosity to G4_Global and G4_Bbc

### DIFF
--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -90,11 +90,14 @@ void Bbc_Reco()
     BbcVertexFastSimReco* bbcvertex = new BbcVertexFastSimReco();
     bbcvertex->set_z_smearing(G4BBC::z_smearing);
     bbcvertex->set_t_smearing(G4BBC::t_smearing);
+    bbcvertex->Verbosity(verbosity);
+
     se->registerSubsystem(bbcvertex);
   }
   if (Enable::BBCRECO)
   {
     BbcSimReco* bbcrec = new BbcSimReco();
+    bbcrec->Verbosity(verbosity);
     se->registerSubsystem(bbcrec);
   }
   return;

--- a/common/G4_Global.C
+++ b/common/G4_Global.C
@@ -12,6 +12,7 @@ namespace Enable
 {
   bool GLOBAL_RECO = false;
   bool GLOBAL_FASTSIM = false;
+  int GLOBAL_VERBOSITY = 0;
 }  // namespace Enable
 
 namespace G4GLOBAL
@@ -26,13 +27,12 @@ void GlobalInit() {}
 
 void Global_Reco()
 {
-  //---------------
-  // Fun4All server
-  //---------------
+  int verbosity = std::max(Enable::VERBOSITY, Enable::GLOBAL_VERBOSITY);
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
   GlobalVertexReco* gblvertex = new GlobalVertexReco();
+  gblvertex->Verbosity(verbosity);
   se->registerSubsystem(gblvertex);
 
   return;
@@ -40,9 +40,7 @@ void Global_Reco()
 
 void Global_FastSim()
 {
-  //---------------
-  // Fun4All server
-  //---------------
+  int verbosity = std::max(Enable::VERBOSITY, Enable::GLOBAL_VERBOSITY);
 
   Fun4AllServer* se = Fun4AllServer::instance();
 
@@ -51,6 +49,8 @@ void Global_FastSim()
   gblvertex->set_y_smearing(G4GLOBAL::y_smearing);
   gblvertex->set_z_smearing(G4GLOBAL::z_smearing);
   gblvertex->set_t_smearing(G4GLOBAL::t_smearing);
+  gblvertex->Verbosity(verbosity);
+
   se->registerSubsystem(gblvertex);
 
   return;


### PR DESCRIPTION
This PR adds in GLOBAL_VERBOSITY to the Enable namespace so it can be set for our global reco. Set BbcReco verbosity to BBC_VERBOSITY in G4_Bbc.C