### PR TITLE
feat: common hit unpackers

### DIFF
--- a/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
+++ b/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
@@ -23,16 +23,12 @@
 #include <phool/recoConsts.h>
 
 #include <intt/InttClusterQA.h>
-#include <intt/InttCombinedRawDataDecoder.h>
 
 #include <micromegas/MicromegasClusterQA.h>
-#include <micromegas/MicromegasCombinedDataDecoder.h>
 
 #include <mvtx/MvtxClusterQA.h>
-#include <mvtx/MvtxCombinedRawDataDecoder.h>
 
 #include <tpc/TpcClusterQA.h>
-#include <tpc/TpcCombinedRawDataUnpacker.h>
 
 #include <trackingdiagnostics/TrackResiduals.h>
 #include <trackingdiagnostics/TrkrNtuplizer.h>
@@ -70,7 +66,8 @@ void Fun4All_TrkrClusteringSeeding(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
-
+ 
+  G4TPC::tpc_drift_velocity_reco = (8.0/1000)*107.0/105.0;
   G4MAGNET::magfield = "0.01";
   G4MAGNET::magfield_rescale = 1;
   ACTSGEOM::ActsGeomInit();
@@ -79,22 +76,10 @@ void Fun4All_TrkrClusteringSeeding(
   hitsin->fileopen(inputRawHitFile);
   se->registerInputManager(hitsin);
 
-  auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
-  se->registerSubsystem(mvtxunpacker);
-
-  auto inttunpacker = new InttCombinedRawDataDecoder;
-  inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
-  se->registerSubsystem(inttunpacker);
-
-  auto tpcunpacker = new TpcCombinedRawDataUnpacker;
-  se->registerSubsystem(tpcunpacker);
-
-  auto tpotunpacker = new MicromegasCombinedDataDecoder;
-
-  std::string calibrationFile = CDBInterface::instance()->getUrl("TPOT_Pedestal");
-  tpotunpacker->set_calibration_file(calibrationFile);
-  se->registerSubsystem(tpotunpacker);
-
+  Mvtx_HitUnpacking();
+  Intt_HitUnpacking();
+  Tpc_HitUnpacking();
+  Micromegas_HitUnpacking();
   Mvtx_Clustering();
   Intt_Clustering();
 

--- a/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
+++ b/TrackingProduction/Fun4All_TrkrClusteringSeeding.C
@@ -66,8 +66,8 @@ void Fun4All_TrkrClusteringSeeding(
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
   ingeo->AddFile(geofile);
   se->registerInputManager(ingeo);
- 
-  G4TPC::tpc_drift_velocity_reco = (8.0/1000)*107.0/105.0;
+
+  G4TPC::tpc_drift_velocity_reco = (8.0 / 1000) * 107.0 / 105.0;
   G4MAGNET::magfield = "0.01";
   G4MAGNET::magfield_rescale = 1;
   ACTSGEOM::ActsGeomInit();

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -4,6 +4,7 @@
  * format. No other reconstruction or analysis is performed
  */
 #include <GlobalVariables.C>
+#include <Trkr_Clustering.C> 
 
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>
@@ -15,11 +16,6 @@
 #include <ffamodules/CDBInterface.h>
 
 #include <phool/recoConsts.h>
-
-#include <intt/InttCombinedRawDataDecoder.h>
-#include <micromegas/MicromegasCombinedDataDecoder.h>
-#include <mvtx/MvtxCombinedRawDataDecoder.h>
-#include <tpc/TpcCombinedRawDataUnpacker.h>
 
 #include <stdio.h>
 
@@ -59,22 +55,10 @@ void Fun4All_TrkrHitSet_Unpacker(
   hitsin->fileopen(filename);
   se->registerInputManager(hitsin);
 
-  auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
-  mvtxunpacker->Verbosity(1);
-  se->registerSubsystem(mvtxunpacker);
-
-  auto inttunpacker = new InttCombinedRawDataDecoder;
-  inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
-  se->registerSubsystem(inttunpacker);
-
-  auto tpcunpacker = new TpcCombinedRawDataUnpacker;
-  se->registerSubsystem(tpcunpacker);
-
-  auto tpotunpacker = new MicromegasCombinedDataDecoder;
-
-  std::string calibrationFile = CDBInterface::instance()->getUrl("TPOT_Pedestal");
-  tpotunpacker->set_calibration_file(calibrationFile);
-  se->registerSubsystem(tpotunpacker);
+  Mvtx_HitUnpacking();
+  Intt_HitUnpacking();
+  Tpc_HitUnpacking();
+  Micromegas_HitUnpacking();
 
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfilename);
   out->StripNode("MVTXRAWHIT");

--- a/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
+++ b/TrackingProduction/Fun4All_TrkrHitSet_Unpacker.C
@@ -4,7 +4,7 @@
  * format. No other reconstruction or analysis is performed
  */
 #include <GlobalVariables.C>
-#include <Trkr_Clustering.C> 
+#include <Trkr_Clustering.C>
 
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllDstOutputManager.h>

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -3,17 +3,17 @@
 
 #include <GlobalVariables.C>
 
-#include <G4_TrkrVariables.C>
 #include <G4_ActsGeom.C>
+#include <G4_TrkrVariables.C>
 
 #include <intt/InttCombinedRawDataDecoder.h>
 #include <micromegas/MicromegasCombinedDataDecoder.h>
 #include <mvtx/MvtxCombinedRawDataDecoder.h>
 #include <tpc/TpcCombinedRawDataUnpacker.h>
 
-#include <mvtx/MvtxHitPruner.h>
-#include <mvtx/MvtxClusterizer.h>
 #include <intt/InttClusterizer.h>
+#include <mvtx/MvtxClusterizer.h>
+#include <mvtx/MvtxHitPruner.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundefined-internal"
@@ -40,19 +40,18 @@ void ClusteringInit()
 void Mvtx_HitUnpacking()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
 
   auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
   mvtxunpacker->Verbosity(verbosity);
   se->registerSubsystem(mvtxunpacker);
-
 }
 void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
- // prune the extra MVTX hits due to multiple strobes per hit
+  // prune the extra MVTX hits due to multiple strobes per hit
   MvtxHitPruner* mvtxhitpruner = new MvtxHitPruner();
   mvtxhitpruner->Verbosity(verbosity);
   se->registerSubsystem(mvtxhitpruner);
@@ -66,12 +65,11 @@ void Mvtx_Clustering()
 void Intt_HitUnpacking()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
 
   auto inttunpacker = new InttCombinedRawDataDecoder;
   inttunpacker->Verbosity(verbosity);
   se->registerSubsystem(inttunpacker);
-
 }
 void Intt_Clustering()
 {
@@ -96,7 +94,7 @@ void Intt_Clustering()
 void Tpc_HitUnpacking()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
 
   auto tpcunpacker = new TpcCombinedRawDataUnpacker;
   tpcunpacker->Verbosity(verbosity);
@@ -118,25 +116,23 @@ void TPC_Clustering()
 
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(verbosity);
-  tpcclusterizer->set_do_hit_association( G4TPC::DO_HIT_ASSOCIATION );
+  tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
   se->registerSubsystem(tpcclusterizer);
-  
+
   auto tpcclustercleaner = new TpcClusterCleaner;
   tpcclustercleaner->Verbosity(verbosity);
   se->registerSubsystem(tpcclustercleaner);
-
 }
 
 void Micromegas_HitUnpacking()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MICROMEGAS_VERBOSITY);
