### PR TITLE
prepare for fieldmaps from cdb

### DIFF
--- a/common/G4_Magnet.C
+++ b/common/G4_Magnet.C
@@ -33,7 +33,17 @@ void MagnetFieldInit()
   if (G4MAGNET::magfield.empty())
   {
     G4MAGNET::magfield = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz_gap_rebuild.root");
+//    G4MAGNET::magfield = "FIELDMAP_GAP";
+  }
+  if (G4MAGNET::magfield_OHCAL_steel.empty())
+  {
     G4MAGNET::magfield_OHCAL_steel = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dbigmapxyz_steel_rebuild.root");
+//    G4MAGNET::magfield_OHCAL_steel = "FIELDMAP_STEEL";
+  }
+  if (G4MAGNET::magfield_tracking.empty())
+  {
+    G4MAGNET::magfield_tracking = string(getenv("CALIBRATIONROOT")) + string("/Field/Map/sphenix3dtrackingmapxyz.root");
+//    G4MAGNET::magfield_tracking = "FIELDMAP_TRACKING";
   }
 }
 

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -80,6 +80,7 @@ namespace G4MAGNET
   double magfield_rescale = NAN;
   std::string magfield;
   std::string magfield_OHCAL_steel;
+  std::string magfield_tracking;
 }  // namespace G4MAGNET
 
 namespace Enable

--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -99,7 +99,7 @@ int G4Setup()
   {  // conversion to double fails -> we have a string
 
     if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos ||
-        G4MAGNET::magfield == "CDB")
+        G4MAGNET::magfield.find(".root") == string::npos)
     {
       g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
     }
@@ -111,6 +111,7 @@ int G4Setup()
   else
   {
     g4Reco->set_field(fieldstrength);  // use const soleniodal field
+    G4MAGNET::magfield_tracking = G4MAGNET::magfield; // set tracking fieldmap to value
   }
   g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
 


### PR DESCRIPTION
This PR adds the hooks to read the tracking fieldmap via G4MAGNET::magfield_tracking from file or the cdb and adds some safety against inconsistent usage of the global fieldmap and the tracking fieldmap (e.g. not sure how the current macros behave for constant fields). Once the new fieldmaps are in the cdb - this will allow testing of the new fieldmaps even before the tracking fieldmap reading from the cdb is implemented