### PR TITLE
removed calls to obsolete methods and corresponding global variables

### DIFF
--- a/common/G4_Tracking.C
+++ b/common/G4_Tracking.C
@@ -292,8 +292,6 @@ void Tracking_Reco_TrackFit()
     auto residuals = new PHTpcResiduals;
     residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
-    residuals->setSavehistograms( G4TRACKING::SC_SAVEHISTOGRAMS );
-    residuals->setHistogramOutputfile( G4TRACKING::SC_HISTOGRAMOUTPUT_FILENAME );
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     residuals->Verbosity(verbosity);
     se->registerSubsystem(residuals);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -138,10 +138,8 @@ namespace G4TRACKING
   // Space Charge calibration flag
   bool SC_CALIBMODE = false;                                            // this is anded with G4TPC::ENABLE_DISTORTIONS in TrackingInit()
   bool SC_USE_MICROMEGAS = true;
-  bool SC_SAVEHISTOGRAMS = false;
   double SC_COLLISIONRATE = 50e3;                                      // leave at 50 KHz for now, scaling of distortion map not implemented yet
   std::string SC_ROOTOUTPUT_FILENAME = "TpcSpaceChargeMatrices.root";  // space charge calibration output file
-  std::string SC_HISTOGRAMOUTPUT_FILENAME = "TpcResiduals.root"; // space charge calibration output file
 
   // Vertexing
   bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -204,8 +204,6 @@ void Tracking_Reco_TrackFit()
     */
     auto residuals = new PHTpcResiduals;
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
-    residuals->setSavehistograms( G4TRACKING::SC_SAVEHISTOGRAMS );
-    residuals->setHistogramOutputfile( G4TRACKING::SC_HISTOGRAMOUTPUT_FILENAME );
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     residuals->Verbosity(verbosity);
     se->registerSubsystem(residuals);


### PR DESCRIPTION
Title says it all.
This affects PHTpcResiduals only