### PR TITLE
Changed INTT phi offset in G4_Trkr_Variables.C so it is now correct

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -77,7 +77,7 @@ namespace G4INTT
   int nladder[4] = {12, 12, 16, 16};
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
-  double offsetphi[4] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3]};
+  double offsetphi[4] = {0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3], 0.0};
 
   enum enu_InttDeadMapType  // Dead map options for INTT
   {


### PR DESCRIPTION
This is the ladder phi offset fix Tony and I found a while ago; it should be trivial but give it a sanity glance over..

Nominally, this should be merged just before we re-run our next batch of simulations