### PR TITLE
feat: add setter for extended readout for tpot

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -485,6 +485,9 @@ void Micromegas_Cells()
   auto se = Fun4AllServer::instance();
   // micromegas
   auto reco = new PHG4MicromegasHitReco;
+  double extended_readout_time = 0.0;
+  if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  reco->set_double_param("micromegas_tmax", 800.0+extended_readout_time);
   reco->Verbosity(0);
   se->registerSubsystem(reco);
 


### PR DESCRIPTION
Currently the TPOT extended readout is set as a default value but not overridden at the macro level, unlike the other detectors. This appears to make TPOT hits lost in the streaming simulations. This sets the minimum value to be the default value + the actual extended readout time set at the macro level.