### PR TITLE
Enable per-module time tracking in `TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C`

### DIFF
--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -123,6 +123,8 @@ void Fun4All_TrkrHitSet_Unpacker(
 
   se->run(nEvents);
   se->End();
+  se->PrintTimer();
+
   delete se;
   std::cout << "Finished"<<std::endl;
   gSystem->Exit(0);


### PR DESCRIPTION
As titled. This will be reported at the end of the Fun4All run and tracked as function of time in the Jenkins CI