### PR TITLE
add cloning of tag and listing of IOVs

### DIFF
--- a/CDBTest/CDBUtils.C
+++ b/CDBTest/CDBUtils.C
@@ -30,6 +30,13 @@ void listPayloadTypes()
   return;
 }
 
+void listPayloadIOVs(uint64_t iov)
+{
+  if (!uti) uti = new CDBUtils();
+  uti->listPayloadIOVs(iov);
+  return;
+}
+
 void createGlobalTag(const std::string &tagname)
 {
   if (!uti) uti = new CDBUtils();
@@ -65,6 +72,12 @@ int setGlobalTag(const std::string &tagname)
   return iret;
 }
 
+int cloneGlobalTag(const std::string &source, const std::string &target)
+{
+  if (!uti) uti = new CDBUtils();
+  int iret = uti->cloneGlobalTag(source, target);
+  return iret;
+}
 
 
 int createPayloadType(const std::string &pt)


### PR DESCRIPTION
This PR adds 2 functions to the CDBUtils macro - cloning a global tag and listing IOVs for debugging