### PR TITLE
remove commented out includes to de-confues grep

### DIFF
--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -12,15 +12,10 @@
 #include <G4_HcalOut_ref.C>
 #include <G4_BeamLine.C>
 #include <G4_Magnet.C>
-/*#include <G4_Mvtx.C>
-#include <G4_Intt.C>
-#include <G4_TPC.C>
-#include <G4_Micromegas.C>
-*/
-#include <G4_TrkrSimulation.C>
 #include <G4_PSTOF.C>
 #include <G4_Pipe.C>
 #include <G4_PlugDoor.C>
+#include <G4_TrkrSimulation.C>
 #include <G4_User.C>
 #include <G4_World.C>
 #include <G4_ZDC.C>


### PR DESCRIPTION
This PR fixes something which has bugged me a long time - it contains old macros which are commented out with a surrounding /* */, means every time I grep for G4_Intt.C, I think there is a macro which still uses this. Since the previous PR will break the QA with merging conflicts in the Fun4All macro, I can just sneak in this other change which will likely break this as well.