### PR TITLE
Distortion correction flags

### DIFF
--- a/common/G4_Tracking_Cosmics.C
+++ b/common/G4_Tracking_Cosmics.C
@@ -70,8 +70,8 @@ void TrackingInit()
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
 
-    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 0, G4TPC::static_correction_filename );
-    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 1, G4TPC::average_correction_filename );
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_Average, G4TPC::average_correction_filename );
 
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }

--- a/common/G4_Tracking_Cosmics.C
+++ b/common/G4_Tracking_Cosmics.C
@@ -70,8 +70,8 @@ void TrackingInit()
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
 
-    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 0, G4TPC::static_correction_filename );
-    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 1, G4TPC::average_correction_filename );
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 0, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 1, G4TPC::average_correction_filename );
 
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }

--- a/common/G4_Tracking_Cosmics.C
+++ b/common/G4_Tracking_Cosmics.C
@@ -62,14 +62,17 @@ namespace G4TRACKING
 void TrackingInit()
 {
   ACTSGEOM::ActsGeomInit();
+
   // space charge correction
-  /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit */
-  if( G4TPC::ENABLE_CORRECTIONS )
+  if( G4TPC::ENABLE_STATIC_CORRECTIONS || G4TPC::ENABLE_AVERAGE_CORRECTIONS )
   {
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
-    tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
+
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 0, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 1, G4TPC::average_correction_filename );
+
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }
 }

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -109,19 +109,21 @@ namespace G4TPC
   // distortions
   bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
 
+  // static distortions
   bool ENABLE_STATIC_DISTORTIONS = false;
   std::string static_distortion_filename = "TPC_STATIC_DISTORTION";
 
+  // time-ordered distortion fluctuations
   bool ENABLE_TIME_ORDERED_DISTORTIONS = false;
   std::string time_ordered_distortion_filename = "TPC_TIMEORDERED_DISTORTION";
 
   bool ENABLE_REACHES_READOUT = true;
 
-  // distortion corrections
+  // static distortion corrections
   bool ENABLE_STATIC_CORRECTIONS = false;
   std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
 
-  // distortion corrections
+  // average distortion corrections
   bool ENABLE_AVERAGE_CORRECTIONS = false;
   std::string average_correction_filename;
 

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -118,8 +118,12 @@ namespace G4TPC
   bool ENABLE_REACHES_READOUT = true;
 
   // distortion corrections
-  bool ENABLE_CORRECTIONS = false;
-  std::string correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
+  bool ENABLE_STATIC_CORRECTIONS = false;
+  std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
+
+  // distortion corrections
+  bool ENABLE_AVERAGE_CORRECTIONS = false;
+  std::string average_correction_filename;
 
   // enable central membrane g4hits generation
   bool ENABLE_CENTRAL_MEMBRANE_HITS = false;

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -25,8 +25,8 @@ void TrackingInit()
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
 
-    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 0, G4TPC::static_correction_filename );
-    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 1, G4TPC::average_correction_filename );
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_Average, G4TPC::average_correction_filename );
 
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -25,8 +25,8 @@ void TrackingInit()
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
 
-    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 0, G4TPC::static_correction_filename );
-    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 1, G4TPC::average_correction_filename );
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 0, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( 1, G4TPC::average_correction_filename );
 
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -17,16 +17,17 @@ void TrackingInit()
   G4MAGNET::magfield_rescale = 1.;
 
   ACTSGEOM::ActsGeomInit();
-  // space charge correction
-  /* corrections are applied in the track finding, and via TpcClusterMover before the final track fit
-   */
 
-  if( G4TPC::ENABLE_CORRECTIONS )
+  // space charge correction
+  if( G4TPC::ENABLE_STATIC_CORRECTIONS || G4TPC::ENABLE_AVERAGE_CORRECTIONS )
   {
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
     tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
-    tpcLoadDistortionCorrection->set_distortion_filename( G4TPC::correction_filename );
+
+    if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 0, G4TPC::static_correction_filename );
+    if( G4TPC::ENABLE_AVERAGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_distortion_filename( 1, G4TPC::average_correction_filename );
+
     se->registerSubsystem(tpcLoadDistortionCorrection);
   }
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -344,7 +344,7 @@ int Fun4All_G4_sPHENIX(
   Enable::TRACK_MATCHING_TREE = Enable::TRACK_MATCHING && false;
   Enable::TRACK_MATCHING_TREE_CLUSTERS = Enable::TRACK_MATCHING_TREE && false;
 
-  //Additional tracking tools 
+  //Additional tracking tools
   //Enable::TRACKING_DIAGNOSTICS = Enable::TRACKING_TRACK && true;
   //G4TRACKING::filter_conversion_electrons = true;
   // G4TRACKING::use_alignment = true;
@@ -355,9 +355,10 @@ int Fun4All_G4_sPHENIX(
 
   // set flags to simulate and correct TPC distortions, specify distortion and correction files
   //G4TPC::ENABLE_STATIC_DISTORTIONS = true;
-  //G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");  
-  //G4TPC::ENABLE_CORRECTIONS = true;
-  //G4TPC::correction_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_smoothed_average.correction_map.hist.root");
+  //G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");
+  //G4TPC::ENABLE_STATIC_CORRECTIONS = true;
+  //G4TPC::static_correction_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_smoothed_average.correction_map.hist.root");
+  //G4TPC::ENABLE_AVERAGE_CORRECTIONS = false;
 
   //  cemc electronics + thin layer of W-epoxy to get albedo from cemc
   //  into the tracking, cannot run together with CEMC
@@ -551,13 +552,13 @@ int Fun4All_G4_sPHENIX(
     Tracking_Reco();
   }
 
-  
+
 
   if(Enable::TRACKING_DIAGNOSTICS)
     {
       const std::string kshortFile = "./kshort_" + outputFile;
       const std::string residualsFile = "./residuals_" + outputFile;
- 
+
       G4KshortReconstruction(kshortFile);
       seedResiduals(residualsFile);
     }


### PR DESCRIPTION
Following today's discussion at the distortion meeting workgroup: 
this updates distortion correction flags to allow loading static distortion corrections and average distortion corrections independantly. 
For now, load from files.
Note (@adfrawley , @jdosbo, @pinkenburg etc.): 
if you have modified steering macros that change the correction flags, they will break 
Explicitly one must replace 
- G4TPC::ENABLE_CORRECTIONS  by G4TPC::ENABLE_STATIC_CORRECTIONS 
- G4TPC::correction_filename  by G4TPC::static_correction_filename

One can now also set and load ENABLE_AVERAGE_CORRECTION and average_correction_filename

TODO: 
- MDC macros might need modifications (I can do that if pointed to the right place)
- allow for using CDB instead of hardcoded root file path.

