### PR TITLE
Enable layer misalignment factors

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -48,11 +48,18 @@ namespace ACTSGEOM
     MakeActsGeometry* geom = new MakeActsGeometry();
     geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
     geom->Verbosity(verbosity);
-     
-    geom->misalignmentFactor(TrkrDefs::TrkrId::mvtxId, ACTSGEOM::mvtxMisalignment);
-    geom->misalignmentFactor(TrkrDefs::TrkrId::inttId, ACTSGEOM::inttMisalignment);
-    geom->misalignmentFactor(TrkrDefs::TrkrId::tpcId, ACTSGEOM::tpcMisalignment);
-    geom->misalignmentFactor(TrkrDefs::TrkrId::micromegasId, ACTSGEOM::tpotMisalignment);
+    for(int i = 0; i < 58; i++)
+      {
+	if(i<3) {
+	  geom->misalignmentFactor(i, ACTSGEOM::mvtxMisalignment);
+	} else if (i < 7) {
+	  geom->misalignmentFactor(i, ACTSGEOM::inttMisalignment);
+	} else if (i < 55) {
+	  geom->misalignmentFactor(i, ACTSGEOM::tpcMisalignment);
+	} else {
+	  geom->misalignmentFactor(i, ACTSGEOM::tpotMisalignment);
+	}
+      }
     
     geom->loadMagField(G4TRACKING::init_acts_magfield);
     geom->setMagField(G4MAGNET::magfield);


### PR DESCRIPTION
Enable layer misalignment values for the Acts KF instead of requiring the entire subsystem to blow up uncertainties by some amount. Gives more flexibility in testing.