### PR TITLE
New location for `qautils/QAHistManagerDef.h`

### DIFF
--- a/common/QA.C
+++ b/common/QA.C
@@ -3,7 +3,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 #include <qa_modules/QAG4SimulationCalorimeterSum.h>
-#include <qa_modules/QAHistManagerDef.h>
+#include <qautils/QAHistManagerDef.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libqa_modules.so)


### PR DESCRIPTION
Following work of https://github.com/sPHENIX-Collaboration/coresoftware/pull/2296 , updating the location for header file `qautils/QAHistManagerDef.h`

PS: It is very interesting this mismatch was not caught in CI check for https://github.com/sPHENIX-Collaboration/coresoftware/pull/2296