-  Fun4AllServer *se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
 
   auto tpotunpacker = new MicromegasCombinedDataDecoder;
   std::string calibrationFile = CDBInterface::instance()->getUrl("TPOT_Pedestal");
   tpotunpacker->set_calibration_file(calibrationFile);
   se->registerSubsystem(tpotunpacker);
-
 }
 
 void Micromegas_Clustering()
@@ -145,6 +141,5 @@ void Micromegas_Clustering()
   auto mm_clus = new MicromegasClusterizer;
   se->registerSubsystem(mm_clus);
 }
-
 
 #endif

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -6,6 +6,11 @@
 #include <G4_TrkrVariables.C>
 #include <G4_ActsGeom.C>
 
+#include <intt/InttCombinedRawDataDecoder.h>
+#include <micromegas/MicromegasCombinedDataDecoder.h>
+#include <mvtx/MvtxCombinedRawDataDecoder.h>
+#include <tpc/TpcCombinedRawDataUnpacker.h>
+
 #include <mvtx/MvtxHitPruner.h>
 #include <mvtx/MvtxClusterizer.h>
 #include <intt/InttClusterizer.h>
@@ -32,6 +37,16 @@ void ClusteringInit()
   ACTSGEOM::ActsGeomInit();
 }
 
+void Mvtx_HitUnpacking()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
+  mvtxunpacker->Verbosity(verbosity);
+  se->registerSubsystem(mvtxunpacker);
+
+}
 void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
@@ -48,7 +63,16 @@ void Mvtx_Clustering()
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
 }
+void Intt_HitUnpacking()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
 
+  auto inttunpacker = new InttCombinedRawDataDecoder;
+  inttunpacker->Verbosity(verbosity);
+  se->registerSubsystem(inttunpacker);
+
+}
 void Intt_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
@@ -69,6 +93,15 @@ void Intt_Clustering()
   se->registerSubsystem(inttclusterizer);
 }
 
+void Tpc_HitUnpacking()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  auto tpcunpacker = new TpcCombinedRawDataUnpacker;
+  tpcunpacker->Verbosity(verbosity);
+  se->registerSubsystem(tpcunpacker);
+}
 
 void TPC_Clustering()
 {
@@ -91,6 +124,18 @@ void TPC_Clustering()
   auto tpcclustercleaner = new TpcClusterCleaner;
   tpcclustercleaner->Verbosity(verbosity);
   se->registerSubsystem(tpcclustercleaner);
+
+}
+
+void Micromegas_HitUnpacking()
+{
+  int verbosity = std::max(Enable::VERBOSITY, Enable::MICROMEGAS_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  auto tpotunpacker = new MicromegasCombinedDataDecoder;
+  std::string calibrationFile = CDBInterface::instance()->getUrl("TPOT_Pedestal");
+  tpotunpacker->set_calibration_file(calibrationFile);
+  se->registerSubsystem(tpotunpacker);
 
 }
 


### PR DESCRIPTION
This adds common hit unpacking functions for any macro to call, so that they only need to be updated in one place.

It also updates the tpc drift velocity in the clustering example macro such that the residuals in z line up better.