### PR TITLE
use G4MAGNET::magfield_tracking for magnetic field

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -64,7 +64,7 @@ namespace ACTSGEOM
       }
     
     geom->loadMagField(G4TRACKING::init_acts_magfield);
-    geom->setMagField(G4MAGNET::magfield);
+    geom->setMagField(G4MAGNET::magfield_tracking);
     geom->setMagFieldRescale(G4MAGNET::magfield_rescale);
     std::cout << "ActsGeomInit: Use survey geometry? ACTSGEOM::inttsurvey=" << ACTSGEOM::inttsurvey << std::endl;
     geom->set_intt_survey(ACTSGEOM::inttsurvey);


### PR DESCRIPTION
This PR enables testing of the new magnetic fields, the field for tracking now uses its own string G4MAGNET::magfield_tracking. WIth this change the new fieldmaps can be tested without interfering with the tracking