### PR TITLE
revert back to previous outer hcal gdml file

### DIFF
--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -42,7 +42,7 @@ namespace Enable
   bool HCALOUT_EVAL = false;
   bool HCALOUT_QA = false;
   bool HCALOUT_OLD = false;
-  bool HCALOUT_RING = false;
+  bool HCALOUT_RING = true;
   bool HCALOUT_G4Hit = true;
   int HCALOUT_VERBOSITY = 0;
 }  // namespace Enable


### PR DESCRIPTION
This PR effectively reverts back to the old outer hcal gdml file (and puts the complete old inner hcal support ring back). The new gdml file kills the hits in the outer hcal if the inner hcal is enabled, not sure about the mechanism, the diff shows a magnet volume made of aluminum which didn't exist in the old gdml file 