### PR TITLE
Adding TowerInfoV2 to HCals

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -83,7 +83,8 @@ namespace G4HCALIN
 
     kHCalInTemplateClusterizer
   };
-
+  
+  bool useTowerInfoV2 = false;
   //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
   enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInTemplateClusterizer;
   //! graph clusterizer, RawClusterBuilderGraph
@@ -300,6 +301,7 @@ void HCALInner_Towers()
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalInRawTowerCalibration");
   TowerCalibration->Detector("HCALIN");
+  TowerCalibration -> set_usetowerinfo_v2(G4HCALIN::useTowerInfoV2);
   //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
   //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -71,6 +71,8 @@ namespace G4HCALOUT
     kHCalOutTemplateClusterizer
   };
 
+  bool useTowerInfoV2 = false;
+
   //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
   enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutTemplateClusterizer;
   //! graph clusterizer, RawClusterBuilderGraph
@@ -331,6 +333,8 @@ void HCALOuter_Towers()
 
   RawTowerCalibration *TowerCalibration = new RawTowerCalibration("HcalOutRawTowerCalibration");
   TowerCalibration->Detector("HCALOUT");
+  TowerCalibration -> set_usetowerinfo_v2(G4HCALOUT::useTowerInfoV2);
+
   //  TowerCalibration->set_raw_tower_node_prefix("RAW_LG");
   //  TowerCalibration->set_calib_tower_node_prefix("CALIB_LG");
   TowerCalibration->set_calib_algorithm(RawTowerCalibration::kSimple_linear_calibration);


### PR DESCRIPTION
Similar to previous PR, TowerInfoV2 boolean has been added to G4HCAL namespaces for use by Fun4All_G4_Calo steering macro