### PR TITLE
add header reco to Fun4All_Year1.C

### DIFF
--- a/CaloProduction/Fun4All_Year1.C
+++ b/CaloProduction/Fun4All_Year1.C
@@ -11,6 +11,10 @@
 #include <caloreco/RawClusterPositionCorrection.h>
 #include <caloreco/TowerInfoDeadHotMask.h>
 
+#include <mbd/MbdReco.h>
+
+#include <globalvertex/GlobalVertexReco.h>
+
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <ffamodules/HeadReco.h>
@@ -25,9 +29,6 @@
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
 #include <fun4all/SubsysReco.h>
-
-#include <mbd/MbdReco.h>
-#include <globalvertex/GlobalVertexReco.h>
 
 #include <phool/recoConsts.h>
 
@@ -68,6 +69,16 @@ void Fun4All_Year1(const std::string &fname = "/sphenix/lustre01/sphnxpro/commis
   // // 64 bit timestamp
   rc->set_uint64Flag("TIMESTAMP", runnumber);
   CDBInterface::instance()->Verbosity(1);
+
+// Sync Headers and Flags
+  SyncReco *sync = new SyncReco();
+  se->registerSubsystem(sync);
+
+  HeadReco *head = new HeadReco();
+  se->registerSubsystem(head);
+
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
 
   // MBD/BBC Reconstruction
   MbdReco *mbdreco = new MbdReco();


### PR DESCRIPTION
This PR adds the header reconstruction (run, event header, sync object and flag saving) to the Fun4All_Year1.C