### PR TITLE
Updated to include TowerInfoV2 flag for RawTowerCalibration class

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -77,7 +77,8 @@ namespace G4CEMC
   enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
   //! graph clusterizer, RawClusterBuilderGraph
   // enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
-
+  
+  bool useTowerInfoV2 = false;
 }  // namespace G4CEMC
 
 // black hole parameters are set in CEmc function
@@ -268,6 +269,7 @@ void CEMC_Towers()
   se->registerSubsystem(TowerDigitizer);
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("EmcRawTowerCalibration");
+  TowerCalibration -> set_usetowerinfo_v2(G4CEMC::useTowerInfoV2);
   TowerCalibration->Detector("CEMC");
   TowerCalibration->Verbosity(verbosity);
   if (!Enable::CEMC_G4Hit) TowerCalibration->set_towerinfo(RawTowerCalibration::ProcessTowerType::kTowerInfoOnly);  // just use towerinfo


### PR DESCRIPTION
The second of three pull requests to add TowerInfoV2 compatibility to simulation. This adds a boolean to the G4CEMC namespace which can be set by the Fun4All_G4_Calo.C module used to steer MC production, which then in turn tells RawTowerCalibration whether or not to store a TowerInfoV2 or V1 object 