### PR TITLE
use old gdml file when full ring in macro is enabled

### DIFF
--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -144,6 +144,11 @@ double HCalOuter(PHG4Reco *g4Reco,
   else
   {
     hcal = new PHG4OHCalSubsystem("HCALOUT");
+    if (Enable::HCALOUT_RING)
+    {
+      std::string gdmlfile_no_ring =   string(getenv("CALIBRATIONROOT")) + "/HcalGeo/OuterHCalAbsorberTiles_merged.gdml"; 
+      hcal->set_string_param("GDMPath", gdmlfile_no_ring);
+    }
     // hcal->set_string_param("GDMPath", "mytestgdml.gdml"); // try other gdml file
     // common setting with tracking, we likely want to move to the cdb with this
     hcal->set_string_param("IronFieldMapPath", G4MAGNET::magfield_OHCAL_steel);


### PR DESCRIPTION
This PR makes the old outer hcal (without parts of the support ring) the current default. Needed to avoid overlaps when the new hcal comes online tomorrow