### PR TITLE
Emphasize dependence of SvtxEvaluator on global reco

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -335,7 +335,7 @@ int Fun4All_G4_sPHENIX(
   Enable::MICROMEGAS_QA = Enable::MICROMEGAS_CLUSTER && Enable::QA && true;
 
   Enable::TRACKING_TRACK = (Enable::MICROMEGAS_CLUSTER && Enable::TPC_CLUSTER && Enable::INTT_CLUSTER && Enable::MVTX_CLUSTER) && true;
-  Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && true;
+  Enable::TRACKING_EVAL = Enable::TRACKING_TRACK && Enable::GLOBAL_RECO && true;
   Enable::TRACKING_QA = Enable::TRACKING_TRACK && Enable::QA && true;
 
   // only do track matching if TRACKINGTRACK is also used


### PR DESCRIPTION
When attempting to isolate the tracking portion of the main Fun4All macro from the rest of the modules, it took a while to realize that SvtxEvaluator (part of Tracking_Eval()) requires global reco to run properly; if a global vertex isn't present, SvtxEvaluator silently crashes. The proposed one-line change makes this dependency explicit in the conditions of the TRACKING_EVAL switch; TRACKING_EVAL can now only be on if GLOBAL_RECO is enabled.