### PR TITLE
feat: iterative siliconseeding

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -158,6 +158,9 @@ namespace G4TRACKING
   // use of the various evaluation tools already available
   bool convert_seeds_to_svtxtracks = false;
 
+  // Runs a second pass of seeding to pick up missed seeds in the first pass
+  bool iterative_seeding = false;
+
   // Flag to run commissioning seeding workflow with tuned parameters for
   // misaligned + distorted tracks
   bool use_alignment = false;

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -4,7 +4,6 @@
 #include <G4_TrkrVariables.C>
 //#include <G4_ActsGeom.C>
 
-
 #include <g4eval/SvtxTruthRecoTableEval.h>
 #include <g4eval/TrackSeedTrackMapConverter.h>
 
@@ -29,8 +28,8 @@
 
 #include <tpccalib/PHTpcResiduals.h>
 
-#include <trackermillepedealignment/MakeMilleFiles.h>
 #include <trackermillepedealignment/HelicalFitter.h>
+#include <trackermillepedealignment/MakeMilleFiles.h>
 
 #include <fun4all/Fun4AllServer.h>
 
@@ -43,12 +42,12 @@ R__LOAD_LIBRARY(libtrackeralign.so)
 
 void convert_seeds()
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
-  TrackSeedTrackMapConverter *converter = new TrackSeedTrackMapConverter();
-  // Default set to full SvtxTrackSeeds. Can be set to 
-  // SiliconTrackSeedContainer or TpcTrackSeedContainer 
+  TrackSeedTrackMapConverter* converter = new TrackSeedTrackMapConverter();
+  // Default set to full SvtxTrackSeeds. Can be set to
+  // SiliconTrackSeedContainer or TpcTrackSeedContainer
   converter->setTrackSeedName("SvtxTrackSeedContainer");
   converter->setFieldMap(G4MAGNET::magfield);
   converter->Verbosity(verbosity);
