### PR TITLE
fix typo

### DIFF
--- a/common/Trkr_QA.C
+++ b/common/Trkr_QA.C
@@ -112,7 +112,7 @@ void Distortions_QA()
 
   Fun4AllServer* se = Fun4AllServer::instance();
   
-  auto qa = new QAG4SimulationsDistortions();
+  auto qa = new QAG4SimulationDistortions();
   qa->Verbosity(verbosity);
   se->registerSubsystem(qa);
 }


### PR DESCRIPTION
Found this typo by browsing through the code.
@bogui56 @osbornjd 
This raises some question about the status of the macro rework. Are the "new" Trkr_XXX.C macros used already, in some steering macro  ? It would seem they are not, otherwise this code would not have compiled at all. Do I miss something ? 
