### PR TITLE
Remove cluster version

### DIFF
--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -101,7 +101,6 @@ namespace G4TPC
 namespace G4TRACKING
 {
   bool init_acts_magfield = true;
-  int cluster_version = 5;
 }
 
 namespace EVTGENDECAYER

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -46,7 +46,6 @@ void Mvtx_Clustering()
   //================
   MvtxClusterizer* mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
   mvtxclusterizer->Verbosity(verbosity);
-  mvtxclusterizer->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(mvtxclusterizer);
 }
 
@@ -57,7 +56,6 @@ void Intt_Clustering()
 
   InttClusterizer* inttclusterizer = new InttClusterizer("InttClusterizer", G4MVTX::n_maps_layer, G4MVTX::n_maps_layer + G4INTT::n_intt_layer - 1);
   inttclusterizer->Verbosity(verbosity);
-  inttclusterizer->set_cluster_version(G4TRACKING::cluster_version);
   // no Z clustering for Intt type 1 layers (we DO want Z clustering for type 0 layers)
   // turning off phi clustering for type 0 layers is not necessary, there is only one strip
   // per sensor in phi
@@ -87,13 +85,11 @@ void TPC_Clustering()
 
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(verbosity);
-  tpcclusterizer->set_cluster_version(G4TRACKING::cluster_version);
   tpcclusterizer->set_do_hit_association( G4TPC::DO_HIT_ASSOCIATION );
   se->registerSubsystem(tpcclusterizer);
   
   auto tpcclustercleaner = new TpcClusterCleaner;
   tpcclustercleaner->Verbosity(verbosity);
-  tpcclustercleaner->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(tpcclustercleaner);
 
 }
@@ -102,7 +98,6 @@ void Micromegas_Clustering()
 {
   auto se = Fun4AllServer::instance();
   auto mm_clus = new MicromegasClusterizer;
-  mm_clus->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(mm_clus);
 }
 

--- a/common/Trkr_Eval.C
+++ b/common/Trkr_Eval.C
@@ -44,7 +44,6 @@ void Tracking_Eval(const std::string& outputfile)
   eval->scan_for_primaries(embed_scan);  // defaults to only thrown particles for ntp_gtrack
   std::cout << "SvtxEvaluator: pp_mode set to " << TRACKING::pp_mode << " and scan_for_embedded set to " << embed_scan << std::endl;
   eval->Verbosity(verbosity);
-  eval->set_cluster_version(G4TRACKING::cluster_version);
  
   se->registerSubsystem(eval);
 

--- a/common/Trkr_LaserClustering.C
+++ b/common/Trkr_LaserClustering.C
@@ -51,7 +51,6 @@ void TPC_LaserClustering()
 
     auto tpcclusterizer = new TpcClusterizer;
     tpcclusterizer->Verbosity(verbosity);
-    tpcclusterizer->set_cluster_version(G4TRACKING::cluster_version);
     tpcclusterizer->set_do_hit_association( G4TPC::DO_HIT_ASSOCIATION );
     se->registerSubsystem(tpcclusterizer);
 
@@ -61,7 +60,6 @@ void TPC_LaserClustering()
   {
     auto tpcclustercleaner = new TpcClusterCleaner;
     tpcclustercleaner->Verbosity(verbosity);
-    tpcclustercleaner->set_cluster_version(G4TRACKING::cluster_version);
     se->registerSubsystem(tpcclustercleaner);
   }
 

--- a/common/Trkr_QA.C
+++ b/common/Trkr_QA.C
@@ -24,7 +24,6 @@ void Mvtx_QA()
   Fun4AllServer* se = Fun4AllServer::instance();
   QAG4SimulationMvtx* qa = new QAG4SimulationMvtx;
   qa->Verbosity(verbosity);
-  qa->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(qa);
 }
 
@@ -35,7 +34,6 @@ void Intt_QA()
   Fun4AllServer* se = Fun4AllServer::instance();
   QAG4SimulationIntt* qa = new QAG4SimulationIntt;
   qa->Verbosity(verbosity);
-  qa->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(qa);
 }
 
@@ -46,7 +44,6 @@ void TPC_QA()
   Fun4AllServer* se = Fun4AllServer::instance();
   QAG4SimulationTpc * qa =  new QAG4SimulationTpc;
   qa->Verbosity(verbosity);
-  qa->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(qa);
 }
 
@@ -55,7 +52,6 @@ void Micromegas_QA()
   auto se = Fun4AllServer::instance();
   auto qa_mm = new QAG4SimulationMicromegas;
   qa_mm->Verbosity(Enable::QA_VERBOSITY);
-  qa_mm->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(qa_mm);
 }
 

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -65,11 +65,8 @@ void Tracking_Reco_TrackSeed()
   
   auto silicon_Seeding = new PHActsSiliconSeeding;
   silicon_Seeding->Verbosity(verbosity);
-  std::cout << "SETTING SI SEED CV" << std::endl;
-  silicon_Seeding->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(silicon_Seeding);
 
-  std::cout << " cluster version: " << G4TRACKING::cluster_version << std::endl; 
 
   auto merger = new PHSiliconSeedMerger;
   merger->Verbosity(verbosity);
