### PR TITLE
Remove setting of INTT offsetphi from macro. 

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -165,11 +165,10 @@ double Intt(PHG4Reco* g4Reco, double radius,
   for (int i = 0; i < G4INTT::n_intt_layer; i++)
   {
     cout << " Intt layer " << i << " laddertype " << G4INTT::laddertype[i] << " nladders " << G4INTT::nladder[i]
-         << " sensor radius " << G4INTT::sensor_radius[i] << " offsetphi " << G4INTT::offsetphi[i] << endl;
+         << " sensor radius " << G4INTT::sensor_radius[i]  << endl;
     sitrack->set_int_param(i, "laddertype", G4INTT::laddertype[i]);
     sitrack->set_int_param(i, "nladder", G4INTT::nladder[i]);
     sitrack->set_double_param(i, "sensor_radius", G4INTT::sensor_radius[i]);  // expecting cm
-    sitrack->set_double_param(i, "offsetphi", G4INTT::offsetphi[i]);          // expecting degrees
   }
 
   // outer radius marker (translation back to cm)

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -77,8 +77,6 @@ namespace G4INTT
   int nladder[4] = {12, 12, 16, 16};
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
-  double offsetphi[4] = {0.0, 0.5 * 360.0 / nladder[1], 0.0, 0.5 * 360.0 / nladder[3]};
-
   enum enu_InttDeadMapType  // Dead map options for INTT
   {
     kInttNoDeadMap = 0,  // All channel in Intt is alive


### PR DESCRIPTION
Remove the (incorrect) setting of offsetphi for the INTT ladders from the macro. The default in the subsystem code is correct. 

This will cause all future simulations to be run with the correct INTT ladder phi offsets.

This does not affect the readback of existing g4hits files, because those files already contain the INTT geometry object that was produced in the simulations. When the READHITS flag is set in Fun4All, the INTT geometry is obtained from the input file.

For reading real data, this macro will produce the correct (ideal) INTT geometry object.