### PR TITLE
Macro changes to enable distortion corrections in extended readout pp running

### DIFF
--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -451,6 +451,8 @@ void Tracking_Reco()
 void Filter_Conversion_Electrons(std::string ntuple_outfile)
 {
   Fun4AllServer* se = Fun4AllServer::instance();
+  int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
+
   SecondaryVertexFinder* secvert = new SecondaryVertexFinder;
   secvert->Verbosity(verbosity);
   //  secvert->set_write_electrons_node(true);  // writes copy of filtered electron tracks to node tree

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -93,6 +93,7 @@ void Tracking_Reco_TrackSeed()
   seeder->SetMinHitsPerCluster(0);
   seeder->SetMinClustersPerTrack(3);
   seeder->useFixedClusterError(true);
+  seeder->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(seeder);
 
   // expand stubs in the TPC using simple kalman filter
@@ -110,7 +111,18 @@ void Tracking_Reco_TrackSeed()
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
   cprop->Verbosity(verbosity);
+  cprop->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(cprop);
+
+ if(TRACKING::pp_mode)
+    {
+      // for pp mode, apply preliminary distortion corrections to TPC clusters before crossing is known
+      // and refit the trackseeds. Replace KFProp fits with the new fit parameters in the TPC seeds.
+      auto prelim_distcorr = new PrelimDistortionCorrection;
+      prelim_distcorr->set_pp_mode(TRACKING::pp_mode);
+      prelim_distcorr->Verbosity(verbosity);
+      se->registerSubsystem(prelim_distcorr);
+    }
 
   std::cout << "Tracking_Reco_TrackSeed - Using stub matching for Si matching " << std::endl;
   // The normal silicon association methods
@@ -310,6 +322,7 @@ void Tracking_Reco_CommissioningTrackSeed()
   seeder->SetMinClustersPerTrack(3);
   seeder->useConstBField(false);
   seeder->useFixedClusterError(true);
+  seeder->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(seeder);
 
   // expand stubs in the TPC using simple kalman filter
@@ -323,7 +336,18 @@ void Tracking_Reco_CommissioningTrackSeed()
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
   cprop->Verbosity(verbosity);
+  cprop->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(cprop);
+
+ if(TRACKING::pp_mode)
+    {
+      // for pp mode, apply preliminary distortion corrections to TPC clusters before crossing is known
+      // and refit the trackseeds. Replace KFProp fits with the new fit parameters in the TPC seeds.
+      auto prelim_distcorr = new PrelimDistortionCorrection;
+      prelim_distcorr->set_pp_mode(TRACKING::pp_mode);
+      prelim_distcorr->Verbosity(verbosity);
+      se->registerSubsystem(prelim_distcorr);
+    }
 
   // match silicon track seeds to TPC track seeds
 

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -21,6 +21,7 @@
 #include <trackreco/PHTrackSeeding.h>
 #include <trackreco/SecondaryVertexFinder.h>
 #include <trackreco/TrackingIterationCounter.h>
+#include <trackreco/PrelimDistortionCorrection.h>
 
 #include <tpc/TpcLoadDistortionCorrection.h>
 
@@ -236,6 +237,7 @@ void Tracking_Reco_TrackFit()
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
   actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
   actsFit->set_pp_mode(TRACKING::pp_mode);
+  actsFit->set_use_clustermover(true); // default is true for now
   actsFit->useActsEvaluator(false);
   actsFit->useOutlierFinder(false);
   actsFit->setFieldMap(G4MAGNET::magfield);
@@ -267,6 +269,7 @@ void Tracking_Reco_TrackFit()
       /* this breaks in truth_track seeding mode because there is no TpcSeed */
       auto cleaner = new PHTrackCleaner;
       cleaner->Verbosity(verbosity);
+      //cleaner->set_quality_cut(30.0);
       se->registerSubsystem(cleaner);
     }
 