@@ -101,7 +98,6 @@ void Tracking_Reco_TrackSeed()
   cprop->useConstBField(false);
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
-  cprop->set_cluster_version(G4TRACKING::cluster_version);
   cprop->Verbosity(verbosity);
   se->registerSubsystem(cprop);
   
@@ -189,8 +185,7 @@ void Tracking_Reco_TrackFit()
   // perform final track fit with ACTS
   auto actsFit = new PHActsTrkFitter;
   actsFit->Verbosity(verbosity);
-  //actsFit->commissioning(G4TRACKING::use_alignment);
-  actsFit->set_cluster_version(G4TRACKING::cluster_version);
+  actsFit->commissioning(G4TRACKING::use_alignment);
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
   actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
@@ -204,7 +199,6 @@ void Tracking_Reco_TrackFit()
     * store in dedicated structure for distortion correction
     */
     auto residuals = new PHTpcResiduals;
-    residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     residuals->Verbosity(verbosity);
@@ -251,7 +245,6 @@ void Tracking_Reco_CommissioningTrackSeed()
 
   auto silicon_Seeding = new PHActsSiliconSeeding;
   silicon_Seeding->Verbosity(verbosity);
-  silicon_Seeding->set_cluster_version(G4TRACKING::cluster_version);
   silicon_Seeding->sigmaScattering(50.);
   silicon_Seeding->setRPhiSearchWindow(2.);
   silicon_Seeding->helixcut(0.01);
@@ -287,7 +280,6 @@ void Tracking_Reco_CommissioningTrackSeed()
   cprop->useConstBField(false);
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
-  cprop->set_cluster_version(G4TRACKING::cluster_version);
   cprop->Verbosity(verbosity);
   se->registerSubsystem(cprop);
   
@@ -344,14 +336,12 @@ void alignment(std::string datafilename = "mille_output_data_file",
   mille->Verbosity(verbosity);
   mille->set_datafile_name(datafilename + ".bin");
   mille->set_steeringfile_name(steeringfilename + ".txt");
-  mille->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(mille);
 
   auto helical = new HelicalFitter;
   helical->Verbosity(0);
   helical->set_datafile_name(datafilename + "_helical.bin");
   helical->set_steeringfile_name(steeringfilename + "_helical.txt");
-  helical->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(helical);
 
 }

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -82,7 +82,6 @@ void Tracking_Reco_TrackSeed()
       auto silicon_Seeding = new PHActsSiliconSeeding;
       silicon_Seeding->Verbosity(verbosity);
       std::cout << "SETTING SI SEED CV" << std::endl;
-      silicon_Seeding->set_cluster_version(G4TRACKING::cluster_version);
       se->registerSubsystem(silicon_Seeding);
       
       auto merger = new PHSiliconSeedMerger;
@@ -129,7 +128,6 @@ void Tracking_Reco_TrackSeed()
       cprop->useConstBField(false);
       cprop->useFixedClusterError(true);
       cprop->set_max_window(5.);
-      cprop->set_cluster_version(G4TRACKING::cluster_version);
       cprop->Verbosity(verbosity);
       se->registerSubsystem(cprop);
     }
@@ -253,7 +251,6 @@ void Tracking_Reco_TrackFit()
   auto actsFit = new PHActsTrkFitter;
   actsFit->Verbosity(verbosity);
   //actsFit->commissioning(G4TRACKING::use_alignment);
-  actsFit->set_cluster_version(G4TRACKING::cluster_version);
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
   actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
@@ -267,7 +264,6 @@ void Tracking_Reco_TrackFit()
     * store in dedicated structure for distortion correction
     */
     auto residuals = new PHTpcResiduals;
-    residuals->setClusterVersion(G4TRACKING::cluster_version);
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
    
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
@@ -315,7 +311,6 @@ void Tracking_Reco_CommissioningTrackSeed()
 
   auto silicon_Seeding = new PHActsSiliconSeeding;
   silicon_Seeding->Verbosity(verbosity);
-  silicon_Seeding->set_cluster_version(G4TRACKING::cluster_version);
   silicon_Seeding->sigmaScattering(50.);
   silicon_Seeding->setRPhiSearchWindow(0.4);
   se->registerSubsystem(silicon_Seeding);
@@ -350,7 +345,6 @@ void Tracking_Reco_CommissioningTrackSeed()
   cprop->useConstBField(false);
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
-  cprop->set_cluster_version(G4TRACKING::cluster_version);
   cprop->Verbosity(verbosity);
   se->registerSubsystem(cprop);
   
@@ -407,14 +401,12 @@ void alignment(std::string datafilename = "mille_output_data_file",
   mille->Verbosity(verbosity);
   mille->set_datafile_name(datafilename + ".bin");
   mille->set_steeringfile_name(steeringfilename + ".txt");
-  mille->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(mille);
 
   auto helical = new HelicalFitter;
   helical->Verbosity(0);
   helical->set_datafile_name(datafilename + "_helical.bin");
   helical->set_steeringfile_name(steeringfilename + "_helical.txt");
-  helical->set_cluster_version(G4TRACKING::cluster_version);
   se->registerSubsystem(helical);
 
 }


### PR DESCRIPTION
The cluster version bloat leaves us open to mistakes or areas of code where the correct version is not properly addressed or propagated. This is a first PR to remove this and use whatever version we are currently using, which our EDM allows us to do anyway to do the base class + version inherited structure.