### PR TITLE
make new inner hcal support ring the default

### DIFF
--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -42,7 +42,7 @@ namespace Enable
   bool HCALOUT_EVAL = false;
   bool HCALOUT_QA = false;
   bool HCALOUT_OLD = false;
-  bool HCALOUT_RING = true;
+  bool HCALOUT_RING = false;
   bool HCALOUT_G4Hit = true;
   int HCALOUT_VERBOSITY = 0;
 }  // namespace Enable


### PR DESCRIPTION
This PR makes the new inner hcal support ring the default, the old support ring can be selected by setting
Enable::HCALOUT_RING = true;
in the Fun4All macro