### PR TITLE
createPayloadType method crashes macro, use createDomain instead

### DIFF
--- a/CDBTest/TestCDBInsert.C
+++ b/CDBTest/TestCDBInsert.C
@@ -14,9 +14,9 @@ void TestCDBInsert()
 // please choose a unique name, if it is your username it's easier to see who created it
   rc->set_StringFlag("CDB_GLOBALTAG","pinkenbu");
   sphenixnpc *cdb = sphenixnpc::instance(rc->get_StringFlag("CDB_GLOBALTAG"));
-  cdb->createPayloadType("TestBeginValidity");
+  cdb->createDomain("TestBeginValidity");
   cdb->insertcalib("TestBeginValidity","test.root",10);
-  cdb->createPayloadType("TestBeingEndValidity");
+  cdb->createDomain("TestBeingEndValidity");
   cdb->insertcalib("TestBeingEndValidity","test.root",10,20);
   return;
 }


### PR DESCRIPTION
This PR only affects the CDBTest macros, should not cause any problems