### PR TITLE
refactor: move seed->track converter

### DIFF
--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -2,9 +2,8 @@
 #define MACRO_TRKRRECO_C
 
 #include <G4_TrkrVariables.C>
-//#include <G4_ActsGeom.C>
 
-#include <g4eval/TrackSeedTrackMapConverter.h>
+#include <trackingdiagnostics/TrackSeedTrackMapConverter.h>
 
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSiliconSeeding.h>

--- a/common/Trkr_Reco_Cosmics.C
+++ b/common/Trkr_Reco_Cosmics.C
@@ -3,7 +3,7 @@
 
 #include <G4_TrkrVariables.C>
 
-#include <g4eval/TrackSeedTrackMapConverter.h>
+#include <trackingdiagnostics/TrackSeedTrackMapConverter.h>
 
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHCASeeding.h>
@@ -31,6 +31,7 @@ R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libtpccalib.so)
 R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libtrackeralign.so)
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
 void convert_seeds()
 {
   Fun4AllServer *se = Fun4AllServer::instance();

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -4,11 +4,10 @@
 #include <GlobalVariables.C>
 
 #include <G4_TrkrVariables.C>
-//#include <G4_ActsGeom.C>
 
 
 #include <g4eval/SvtxTruthRecoTableEval.h>
-#include <g4eval/TrackSeedTrackMapConverter.h>
+#include <trackingdiagnostics/TrackSeedTrackMapConverter.h>
 
 #include <trackreco/MakeActsGeometry.h>
 #include <trackreco/PHActsSiliconSeeding.h>
@@ -38,7 +37,7 @@
 
 #include <fun4all/Fun4AllServer.h>
 
-
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libtpccalib.so)
 R__LOAD_LIBRARY(libtrackeralign.so)


### PR DESCRIPTION
Moves the seed->track converter out of g4eval so that we aren't accidentally pulling in this dependency, since it only uses reco information.