### PR TITLE
Distortion flags

### DIFF
--- a/common/G4_Tracking_Cosmics.C
+++ b/common/G4_Tracking_Cosmics.C
@@ -68,6 +68,7 @@ void TrackingInit()
   {
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
+    tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
     tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }
@@ -90,13 +91,13 @@ void Tracking_Reco_TrackSeed()
 {
   // set up verbosity
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
-  
+
   // get fun4all server instance
   auto se = Fun4AllServer::instance();
 
   if (!G4TRACKING::use_full_truth_track_seeding)
-  {  
-    // Assemble TPC clusters into track stubs 
+  {
+    // Assemble TPC clusters into track stubs
     if (G4TRACKING::use_truth_tpc_seeding)
     {
       // For the TPC, for each truth particle, create a track and associate clusters with it using truth information, write to Svtx track map
@@ -109,7 +110,7 @@ void Tracking_Reco_TrackSeed()
       se->registerSubsystem(pat_rec);
 
     } else {
-      
+
       auto seeder = new PHCASeeding("PHCASeeding");
       seeder->set_field_dir(G4MAGNET::magfield_rescale);  // to get charge sign right
       if (G4MAGNET::magfield.find("3d") != std::string::npos)
@@ -143,7 +144,7 @@ void Tracking_Reco_TrackSeed()
     PHSiliconHelicalPropagator* hprop = new PHSiliconHelicalPropagator("HelicalPropagator");
     hprop->Verbosity(verbosity);
     se->registerSubsystem(hprop);
- 
+
     // Associate Micromegas clusters with the tracks
     if( Enable::MICROMEGAS )
     {
@@ -172,7 +173,7 @@ void Tracking_Reco_TrackSeed()
     }
 
   } else {
-    
+
     // full truth track finding
     std::cout << "Tracking_Reco_TrackSeed - Using full truth track seeding" << std::endl;
 
@@ -190,7 +191,7 @@ void Tracking_Reco_TrackSeed()
    * all done
    * at this stage tracks are fully assembled. They contain clusters spaning Silicon detectors, TPC and Micromegas
    * they are ready to be fit.
-   */ 
+   */
     convert_seeds();
 }
 
@@ -204,7 +205,7 @@ void vertexing()
   se->registerSubsystem(vtxfinder);
 }
 
-void alignment(std::string datafilename = "mille_output_data_file", 
+void alignment(std::string datafilename = "mille_output_data_file",
 	       std::string steeringfilename = "mille_steer")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
@@ -235,7 +236,7 @@ void build_truthreco_tables()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-  
+
   // this module builds high level truth track association table.
   // If this module is used, this table should be called before any evaluator calls.
   // Removing this module, evaluation will still work but trace truth association through the layers of G4-hit-cluster
@@ -255,7 +256,7 @@ void Tracking_Eval(const std::string& outputfile)
   //---------------
 
   Fun4AllServer* se = Fun4AllServer::instance();
-  build_truthreco_tables(); 
+  build_truthreco_tables();
 
   //----------------
   // Tracking evaluation

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -336,37 +336,37 @@ double TPC(PHG4Reco* g4Reco,
   tpc->SetActive();
   tpc->SuperDetector("TPC");
   tpc->set_double_param("steplimits", 1);  // 1cm steps
- 
+
   tpc->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
   tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
   tpc->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);
-  
+
   if (AbsorberActive)
     {
       tpc->SetAbsorberActive();
     }
-  
+
   double extended_readout_time = 0.0;
-  if(TRACKING::pp_mode) 
+  if(TRACKING::pp_mode)
   {
     extended_readout_time = TRACKING::pp_extended_readout_time;
   }
-  
+
   tpc->set_double_param("extended_readout_time", extended_readout_time);
 
   tpc->OverlapCheck(OverlapCheck);
   g4Reco->registerSubsystem(tpc);
-  
+
   if (Enable::TPC_ENDCAP)
     {
       TPC_Endcaps(g4Reco);
     }
-  
+
   radius = G4TPC::tpc_outer_radius;
-  
+
   radius += no_overlapp;
-  
+
   return radius;
 }
 
@@ -392,14 +392,14 @@ void TPC_Cells()
     // setup phi and theta steps
     /* use 5deg steps */
     static constexpr double deg_to_rad = M_PI/180.;
-    directLaser->SetPhiStepping( 144, 0*deg_to_rad, 360*deg_to_rad );           
-    directLaser->SetThetaStepping( 36, 0*deg_to_rad, 90*deg_to_rad );           
+    directLaser->SetPhiStepping( 144, 0*deg_to_rad, 360*deg_to_rad );
+    directLaser->SetThetaStepping( 36, 0*deg_to_rad, 90*deg_to_rad );
     //directLaser->SetArbitraryThetaPhi(50*deg_to_rad, 145*deg_to_rad);
-    directLaser->SetDirectLaserAuto( true );                                    
-    //__Variable stepping: hitting all of the central membrane____________        
-    //directLaser->SetDirectLaserPatternfromFile( true );                         
-    //directLaser->SetFileStepping(13802);                                        
-    //___________________________________________________________________     
+    directLaser->SetDirectLaserAuto( true );
+    //__Variable stepping: hitting all of the central membrane____________
+    //directLaser->SetDirectLaserPatternfromFile( true );
+    //directLaser->SetFileStepping(13802);
+    //___________________________________________________________________
 
     directLaser->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
     se->registerSubsystem(directLaser);
@@ -423,6 +423,9 @@ void TPC_Cells()
   if( G4TPC::ENABLE_STATIC_DISTORTIONS || G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS )
   {
     auto distortionMap = new PHG4TpcDistortion;
+
+    distortionMap->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
+
     distortionMap->set_do_static_distortions( G4TPC::ENABLE_STATIC_DISTORTIONS );
     distortionMap->set_static_distortion_filename( G4TPC::static_distortion_filename );
 
@@ -513,7 +516,7 @@ void Micromegas_Cells()
   reco->Verbosity(verbosity);
   double extended_readout_time = 0.0;
   if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
-  
+
   reco->set_double_param("micromegas_tmax", 800.0+extended_readout_time);
   se->registerSubsystem(reco);
 

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -10,14 +10,14 @@ namespace Enable
 {
   bool MVTX = false;
   bool MVTX_OVERLAPCHECK = false;
-  
+
   bool MVTX_CELL = false;
   bool MVTX_CLUSTER = false;
   bool MVTX_QA = false;
   bool MVTX_SUPPORT = false;
-  
+
   int MVTX_VERBOSITY = 0;
-  
+
   bool INTT = false;
   bool INTT_ABSORBER = false;
   bool INTT_OVERLAPCHECK = false;
@@ -44,7 +44,7 @@ namespace Enable
   bool MICROMEGAS_QA = false;
   bool MICROMEGAS_SUPPORT = false;
   int MICROMEGAS_VERBOSITY = 0;
-  
+
   bool TRACKING_TRACK = false;
   bool TRACKING_EVAL = false;
   bool TRACK_MATCHING = false;
@@ -109,6 +109,8 @@ namespace G4TPC
   bool USE_SIMPLE_CLUSTERIZER = false;
 
   // distortions
+  bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
+
   bool ENABLE_STATIC_DISTORTIONS = false;
   auto static_distortion_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only.distortion_map.hist.root";
 
@@ -121,7 +123,7 @@ namespace G4TPC
 
   // enable central membrane g4hits generation
   bool ENABLE_CENTRAL_MEMBRANE_HITS = false;
-  
+
   // enable direct laser g4hits generation
   bool ENABLE_DIRECT_LASER_HITS = false;
 
@@ -130,11 +132,11 @@ namespace G4TPC
 
   // do cluster <-> hit association
   bool DO_HIT_ASSOCIATION = true;
-  
+
   // space charge calibration output file
   std::string DIRECT_LASER_ROOTOUTPUT_FILENAME = "TpcSpaceChargeMatrices.root";
-  std::string DIRECT_LASER_HISTOGRAMOUTPUT_FILENAME = "TpcDirectLaserReconstruction.root"; 
-  
+  std::string DIRECT_LASER_HISTOGRAMOUTPUT_FILENAME = "TpcDirectLaserReconstruction.root";
+
 }  // namespace G4TPC
 
 
@@ -148,7 +150,7 @@ namespace G4TRACKING
 
   // Vertexing
   bool g4eval_use_initial_vertex = true;  // if true, g4eval uses initial vertices in SvtxVertexMap, not final vertices in SvtxVertexMapRefit
-  
+
   // Truth seeding options for diagnostics (can use any or all)
   bool use_truth_silicon_seeding = false;     // if true runs truth silicon seeding instead of acts silicon seeding
   bool use_truth_tpc_seeding = false;         // if true runs truth silicon seeding instead of reco TPC seeding

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -18,17 +18,18 @@ void TrackingInit()
 
   ACTSGEOM::ActsGeomInit();
   // space charge correction
-  /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit 
+  /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit
    */
-  
+
   if( G4TPC::ENABLE_CORRECTIONS )
   {
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
+    tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
     tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }
- 
+
 }
 
 


### PR DESCRIPTION
This PR adds a flag to select the format of the distortion corrections (namely using either radian or cm for the phi distortions), which is the propagated to the relevant modules. 

The default value is "true" which is also what's in the modules, so behavior is unchanged.
