### PR TITLE
Set the same parameters to PHG4TpcSubsystem as to PHG4TpcPadPlaneRead…

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -272,6 +272,7 @@ void Intt_Cells()
 
 void TPCInit()
 {
+  std::cout << "G4_TrkrSimulation::TpcInit" << std::endl;
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4TPC::tpc_outer_radius);
 
   if (Enable::TPC_ENDCAP)
@@ -323,6 +324,7 @@ void TPC_Endcaps(PHG4Reco* g4Reco)
 double TPC(PHG4Reco* g4Reco,
            double radius)
 {
+  std::cout << "G4_TrkrSimulation::TPC" << std::endl;
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TPC_OVERLAPCHECK;
   bool AbsorberActive = Enable::ABSORBER || Enable::TPC_ABSORBER;
 
@@ -330,6 +332,12 @@ double TPC(PHG4Reco* g4Reco,
   tpc->SetActive();
   tpc->SuperDetector("TPC");
   tpc->set_double_param("steplimits", 1);  // 1cm steps
+
+  // copied from PHG4PadPlaneReadout
+  tpc->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
+  tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
+  tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
+  tpc->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);
   
   if (AbsorberActive)
     {

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -333,7 +333,7 @@ double TPC(PHG4Reco* g4Reco,
   tpc->SuperDetector("TPC");
   tpc->set_double_param("steplimits", 1);  // 1cm steps
 
-  // copied from PHG4PadPlaneReadout
+  // copied from PHG4TpcPadPlaneReadout
   tpc->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
   tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -333,7 +333,6 @@ double TPC(PHG4Reco* g4Reco,
   tpc->SuperDetector("TPC");
   tpc->set_double_param("steplimits", 1);  // 1cm steps
 
-  // copied from PHG4TpcPadPlaneReadout
   tpc->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
   tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
@@ -434,13 +433,6 @@ void TPC_Cells()
   // defaults are 0.085 and 0.105, they can be changed here to get a different resolution
   edrift->registerPadPlane(padplane);
   se->registerSubsystem(edrift);
-
-  // The pad plane readout default is set in PHG4TpcPadPlaneReadout
-
-  // We may want to change the number of inner layers, and can do that here
-  padplane->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);  // sPHENIX layer number of first Tpc readout layer
-  padplane->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
-  padplane->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);
 
   // Tpc digitizer
   //=========


### PR DESCRIPTION
Set the same parameters to PHG4TpcSubsystem as to PHG4TpcPadPlaneReadout.
This is a first step towards moving the TPC initialization to PHG4TpcDetector.

(take two)