### PR TITLE
feat: add prelim hot map

### DIFF
--- a/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
+++ b/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
@@ -72,10 +72,10 @@ void Fun4All_TrkrClusteringSeeding(
   se->registerInputManager(hitsin);
 
   auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
-  mvtxunpacker->Verbosity(1);
   se->registerSubsystem(mvtxunpacker);
 
   auto inttunpacker = new InttCombinedRawDataDecoder;
+  inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
   se->registerSubsystem(inttunpacker);
 
   auto tpcunpacker = new TpcCombinedRawDataUnpacker;

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -64,6 +64,7 @@ void Fun4All_TrkrHitSet_Unpacker(
   se->registerSubsystem(mvtxunpacker);
 
   auto inttunpacker = new InttCombinedRawDataDecoder;
+  inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
   se->registerSubsystem(inttunpacker);
 
   auto tpcunpacker = new TpcCombinedRawDataUnpacker;


### PR DESCRIPTION
Adds a preliminary hot map created from early in run 23 for the INTT, still some hot channels present in the cosmics but this is at least a starting point