### PR TITLE
use libmbd instead of libmbd_io

### DIFF
--- a/CaloProduction/Fun4All_Year1.C
+++ b/CaloProduction/Fun4All_Year1.C
@@ -33,7 +33,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libcalo_reco.so)
 R__LOAD_LIBRARY(libffamodules.so)
-R__LOAD_LIBRARY(libmbd_io.so)
+R__LOAD_LIBRARY(libmbd.so)
 
 void Fun4All_Year1(const std::string &fname = "/sphenix/lustre01/sphnxpro/commissioning/aligned_prdf/beam-00021796-0076.prdf", int nEvents = 5)
 {


### PR DESCRIPTION
From the next build on the mbd will be split into an libmbd_io.so and libmbd.so, so we don't have to load the whole universe when just looking at a DST. The reconstruction needs the libmbd which contains all modules.