### PR TITLE
Rename intt

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -123,7 +123,7 @@ void InttInit()
   }
 }
 
-double Intt(PHG4Reco* g4Reco, double radius,
+double Intt_Sim(PHG4Reco* g4Reco, double radius,
             const int absorberactive = 0)
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
@@ -203,7 +203,7 @@ void Intt_Cells()
       }
       else
       {
-        cout << "G4_Intt.C - fatal error - invalid InttDeadMapOption = " << G4INTT::InttDeadMapOption << endl;
+        cout << "G4_TrkrSimulation.C - fatal error - invalid InttDeadMapOption = " << G4INTT::InttDeadMapOption << endl;
         exit(1);
       }
     }

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -120,7 +120,7 @@ int G4Setup()
 
   if (Enable::PIPE) radius = Pipe(g4Reco, radius);
   if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
-  if (Enable::INTT) radius = Intt(g4Reco, radius);
+  if (Enable::INTT) radius = Intt_Sim(g4Reco, radius);
   if (Enable::TPC) radius = TPC(g4Reco, radius);
   if (Enable::MICROMEGAS) Micromegas(g4Reco);
   if (Enable::MBD) Mbd(g4Reco);


### PR DESCRIPTION
This PR fixes a name clash between the Intt namespace and the Intt() function in a simulation macro. It renames Intt() to Intt_Sim()