### PR TITLE
Add missing flag

### DIFF
--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -193,6 +193,7 @@ void Tracking_Reco_TrackFit()
   actsFit->set_cluster_version(G4TRACKING::cluster_version);
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+  actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
   actsFit->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(actsFit);
   


### PR DESCRIPTION
Adds missing flag for silicon+TPOT fit after reverting the PR.