@@ -397,7 +400,7 @@ void alignment(std::string datafilename = "mille_output_data_file",
   se->registerSubsystem(mille);
 
   auto helical = new HelicalFitter;
-  helical->Verbosity(0);
+  helical->Verbosity(verbosity);
   helical->set_datafile_name(datafilename + "_helical.bin");
   helical->set_steeringfile_name(steeringfilename + "_helical.txt");
   se->registerSubsystem(helical);
@@ -449,7 +452,7 @@ void Filter_Conversion_Electrons(std::string ntuple_outfile)
 {
   Fun4AllServer* se = Fun4AllServer::instance();
   SecondaryVertexFinder* secvert = new SecondaryVertexFinder;
-  secvert->Verbosity(0);
+  secvert->Verbosity(verbosity);
   //  secvert->set_write_electrons_node(true);  // writes copy of filtered electron tracks to node tree
   //  secvert->set_write_ntuple(false);  // writes ntuple for tuning cuts
   secvert->setDecayParticleMass(0.000511);  // for electrons

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -348,14 +348,16 @@ int Fun4All_G4_sPHENIX(
   //Enable::TRACKING_DIAGNOSTICS = Enable::TRACKING_TRACK && true;
   //G4TRACKING::filter_conversion_electrons = true;
   // G4TRACKING::use_alignment = true;
-  TRACKING::pp_mode = true;
-  TRACKING::pp_extended_readout_time = 20000;
 
-  // simulate and correct distortions
-  G4TPC::ENABLE_STATIC_DISTORTIONS = true;
-  G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");  
-  G4TPC::ENABLE_CORRECTIONS = true;
-  G4TPC::correction_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_smoothed_average.correction_map.hist.root");
+  // enable pp mode and set extended readout time
+  // TRACKING::pp_mode = true;
+  // TRACKING::pp_extended_readout_time = 20000;
+
+  // set flags to simulate and correct TPC distortions, specify distortion and correction files
+  //G4TPC::ENABLE_STATIC_DISTORTIONS = true;
+  //G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");  
+  //G4TPC::ENABLE_CORRECTIONS = true;
+  //G4TPC::correction_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_smoothed_average.correction_map.hist.root");
 
   //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
   //  into the tracking, cannot run together with CEMC
@@ -392,11 +394,11 @@ int Fun4All_G4_sPHENIX(
   Enable::EPD_TILE = Enable::EPD && true;
 
   Enable::BEAMLINE = true;
-//  Enable::BEAMLINE_ABSORBER = true;  // makes the beam line magnets sensitive volumes
-//  Enable::BEAMLINE_BLACKHOLE = true; // turns the beamline magnets into black holes
+  //  Enable::BEAMLINE_ABSORBER = true;  // makes the beam line magnets sensitive volumes
+  //  Enable::BEAMLINE_BLACKHOLE = true; // turns the beamline magnets into black holes
   Enable::ZDC = true;
-//  Enable::ZDC_ABSORBER = true;
-//  Enable::ZDC_SUPPORT = true;
+  //  Enable::ZDC_ABSORBER = true;
+  //  Enable::ZDC_SUPPORT = true;
   Enable::ZDC_TOWER = Enable::ZDC && true;
   Enable::ZDC_EVAL = Enable::ZDC_TOWER && true;
 
@@ -721,7 +723,7 @@ int Fun4All_G4_sPHENIX(
 
   se->skip(skip);
   se->run(nEvents);
-  //se->PrintTimer();
+  //  se->PrintTimer();
 
   //-----
   // QA output

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -347,7 +347,15 @@ int Fun4All_G4_sPHENIX(
   //Additional tracking tools 
   //Enable::TRACKING_DIAGNOSTICS = Enable::TRACKING_TRACK && true;
   //G4TRACKING::filter_conversion_electrons = true;
+  // G4TRACKING::use_alignment = true;
+  TRACKING::pp_mode = true;
+  TRACKING::pp_extended_readout_time = 20000;
 
+  // simulate and correct distortions
+  G4TPC::ENABLE_STATIC_DISTORTIONS = true;
+  G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");  
+  G4TPC::ENABLE_CORRECTIONS = true;
+  G4TPC::correction_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_smoothed_average.correction_map.hist.root");
 
   //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
   //  into the tracking, cannot run together with CEMC
@@ -713,6 +721,7 @@ int Fun4All_G4_sPHENIX(
 
   se->skip(skip);
   se->run(nEvents);
+  //se->PrintTimer();
 
   //-----
   // QA output


### PR DESCRIPTION
Macro changes for pp extended readout running. Adds PrelimDistortionCorrection module that makes preliminary distortion corrections to TPC track seeds after the initial seeding and KFProp fit, refits them and replaces the fit parameters on the node tree before silicon-TPC track matching. 