### PR TITLE
Option in driving macro to do track matching w/ clusters

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -44,7 +44,11 @@ namespace Enable
 
   bool TRACKING_TRACK = false;
   bool TRACKING_EVAL = false;
-  int TRACKING_VERBOSITY = 0;
+  bool TRACK_MATCHING = false;
+  bool TRACK_MATCHING_TREE = false;
+  bool TRACK_MATCHING_TREE_CLUSTERS = false;
+  // 0=no output TTree file, 1=output for tracks only, 2=tracks+clusters
+  int  TRACKING_VERBOSITY = 0;
   bool TRACKING_QA = false;
   bool TRACKING_DIAGNOSTICS = false;
 }  // namespace Enable

--- a/common/Trkr_Eval.C
+++ b/common/Trkr_Eval.C
@@ -5,6 +5,9 @@
 #include <G4_TrkrVariables.C>
 #include <Trkr_TruthTables.C>
 #include <g4eval/SvtxEvaluator.h>
+#include <g4eval/TruthRecoTrackMatching.h>
+#include <g4eval/TrkrClusterIsMatcher.h>
+#include <g4eval/FillClusMatchTree.h>
 
 R__LOAD_LIBRARY(libg4eval.so)
 
@@ -50,5 +53,51 @@ void Tracking_Eval(const std::string& outputfile)
   return;
 }
 
