### PR TITLE
Reorganize BBC Reco

### DIFF
--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -5,7 +5,7 @@
 
 #include <g4detectors/PHG4BbcSubsystem.h>
 
-#include <g4bbc/BbcSimReco.h>
+#include <g4bbc/BbcDigitization.h>
 #include <g4bbc/BbcVertexFastSimReco.h>
 
 #include <g4main/PHG4Reco.h>
@@ -96,7 +96,7 @@ void Bbc_Reco()
   }
   if (Enable::BBCRECO)
   {
-    BbcSimReco* bbcrec = new BbcSimReco();
+    auto bbcrec = new BbcDigitization();
     bbcrec->Verbosity(verbosity);
     se->registerSubsystem(bbcrec);
   }

--- a/common/G4_Bbc.C
+++ b/common/G4_Bbc.C
@@ -7,6 +7,7 @@
 
 #include <g4bbc/BbcDigitization.h>
 #include <g4bbc/BbcVertexFastSimReco.h>
+#include <bbc/BbcReconstruction.h>
 
 #include <g4main/PHG4Reco.h>
 
@@ -96,9 +97,13 @@ void Bbc_Reco()
   }
   if (Enable::BBCRECO)
   {
-    auto bbcrec = new BbcDigitization();
-    bbcrec->Verbosity(verbosity);
-    se->registerSubsystem(bbcrec);
+    auto bbcdigi = new BbcDigitization();
+    bbcdigi->Verbosity(verbosity);
+    se->registerSubsystem(bbcdigi);
+
+    auto bbcreco = new BbcReconstruction();
+    bbcreco->Verbosity(verbosity);
+    se->registerSubsystem(bbcreco);
   }
   return;
 }


### PR DESCRIPTION
This PR separates the BBC reconstruction and digitization into two separate modules. Performance is the same, i.e. only one vertex is reconstructed.