### PR TITLE
fix: set intt ref radii to survey values

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -26,7 +26,7 @@ namespace ACTSGEOM
   unsigned int tpcMisalignment = 1;
   unsigned int tpotMisalignment = 1;
 
-  bool inttsurvey = true;
+  bool inttsurvey = Enable::INTT_USEG4SURVEYGEOM;
 
   void ActsGeomInit()
   {

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -487,7 +487,7 @@ void TPC_Cells()
   digitpc->Verbosity(verbosity);
   cout << " Tpc digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
        << " maps+Intt layers set to " << G4MVTX::n_maps_layer + G4INTT::n_intt_layer << endl;
-  digitpc->set_skip_noise_flag(true);
+  digitpc->set_skip_noise_flag(false);
   se->registerSubsystem(digitpc);
 }
 

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -127,6 +127,14 @@ void InttInit()
   {
     G4MVTX::n_maps_layer = 0;
   }
+  if (!Enable::INTT_USEG4SURVEYGEOM)
+  {
+    G4INTT::sensor_radius[0] = 7.188 - 36e-4;
+    G4INTT::sensor_radius[1] = 7.732 - 36e-4;
+    G4INTT::sensor_radius[2] = 9.680 - 36e-4;
+    G4INTT::sensor_radius[3] = 10.262 - 36e-4;
+  
+  }
 }
 
 double Intt(PHG4Reco* g4Reco, double radius,
@@ -479,7 +487,7 @@ void TPC_Cells()
   digitpc->Verbosity(verbosity);
   cout << " Tpc digitizer: Setting ENC to " << ENC << " ADC threshold to " << ADC_threshold
        << " maps+Intt layers set to " << G4MVTX::n_maps_layer + G4INTT::n_intt_layer << endl;
-  digitpc->set_skip_noise_flag(false);
+  digitpc->set_skip_noise_flag(true);
   se->registerSubsystem(digitpc);
 }
 

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -78,7 +78,8 @@ namespace G4INTT
                        PHG4InttDefs::SEGMENTATION_PHI,
                        PHG4InttDefs::SEGMENTATION_PHI};
   int nladder[4] = {12, 12, 16, 16};
-  double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
+  //! default to survey geometry
+  double sensor_radius[4] = {7.453, 8.046, 9.934, 10.569};
 
   enum enu_InttDeadMapType  // Dead map options for INTT
   {


### PR DESCRIPTION
This PR sets the reference radii for the INTT layers to the actual survey values that were implemented into the geant4 geometry. This should make the reconstruction geometry objects consistent