### PR TITLE
feat: update unpacker to create output hitset DST

### DIFF
--- a/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
+++ b/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
@@ -31,7 +31,7 @@ R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libmicromegas.so)
 R__LOAD_LIBRARY(libTrackingDiagnostics.so)
-void Fun4All_TrkrHitSet_Unpacker(
+void Fun4All_TrkrClusteringSeeding(
     const int nEvents = 2,
     const int runnumber = 26048,
     const std::string outfilename = "cosmics",
@@ -50,11 +50,15 @@ void Fun4All_TrkrHitSet_Unpacker(
   Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG","ProdA_2023");
   rc->set_uint64Flag("TIMESTAMP",6);
-
   std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+ 
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo); 
+
+  G4MAGNET::magfield = "0.01";
+  G4MAGNET::magfield_rescale = 1;
+  ACTSGEOM::ActsGeomInit();
 
   auto hitsin = new Fun4AllDstInputManager("InputManager");
   hitsin->fileopen(filename);
@@ -76,8 +80,46 @@ void Fun4All_TrkrHitSet_Unpacker(
   tpotunpacker->set_calibration_file(calibrationFile);
   se->registerSubsystem(tpotunpacker);
 
-  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
-  se->registerOutputManager(out);
+  Mvtx_Clustering();
+  Intt_Clustering();
+
+  auto tpcclusterizer = new TpcClusterizer;
+  tpcclusterizer->Verbosity(0);
+  tpcclusterizer->set_do_hit_association( G4TPC::DO_HIT_ASSOCIATION );  
+  tpcclusterizer->set_rawdata_reco();  
+  se->registerSubsystem(tpcclusterizer);
+ 
+  Micromegas_Clustering();
+
+  Tracking_Reco_TrackSeed();
+  convert_seeds();
+
+  TString residoutfile = outfilename + runnumber + "_resid.root";
+  std::string residstring(residoutfile.Data());
+  
+  auto resid = new TrackResiduals("TrackResiduals");
+  resid->outfileName(residstring);
+  resid->alignment(false);
+  se->registerSubsystem(resid);
+
+  TString ntupoutfile = outfilename + runnumber + "_ntup.root";
+  std::string ntupstring(ntupoutfile.Data());
+
+  auto ntp = new TrkrNtuplizer("TrkrNtuplizer",ntupstring);
+  ntp->do_hit_eval(true);
+  ntp->do_cluster_eval(true);
+  ntp->do_track_eval(true);
+  ntp->do_siseed_eval(true);
+  ntp->do_tpcseed_eval(true);
+  ntp->do_clus_trk_eval(true);
+  ntp->do_vertex_eval(false);
+  ntp->set_trkclus_seed_container("SvtxTrackSeedContainer");
+  ntp->Verbosity(0);
+  ntp->do_info_eval(false);
+  se->registerSubsystem(ntp);
+
+  //Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", "/sphenix/tg/tg01/hf/jdosbo/tracking_development/onlineoffline/hitsets.root");
+  //se->registerOutputManager(out);
 
   se->run(nEvents);
   se->End();

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -77,6 +77,14 @@ void Fun4All_TrkrHitSet_Unpacker(
   se->registerSubsystem(tpotunpacker);
 
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
+  out->StripNode("MVTXRAWHIT");
+  out->StripNode("INTTRAWHIT");
+  out->StripNode("MICROMEGASRAWHIT");
+  out->StripNode("TPCRAWHIT");
+  out->StripNode("GL1RAWHIT");
+  out->StripNode("MVTXRAWEVTHEADER");
+  out->StripNode("MVTXEVENTHEADER");
+  
   se->registerOutputManager(out);
 
   se->run(nEvents);

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -1,8 +1,4 @@
 #include <GlobalVariables.C>
-#include <G4_Magnet.C>
-#include <G4_ActsGeom.C>
-#include <Trkr_Clustering.C>
-#include <Trkr_Reco_Cosmics.C>
 
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
@@ -19,9 +15,6 @@
 #include <tpc/TpcCombinedRawDataUnpacker.h>
 #include <micromegas/MicromegasCombinedDataDecoder.h>
 
-#include <trackingdiagnostics/TrkrNtuplizer.h>
-#include <trackingdiagnostics/TrackResiduals.h>
-
 #include <stdio.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
@@ -30,7 +23,6 @@ R__LOAD_LIBRARY(libmvtx.so)
 R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libmicromegas.so)
-R__LOAD_LIBRARY(libTrackingDiagnostics.so)
 void Fun4All_TrkrHitSet_Unpacker(
     const int nEvents = 2,
     const int runnumber = 26048,

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -30,6 +30,7 @@ void Fun4All_TrkrHitSet_Unpacker(
     const std::string dir = "/sphenix/lustre01/sphnxpro/commissioning/aligned_streaming_all/",
     const std::string file = "cosmics-")
 {
+  gSystem->Load("libg4dst.so");
   std::string inputRawHitFile = dir + file;
   char filename[500];
   sprintf(filename, "%s%08d-0000.root",inputRawHitFile.c_str(),runnumber);

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -82,8 +82,6 @@ void Fun4All_TrkrHitSet_Unpacker(
   out->StripNode("MICROMEGASRAWHIT");
   out->StripNode("TPCRAWHIT");
   out->StripNode("GL1RAWHIT");
-  out->StripNode("MVTXRAWEVTHEADER");
-  out->StripNode("MVTXEVENTHEADER");
   
   se->registerOutputManager(out);
 


### PR DESCRIPTION
Updates the unpacker macro to only create an output hitset dst. Copies the current macro to a new file which can still be checked in the CI. To be discussed at the software meeting today