### PR TITLE
Move libraries to jetbase (except simulation left in g4jets)

### DIFF
--- a/common/G4_HIJetReco.C
+++ b/common/G4_HIJetReco.C
@@ -3,9 +3,9 @@
 
 #include <GlobalVariables.C>
 
-#include <g4jets/FastJetAlgo.h>
-#include <g4jets/JetReco.h>
-#include <g4jets/TowerJetInput.h>
+#include <jetbase/FastJetAlgo.h>
+#include <jetbase/JetReco.h>
+#include <jetbase/TowerJetInput.h>
 #include <g4jets/TruthJetInput.h>
 
 #include <jetbackground/CopyAndSubtractJets.h>
@@ -17,6 +17,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 
+R__LOAD_LIBRARY(libjetbase.so)
 R__LOAD_LIBRARY(libg4jets.so)
 R__LOAD_LIBRARY(libjetbackground.so)
 

--- a/common/G4_Jets.C
+++ b/common/G4_Jets.C
@@ -4,11 +4,11 @@
 #include <GlobalVariables.C>
 #include <QA.C>
 
-#include <g4jets/ClusterJetInput.h>
-#include <g4jets/FastJetAlgo.h>
-#include <g4jets/JetReco.h>
-#include <g4jets/TowerJetInput.h>
-#include <g4jets/TrackJetInput.h>
+#include <jetbase/ClusterJetInput.h>
+#include <jetbase/FastJetAlgo.h>
+#include <jetbase/JetReco.h>
+#include <jetbase/TowerJetInput.h>
+#include <jetbase/TrackJetInput.h>
 #include <g4jets/TruthJetInput.h>
 
 #include <g4eval/JetEvaluator.h>
@@ -16,6 +16,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 
+R__LOAD_LIBRARY(libjetbase.so)
 R__LOAD_LIBRARY(libg4jets.so)
 R__LOAD_LIBRARY(libg4eval.so)
 R__LOAD_LIBRARY(libqa_modules.so)

--- a/common/G4_ParticleFlow.C
+++ b/common/G4_ParticleFlow.C
@@ -3,8 +3,8 @@
 
 #include <GlobalVariables.C>
 
-#include <g4jets/FastJetAlgo.h>
-#include <g4jets/JetReco.h>
+#include <jetbase/FastJetAlgo.h>
+#include <jetbase/JetReco.h>
 
 #include <particleflowreco/ParticleFlowJetInput.h>
 #include <particleflowreco/ParticleFlowReco.h>
@@ -12,7 +12,7 @@
 #include <fun4all/Fun4AllServer.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
-R__LOAD_LIBRARY(libg4jets.so)
+R__LOAD_LIBRARY(libjetbase.so)
 R__LOAD_LIBRARY(libparticleflow.so)
 
 namespace Enable

--- a/common/HIJetReco.C
+++ b/common/HIJetReco.C
@@ -3,9 +3,9 @@
 
 #include <GlobalVariables.C>
 
-#include <g4jets/FastJetAlgo.h>
-#include <g4jets/JetReco.h>
-#include <g4jets/TowerJetInput.h>
+#include <jetbase/FastJetAlgo.h>
+#include <jetbase/JetReco.h>
+#include <jetbase/TowerJetInput.h>
 #include <g4jets/TruthJetInput.h>
 
 #include <jetbackground/CopyAndSubtractJets.h>
@@ -17,6 +17,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 
+R__LOAD_LIBRARY(libjetbase.so)
 R__LOAD_LIBRARY(libg4jets.so)
 R__LOAD_LIBRARY(libjetbackground.so)
 


### PR DESCRIPTION
to update macros to work with moving most jet functions from g4jets to jetbase