+void Track_Matching(const std::string& ttreefilename) {
+  TrkrClusterIsMatcher* ismatcher = new TrkrClusterIsMatcher();
+  // These are the default values -- uncomment and change as desired
+  //  ismatcher->single_pixel_phi_MVTX = false ; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_MVTX
+  //  ismatcher->single_pixel_phi_INTT = false ; // ... same as for MVTX
+  //  ismatcher->single_bin_phi_TPC    = true  ;  // default to pitch*tol_phi_TPC
+  //
+  //  ismatcher->single_pixel_z_MVTX = false ; // default to pitch*max(N_pixels_M,N_pixels_T)*tol_z_MVTX
+  //  ismatcher->single_pixel_z_INTT = false ; // ... same as for MVTX
+  //  ismatcher->single_bin_t_TPC    = true  ;  // default to pitch*tol_t_TPC
+  //
+  //  ismatcher-> tol_phi_MVTX = 0.5;
+  //  ismatcher-> tol_phi_INTT = 0.5;
+  //  ismatcher-> tol_phi_TPC  = 1.0;
+
+  //  ismatcher-> tol_z_MVTX  = 0.5;
+  //  ismatcher-> tol_t_TPC   = 1.0;
+  auto trackmatcher = new TruthRecoTrackMatching(ismatcher);
+  trackmatcher->set_min_cl_match     (5);    // minimum number of matched clusters to make a matched track
+  trackmatcher->set_min_cl_ratio     (0.1);  // at least 10% of truth clusters must be matched
+  trackmatcher->set_cutoff_deta      (0.3);  // won't compare tracks with |Δeta|>0.3 away
+  trackmatcher->set_cutoff_dphi      (0.3);  // won't compare tracks with |Δphi|>0.3 away
+  trackmatcher->set_smallsearch_deta (0.05); // will first compare tracks within this |Δphi|
+  trackmatcher->set_smallsearch_dphi (0.05); // will first compare tracks within this |Δeta|
+  trackmatcher->set_max_nreco_per_truth (4); // maximum reco tracks matched for any truth track
+  trackmatcher->set_max_ntruth_per_reco (4); // maximum truth tracks matched for any reco track
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  trackmatcher->Verbosity(verbosity);
+  se->registerSubsystem(trackmatcher);
+
+  if (Enable::TRACK_MATCHING_TREE) {
+    auto treefiller = new FillClusMatchTree(ismatcher, ttreefilename);//, true, true, true, outputFile);
+    treefiller->Verbosity(verbosity);
+    if (Enable::TRACK_MATCHING_TREE_CLUSTERS) {
+      treefiller->m_fill_clusters     = true;
+      treefiller->m_fill_SvUnmatched  = true;
+    } else {
+      treefiller->m_fill_clusters     = false;
+      treefiller->m_fill_SvUnmatched  = false;
+    }
+    treefiller->m_fill_clusverbose = false;
+    se->registerSubsystem(treefiller);
+  }
+}
 
 #endif

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -58,11 +58,6 @@ int Fun4All_G4_sPHENIX(
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
 
-  // Can enable writing out track matching (and track matching tree) here
-  // Enable::TRACK_MATCHING = true;
-  // Enable::TRACK_MATCHING_TREE = true;
-  // Enable::TRACK_MATCHING_TREE_CLUSTERS = true;
-
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
   PHRandomSeed::Verbosity(1);
 
@@ -327,9 +322,9 @@ int Fun4All_G4_sPHENIX(
   Enable::TRACKING_QA = Enable::TRACKING_TRACK && Enable::QA && true;
 
   // only do track matching if TRACKINGTRACK is also used
-  Enable::TRACK_MATCHING = Enable::TRACKING_TRACK && Enable::TRACK_MATCHING;
-  Enable::TRACK_MATCHING_TREE = Enable::TRACK_MATCHING && Enable::TRACK_MATCHING_TREE;
-  Enable::TRACK_MATCHING_TREE_CLUSTERS = Enable::TRACK_MATCHING_TREE && Enable::TRACK_MATCHING_TREE_CLUSTERS;
+  Enable::TRACK_MATCHING = Enable::TRACKING_TRACK && false;
+  Enable::TRACK_MATCHING_TREE = Enable::TRACK_MATCHING && false;
+  Enable::TRACK_MATCHING_TREE_CLUSTERS = Enable::TRACK_MATCHING_TREE && false;
 
   //Additional tracking tools 
   //Enable::TRACKING_DIAGNOSTICS = Enable::TRACKING_TRACK && true;

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -58,6 +58,11 @@ int Fun4All_G4_sPHENIX(
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(0);
 
+  // Can enable writing out track matching (and track matching tree) here
+  // Enable::TRACK_MATCHING = true;
+  // Enable::TRACK_MATCHING_TREE = true;
+  // Enable::TRACK_MATCHING_TREE_CLUSTERS = true;
+
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
   PHRandomSeed::Verbosity(1);
 
@@ -321,6 +326,11 @@ int Fun4All_G4_sPHENIX(
   Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
   Enable::TRACKING_QA = Enable::TRACKING_TRACK && Enable::QA && true;
 
+  // only do track matching if TRACKINGTRACK is also used
+  Enable::TRACK_MATCHING = Enable::TRACKING_TRACK && Enable::TRACK_MATCHING;
+  Enable::TRACK_MATCHING_TREE = Enable::TRACK_MATCHING && Enable::TRACK_MATCHING_TREE;
+  Enable::TRACK_MATCHING_TREE_CLUSTERS = Enable::TRACK_MATCHING_TREE && Enable::TRACK_MATCHING_TREE_CLUSTERS;
+
   //Additional tracking tools 
   //Enable::TRACKING_DIAGNOSTICS = Enable::TRACKING_TRACK && true;
   //G4TRACKING::filter_conversion_electrons = true;
@@ -519,6 +529,8 @@ int Fun4All_G4_sPHENIX(
     Tracking_Reco();
   }
 
+  
+
   if(Enable::TRACKING_DIAGNOSTICS)
     {
       const std::string kshortFile = "./kshort_" + outputFile;
@@ -527,6 +539,7 @@ int Fun4All_G4_sPHENIX(
       G4KshortReconstruction(kshortFile);
       seedResiduals(residualsFile);
     }
+
 
   //-----------------
   // Global Vertexing
@@ -596,11 +609,14 @@ int Fun4All_G4_sPHENIX(
 
   if (Enable::DSTREADER) G4DSTreader(outputroot + "_DSTReader.root");
 
+
+
   if (Enable::USER) UserAnalysisInit();
 
   // Writes electrons from conversions to a new track map on the node tree
   // the ntuple file is for diagnostics, it is produced only if the flag is set in G4_Tracking.C
   if(G4TRACKING::filter_conversion_electrons) Filter_Conversion_Electrons(outputroot + "_secvert_ntuple.root");
+
 
   //======================
   // Run KFParticle on evt
@@ -625,6 +641,8 @@ int Fun4All_G4_sPHENIX(
   if (Enable::TRACKING_QA) Tracking_QA();
 
   if (Enable::TRACKING_QA && Enable::CEMC_QA && Enable::HCALIN_QA && Enable::HCALOUT_QA) QA_G4CaloTracking();
+
+  if (Enable::TRACK_MATCHING) Track_Matching(outputroot + "_g4trackmatching.root");
 
   //--------------
   // Set up Input Managers


### PR DESCRIPTION
May optionally generate a file with a TTree that recorded which track are matched (and which are not). May additionally put the clusteres of these tracks on the tree, along with which are, and are not, matched.