@@ -59,12 +58,12 @@ void Tracking_Reco_TrackSeed()
 {
   // set up verbosity
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
-  
+
   // get fun4all server instance
   auto se = Fun4AllServer::instance();
-  
-  // Assemble silicon clusters into track stubs 
-  
+
+  // Assemble silicon clusters into track stubs
+
   auto silicon_Seeding = new PHActsSiliconSeeding;
   silicon_Seeding->Verbosity(verbosity);
   se->registerSubsystem(silicon_Seeding);
@@ -72,22 +71,21 @@ void Tracking_Reco_TrackSeed()
   auto merger = new PHSiliconSeedMerger;
   merger->Verbosity(verbosity);
   se->registerSubsystem(merger);
-  
-  
+
   auto seeder = new PHCASeeding("PHCASeeding");
   seeder->set_field_dir(G4MAGNET::magfield_rescale);  // to get charge sign right
-  
+
   if (G4MAGNET::magfield.find("3d") != std::string::npos)
-    {
-      seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
-      seeder->useConstBField(false);
-    }
-  if(G4MAGNET::magfield.find(".root") == std::string::npos)
-    {
-      //! constant field
-      seeder->useConstBField(true);
-      seeder->constBField(std::stod(G4MAGNET::magfield));
-    }
+  {
+    seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
+    seeder->useConstBField(false);
+  }
+  if (G4MAGNET::magfield.find(".root") == std::string::npos)
+  {
+    //! constant field
+    seeder->useConstBField(true);
+    seeder->constBField(std::stod(G4MAGNET::magfield));
+  }
   seeder->Verbosity(verbosity);
   seeder->SetLayerRange(7, 55);
   seeder->SetSearchWindow(1.5, 0.05);  // (z width, phi width)
@@ -95,24 +93,24 @@ void Tracking_Reco_TrackSeed()
   seeder->SetMinClustersPerTrack(3);
   seeder->useFixedClusterError(true);
   se->registerSubsystem(seeder);
-  
+
   // expand stubs in the TPC using simple kalman filter
   auto cprop = new PHSimpleKFProp("PHSimpleKFProp");
   cprop->set_field_dir(G4MAGNET::magfield_rescale);
   if (G4MAGNET::magfield.find("3d") != std::string::npos)
-    {
-      cprop->set_field_dir(-1 * G4MAGNET::magfield_rescale);
-    }
-  if(G4MAGNET::magfield.find(".root") == std::string::npos)
-    {
-      cprop->useConstBField(false);
-      cprop->setConstBField(std::stod(G4MAGNET::magfield));
-    }
+  {
+    cprop->set_field_dir(-1 * G4MAGNET::magfield_rescale);
+  }
+  if (G4MAGNET::magfield.find(".root") == std::string::npos)
+  {
+    cprop->useConstBField(false);
+    cprop->setConstBField(std::stod(G4MAGNET::magfield));
+  }
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
   cprop->Verbosity(verbosity);
   se->registerSubsystem(cprop);
-  
+
   std::cout << "Tracking_Reco_TrackSeed - Using stub matching for Si matching " << std::endl;
   // The normal silicon association methods
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
@@ -121,34 +119,39 @@ void Tracking_Reco_TrackSeed()
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   std::cout << "PHSiliconTpcTrackMatching pp_mode set to " << TRACKING::pp_mode << std::endl;
   if (G4TRACKING::SC_CALIBMODE)
-    {
-      // search windows for initial matching with distortions
-      // tuned values are 0.04 and 0.008 in distorted events
-      silicon_match->set_phi_search_window(0.04);
-      silicon_match->set_eta_search_window(0.008);
-    } else {
+  {
+    // search windows for initial matching with distortions
+    // tuned values are 0.04 and 0.008 in distorted events
+    silicon_match->set_phi_search_window(0.04);
+    silicon_match->set_eta_search_window(0.008);
+  }
+  else
+  {
     // after distortion corrections and rerunning clustering, default tuned values are 0.02 and 0.004 in low occupancy events
     silicon_match->set_phi_search_window(0.03);
     silicon_match->set_eta_search_window(0.005);
   }
   silicon_match->set_test_windows_printout(false);  // used for tuning search windows
   se->registerSubsystem(silicon_match);
- 
+
   // Associate Micromegas clusters with the tracks
-  if( Enable::MICROMEGAS ){
+  if (Enable::MICROMEGAS)
+  {
     std::cout << "Tracking_Reco_TrackSeed - Using Micromegas matching " << std::endl;
-    
+
     // Match TPC track stubs from CA seeder to clusters in the micromegas layers
     auto mm_match = new PHMicromegasTpcTrackMatching;
     mm_match->Verbosity(verbosity);
     if (G4TRACKING::SC_CALIBMODE)
-      {
-	// configuration is potentially with different search windows
-	mm_match->set_rphi_search_window_lyr1(0.2);
-	mm_match->set_rphi_search_window_lyr2(13.0);
-	mm_match->set_z_search_window_lyr1(26.0);
-	mm_match->set_z_search_window_lyr2(0.2);
-      } else {
+    {
+      // configuration is potentially with different search windows
+      mm_match->set_rphi_search_window_lyr1(0.2);
+      mm_match->set_rphi_search_window_lyr2(13.0);
+      mm_match->set_z_search_window_lyr1(26.0);
+      mm_match->set_z_search_window_lyr2(0.2);
+    }
+    else
+    {
       // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
       mm_match->set_rphi_search_window_lyr1(0.2);
       mm_match->set_rphi_search_window_lyr2(13.0);
@@ -159,7 +162,6 @@ void Tracking_Reco_TrackSeed()
     mm_match->set_test_windows_printout(false);  // used for tuning search windows only
     se->registerSubsystem(mm_match);
   }
-
 }
 
 void Tracking_Reco_TrackSeed_pass1()
@@ -195,7 +197,6 @@ void vertexing()
   auto vtxfinder = new PHSimpleVertexFinder;
   vtxfinder->Verbosity(verbosity);
   se->registerSubsystem(vtxfinder);
-  
 }
 
 void Tracking_Reco_TrackFit()
@@ -207,7 +208,6 @@ void Tracking_Reco_TrackFit()
   auto deltazcorr = new PHTpcDeltaZCorrection;
   deltazcorr->Verbosity(verbosity);
   se->registerSubsystem(deltazcorr);
-  
 
   // perform final track fit with ACTS
   auto actsFit = new PHActsTrkFitter;
@@ -221,27 +221,28 @@ void Tracking_Reco_TrackFit()
   actsFit->useOutlierFinder(false);
   actsFit->setFieldMap(G4MAGNET::magfield);
   se->registerSubsystem(actsFit);
-  
+
   if (G4TRACKING::SC_CALIBMODE)
   {
     /*
-    * in calibration mode, calculate residuals between TPC and fitted tracks, 
-    * store in dedicated structure for distortion correction
-    */
+     * in calibration mode, calculate residuals between TPC and fitted tracks,
+     * store in dedicated structure for distortion correction
+     */
     auto residuals = new PHTpcResiduals;
     residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
     residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     residuals->Verbosity(verbosity);
     se->registerSubsystem(residuals);
-  } else {
-    
-    /* 
-     * in full tracking mode, run track cleaner, vertex finder, 
-     * propagete tracks to vertex 
+  }
+  else
+  {
+    /*
+     * in full tracking mode, run track cleaner, vertex finder,
+     * propagete tracks to vertex
      * propagate tracks to EMCAL
-     */ 
-    
-    if( !G4TRACKING::use_full_truth_track_seeding )
+     */
+
+    if (!G4TRACKING::use_full_truth_track_seeding)
     {
       // Choose the best silicon matched track for each TPC track seed
       /* this breaks in truth_track seeding mode because there is no TpcSeed */
@@ -249,9 +250,9 @@ void Tracking_Reco_TrackFit()
       cleaner->Verbosity(verbosity);
       se->registerSubsystem(cleaner);
     }
-    
+
     vertexing();
-    
+
     // Propagate track positions to the vertex position
     auto vtxProp = new PHActsVertexPropagator;
     vtxProp->Verbosity(verbosity);
@@ -261,20 +262,19 @@ void Tracking_Reco_TrackFit()
     // project tracks to EMCAL
     auto projection = new PHActsTrackProjection;
     projection->Verbosity(verbosity);
-    if(G4MAGNET::magfield.find(".root") == std::string::npos)
-      {
-	projection->setConstFieldVal(std::stod(G4MAGNET::magfield));
-      }
+    if (G4MAGNET::magfield.find(".root") == std::string::npos)
+    {
+      projection->setConstFieldVal(std::stod(G4MAGNET::magfield));
+    }
     se->registerSubsystem(projection);
   }
-  
 }
 
 void Tracking_Reco_CommissioningTrackSeed()
 {
-   // set up verbosity
+  // set up verbosity
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
-  
+
   // get fun4all server instance
   auto se = Fun4AllServer::instance();
 
@@ -288,14 +288,14 @@ void Tracking_Reco_CommissioningTrackSeed()
   auto merger = new PHSiliconSeedMerger;
   merger->Verbosity(verbosity);
   se->registerSubsystem(merger);
-  
-  // Assemble TPC clusters into track stubs 
+
+  // Assemble TPC clusters into track stubs
   auto seeder = new PHCASeeding("PHCASeeding");
   seeder->set_field_dir(G4MAGNET::magfield_rescale);  // to get charge sign right
   if (G4MAGNET::magfield.find("3d") != std::string::npos)
-    {
-      seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
-    }
+  {
+    seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
+  }
   seeder->Verbosity(verbosity);
   seeder->SetLayerRange(7, 55);
   seeder->SetSearchWindow(1.5, 0.05);  // (z width, phi width)
@@ -304,67 +304,63 @@ void Tracking_Reco_CommissioningTrackSeed()
   seeder->useConstBField(false);
   seeder->useFixedClusterError(true);
   se->registerSubsystem(seeder);
-  
+
   // expand stubs in the TPC using simple kalman filter
   auto cprop = new PHSimpleKFProp("PHSimpleKFProp");
   cprop->set_field_dir(G4MAGNET::magfield_rescale);
   if (G4MAGNET::magfield.find("3d") != std::string::npos)
-    {
-      cprop->set_field_dir(-1 * G4MAGNET::magfield_rescale);
-    }
+  {
+    cprop->set_field_dir(-1 * G4MAGNET::magfield_rescale);
+  }
   cprop->useConstBField(false);
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
   cprop->Verbosity(verbosity);
   se->registerSubsystem(cprop);
-  
-  
+
   // match silicon track seeds to TPC track seeds
-  
+
   // The normal silicon association methods
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(verbosity);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
-  
+
   silicon_match->set_phi_search_window(0.2);
   silicon_match->set_eta_search_window(0.015);
-  silicon_match->set_x_search_window(std::numeric_limits<double>::max());  
-  silicon_match->set_y_search_window(std::numeric_limits<double>::max());  
-  silicon_match->set_z_search_window(std::numeric_limits<double>::max());  
-  
+  silicon_match->set_x_search_window(std::numeric_limits<double>::max());
+  silicon_match->set_y_search_window(std::numeric_limits<double>::max());
+  silicon_match->set_z_search_window(std::numeric_limits<double>::max());
+
   silicon_match->set_test_windows_printout(false);  // used for tuning search windows
   se->registerSubsystem(silicon_match);
-  
-  
+
   // Associate Micromegas clusters with the tracks
-  if( Enable::MICROMEGAS )
-    {
-      // Match TPC track stubs from CA seeder to clusters in the micromegas layers
-      auto mm_match = new PHMicromegasTpcTrackMatching;
-      mm_match->Verbosity(verbosity);
-      
-      mm_match->set_rphi_search_window_lyr1(0.4);
-      mm_match->set_rphi_search_window_lyr2(13.0);
-      mm_match->set_z_search_window_lyr1(26.0);
-      mm_match->set_z_search_window_lyr2(0.2);
-      
-      mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
-      mm_match->set_test_windows_printout(false);  // used for tuning search windows only
-      se->registerSubsystem(mm_match);
-      
-      
-    } 
-  if(G4TRACKING::convert_seeds_to_svtxtracks)
-    {
-      convert_seeds();
-    }
+  if (Enable::MICROMEGAS)
+  {
+    // Match TPC track stubs from CA seeder to clusters in the micromegas layers
+    auto mm_match = new PHMicromegasTpcTrackMatching;
+    mm_match->Verbosity(verbosity);
+
+    mm_match->set_rphi_search_window_lyr1(0.4);
+    mm_match->set_rphi_search_window_lyr2(13.0);
+    mm_match->set_z_search_window_lyr1(26.0);
+    mm_match->set_z_search_window_lyr2(0.2);
+
+    mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
+    mm_match->set_test_windows_printout(false);  // used for tuning search windows only
+    se->registerSubsystem(mm_match);
+  }
+  if (G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    convert_seeds();
+  }
 }
 
-void alignment(std::string datafilename = "mille_output_data_file", 
-	       std::string steeringfilename = "mille_steer")
+void alignment(std::string datafilename = "mille_output_data_file",
+               std::string steeringfilename = "mille_steer")
 {
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
   auto mille = new MakeMilleFiles;
@@ -378,62 +374,59 @@ void alignment(std::string datafilename = "mille_output_data_file",
   helical->set_datafile_name(datafilename + "_helical.bin");
   helical->set_steeringfile_name(steeringfilename + "_helical.txt");
   se->registerSubsystem(helical);
-
 }
- 
+
 void Tracking_Reco()
 {
   /*
-   * just a wrapper around track seeding and track fitting methods, 
+   * just a wrapper around track seeding and track fitting methods,
    * to minimize disruption to existing steering macros
    */
-  if(G4TRACKING::use_alignment)
-    {
-      Tracking_Reco_CommissioningTrackSeed();
-    }
+  if (G4TRACKING::use_alignment)
+  {
+    Tracking_Reco_CommissioningTrackSeed();
+  }
   else
-    {
-      Tracking_Reco_TrackSeed();
-    }
+  {
+    Tracking_Reco_TrackSeed();
+  }
 
-    if (G4TRACKING::convert_seeds_to_svtxtracks)
-    {
-      convert_seeds();
-      vertexing();
-    }
+  if (G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    convert_seeds();
+    vertexing();
+  }
   else
-    {
-      Tracking_Reco_TrackFit();
-    }
+  {
+    Tracking_Reco_TrackFit();
+  }
 
-    if (G4TRACKING::iterative_seeding)
-    {
-      Tracking_Reco_TrackSeed_pass1();
-    }
-    if (G4TRACKING::convert_seeds_to_svtxtracks)
-    {
-      convert_seeds();
-      vertexing();
-    }
+  if (G4TRACKING::iterative_seeding)
+  {
+    Tracking_Reco_TrackSeed_pass1();
+  }
+  if (G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    convert_seeds();
+    vertexing();
+  }
 
-  if(G4TRACKING::use_alignment)
-    {
-      alignment();
-    }
-
+  if (G4TRACKING::use_alignment)
+  {
+    alignment();
+  }
 }
 
-void  Filter_Conversion_Electrons(std::string ntuple_outfile)
+void Filter_Conversion_Electrons(std::string ntuple_outfile)
 {
   Fun4AllServer* se = Fun4AllServer::instance();
   SecondaryVertexFinder* secvert = new SecondaryVertexFinder;
   secvert->Verbosity(0);
   //  secvert->set_write_electrons_node(true);  // writes copy of filtered electron tracks to node tree
   //  secvert->set_write_ntuple(false);  // writes ntuple for tuning cuts
-  secvert->setDecayParticleMass( 0.000511);  // for electrons
+  secvert->setDecayParticleMass(0.000511);  // for electrons
   secvert->setOutfileName(ntuple_outfile);
   se->registerSubsystem(secvert);
 }
-
 
 #endif

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -50,9 +50,9 @@ void convert_seeds()
   TrackSeedTrackMapConverter* converter = new TrackSeedTrackMapConverter();
   // Default set to full SvtxTrackSeeds. Can be set to
   // SiliconTrackSeedContainer or TpcTrackSeedContainer
-  converter->setTrackSeedName("SiliconTrackSeedContainer");
+  converter->setTrackSeedName("SvtxTrackSeedContainer");
   converter->setFieldMap(G4MAGNET::magfield);
-  converter->Verbosity(4);
+  converter->Verbosity(verbosity);
   se->registerSubsystem(converter);
 }
 


### PR DESCRIPTION
This introduces a function that can call iterative silicon seeding. The second iteration includes the INTT and thus picks up some seeds that couldn't be found due to either leaving <3 clusters in the MVTX or due to some dead areas that we will have to deal with in real data.