### PR TITLE
pass the proper cluster version to PHTpcResiduals, as was done in the…

### DIFF
--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -203,6 +203,7 @@ void Tracking_Reco_TrackFit()
     * store in dedicated structure for distortion correction
     */
     auto residuals = new PHTpcResiduals;
+    residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     residuals->Verbosity(verbosity);

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -267,6 +267,7 @@ void Tracking_Reco_TrackFit()
     * store in dedicated structure for distortion correction
     */
     auto residuals = new PHTpcResiduals;
+    residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
     residuals->setSavehistograms( G4TRACKING::SC_SAVEHISTOGRAMS );
     residuals->setHistogramOutputfile( G4TRACKING::SC_HISTOGRAMOUTPUT_FILENAME );


### PR DESCRIPTION
… previous macro G4_Tracking.C

Note: this must be merged to master, but also other branches such as all the QA-XXX branches, in particular the QA-tracking-distortions branch.
@blackcathj  this should get the distortions QA running again. Sorry for the trouble!