### PR TITLE
add two new required entries

### DIFF
--- a/CDBTest/mycdb.json
+++ b/CDBTest/mycdb.json
@@ -7,5 +7,7 @@
   "print_time_stamps": false,
   "cache_life_time": 10,
   "cache_max_mb": 1,
-  "use_fake_backend": false
+  "use_fake_backend": false,
+  "logger": "terminal",
+  "log_level": "INFO"
 }


### PR DESCRIPTION
This PR adds 
  "logger": "terminal",
  "log_level": "INFO"
to mycdb.json in the CDBTest area. They are needed for the new client. If someone uses the old client from an old ana build they are ignored (but then the old client cannot read our DB, so this is mute