### PR TITLE
Reconciled INTT calibration handles

### DIFF
--- a/InttProduction/Fun4All_Intt_Combiner.C
+++ b/InttProduction/Fun4All_Intt_Combiner.C
@@ -59,12 +59,13 @@ void Fun4All_Intt_Combiner(int nEvents = 0,
 
   //! [TO CONFIRM] The switches for the ideal and survey geometries do not seem to work anymore. Is this intended?
   Enable::INTT_USEG4SURVEYGEOM = usesurveygeom;
+  ACTSGEOM::inttsurvey = usesurveygeom;
 
   TString outname = Form("ProdDST/intt-%08d", runnumber);
-  if (G4INTT::UseBadMap)outname += "-HotDead";
-  if (G4INTT::UseBcoMap)outname += "-BCO";
-  if (G4INTT::UseDacMap)outname += "-ADC";
-  if (G4INTT::UseSurvey)outname += "-Survey";
+  if (applyHotChannel)    outname += "-HotDead";
+  if (applyBCOCut)         outname += "-BCO";
+  if (applyADCConversion) outname += "-ADC";
+  if (usesurveygeom)      outname += "-Survey";
   outname = outname + ".root";
   system(Form("mkdir -p %s", outname.Data()));
 
@@ -107,6 +108,10 @@ void Fun4All_Intt_Combiner(int nEvents = 0,
 
   if (runTkrkClus)
   {
+    Enable::MVTX = true;
+    Enable::INTT = true;
+    Enable::TPC = true;
+    Enable::MICROMEGAS = true;
     Intt_Clustering();  // Be careful!!! INTT z-clustering may be off which is not what you want!
   }
 

--- a/InttProduction/Fun4All_Intt_Combiner.C
+++ b/InttProduction/Fun4All_Intt_Combiner.C
@@ -31,32 +31,27 @@ void Fun4All_Intt_Combiner(int nEvents = 0,
                            const string &input_file07 = "intt7.list")
 {
   bool runTrkrHits = true;
-  bool applyHotChannel = true;
-  bool applyBCOCut = true;
-  bool applyADCConversion = true;
   bool runTkrkClus = true;
-  bool usesurveygeom = false;
   bool stripRawHit = true;
 
-  TString outinitial = "intt-00020869";
-  TString outend = ".root";
-  if (applyHotChannel)
+  TString outname =  "intt-00020869";
+  if (G4INTT::UseBadMap)
   {
     outinitial += "-HotDead";
   }
-  if (applyBCOCut)
+  if (G4INTT::UseBcoMap)
   {
     outinitial += "-BCO";
   }
-  if (applyADCConversion)
+  if (G4INTT::UseDacMap)
   {
     outinitial += "-ADC";
   }
-  if (usesurveygeom)
+  if (G4INTT::UseSurvey)
   {
     outinitial += "-Survey";
   }
-  TString outname = outinitial + outend;
+  outname = outinitial + ".root";
 
   vector<string> infile;
   infile.push_back(input_file00);
@@ -102,26 +97,20 @@ void Fun4All_Intt_Combiner(int nEvents = 0,
 
   if (runTrkrHits)
   {
-    InttCombinedRawDataDecoder *myDecoder = new InttCombinedRawDataDecoder("myUnpacker");
-    myDecoder->runInttStandalone(true);
-    myDecoder->writeInttEventHeader(true);
-    if (applyHotChannel) myDecoder->LoadHotChannelMapRemote("INTT_HotMap");
-    if (applyADCConversion) myDecoder->SetCalibDAC();
-    if (applyBCOCut) myDecoder->SetCalibBCO();
-    se->registerSubsystem(myDecoder);
+	bool prev_RunStandalone = G4INTT::RunStandalone;
+	bool prev_WriteEvtHeader = G4INTT::WriteEvtHeader;
+
+	G4INTT::RunStandalone = true;
+	G4INTT::WriteEvtHeader = true;
+
+	Intt_HitUnpacking();
+
+	G4INTT::RunStandalone = prev_RunStandalone;
+	G4INTT::WriteEvtHeader = prev_WriteEvtHeader;
   }
 
   if (runTkrkClus)
   {
-    if (usesurveygeom)
-    {
-      Enable::INTT = true;
-      G4Init();
-      G4Setup();
-
-      ClusteringInit();   // ActsGeomInit() is called here
-    }
-    
     Intt_Clustering();  // Be careful!!! INTT z-clustering may be off which is not what you want!
   }
 

--- a/InttProduction/Fun4All_Intt_Combiner.C
+++ b/InttProduction/Fun4All_Intt_Combiner.C
@@ -20,6 +20,8 @@ R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libffarawmodules.so)
 R__LOAD_LIBRARY(libintt.so)
 
+bool isGood(string const&);
+
 void Fun4All_Intt_Combiner(int nEvents = 0,
                            const string &input_file00 = "intt0.list",
                            const string &input_file01 = "intt1.list",
@@ -37,21 +39,21 @@ void Fun4All_Intt_Combiner(int nEvents = 0,
   TString outname =  "intt-00020869";
   if (G4INTT::UseBadMap)
   {
-    outinitial += "-HotDead";
+    outname += "-HotDead";
   }
   if (G4INTT::UseBcoMap)
   {
-    outinitial += "-BCO";
+    outname += "-BCO";
   }
   if (G4INTT::UseDacMap)
   {
-    outinitial += "-ADC";
+    outname += "-ADC";
   }
   if (G4INTT::UseSurvey)
   {
-    outinitial += "-Survey";
+    outname += "-Survey";
   }
-  outname = outinitial + ".root";
+  outname = outname + ".root";
 
   vector<string> infile;
   infile.push_back(input_file00);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -81,13 +81,8 @@ namespace G4INTT
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
   bool UseBadMap = true; // Mask hot/bad channels
-  std::string BadMapTag = "INTT_HotMap";
-
   bool UseBcoMap = true; // Keep only hits local to BCO peak
-  std::string BcoMapTag = "INTT_BCOMAP";
-
   bool UseDacMap = true; // Convert digital signals back to analog thresholds
-  std::string DacMapTag = "INTT_DACMAP";
 
   bool RunStandalone = false;
   bool WriteEvtHeader = false;

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -88,15 +88,13 @@ namespace G4INTT
   bool RunStandalone = false;
   bool WriteEvtHeader = false;
 
-  bool UseSurvey = true;
-
   // This enum needs to be replaced/removed
   enum enu_InttDeadMapType
   {
 	  kInttNoDeadMap = 0,
-	  kInttDeadmap,
+	  kInttDeadMap,
   };
-  enu_InttDeadMapType InttDeadMapOption = kInttDeadMap;
+  enu_InttDeadMapType InttDeadMapOption = enu_InttDeadMapType::kInttDeadMap;
 
 }  // namespace G4INTT
 

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -94,6 +94,14 @@ namespace G4INTT
 
   bool UseSurvey = true;
 
+  // This enum needs to be replaced/removed
+  enum enu_InttDeadMapType
+  {
+	  kInttNoDeadMap = 0,
+	  kInttDeadmap,
+  };
+  enu_InttDeadMapType InttDeadMapOption = kInttDeadMap;
+
 }  // namespace G4INTT
 
 namespace G4TPC

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -80,13 +80,19 @@ namespace G4INTT
   int nladder[4] = {12, 12, 16, 16};
   double sensor_radius[4] = {7.188 - 36e-4, 7.732 - 36e-4, 9.680 - 36e-4, 10.262 - 36e-4};
 
-  enum enu_InttDeadMapType  // Dead map options for INTT
-  {
-    kInttNoDeadMap = 0,  // All channel in Intt is alive
-    kInttDeadMap = 1,    // with dead channel
-  };
-  // enu_InttDeadMapType InttDeadMapOption = kInttNoDeadMap;  // Choose Intt deadmap here
-  enu_InttDeadMapType InttDeadMapOption = kInttDeadMap;  // Choose Intt deadmap here
+  bool UseBadMap = true; // Mask hot/bad channels
+  std::string BadMapTag = "INTT_HotMap";
+
+  bool UseBcoMap = true; // Keep only hits local to BCO peak
+  std::string BcoMapTag = "INTT_BCOMAP";
+
+  bool UseDacMap = true; // Convert digital signals back to analog thresholds
+  std::string DacMapTag = "INTT_DACMAP";
+
+  bool RunStandalone = false;
+  bool WriteEvtHeader = false;
+
+  bool UseSurvey = true;
 
 }  // namespace G4INTT
 

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -85,7 +85,7 @@ void Intt_Clustering()
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  if(G4INTT::UseSurvey) {
+  if(Enable::INTT_USEG4SURVEYGEOM) {
 	  Enable::INTT = true;
 	  G4Init();
 	  G4Setup();

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -74,15 +74,10 @@ void Intt_HitUnpacking()
   inttunpacker->runInttStandalone(G4INTT::RunStandalone);
   inttunpacker->writeInttEventHeader(G4INTT::WriteEvtHeader);
 
-  if(G4INTT::UseBadMap) {
-	  inttunpacker->LoadHotChannelMapRemote(G4INTT::BadMapTag);
-  }
-  if(G4INTT::UseBcoMap) {
-	  inttunpacker->SetCalibBCO(G4INTT::BcoMapTag);
-  }
-  if(G4INTT::UseDacMap) {
-	  inttunpacker->SetCalibDAC(G4INTT::DacMapTag);
-  }
+  if(G4INTT::UseBadMap)inttunpacker->LoadBadMap();
+  if(G4INTT::UseBcoMap)inttunpacker->LoadBcoMap();
+  if(G4INTT::UseDacMap)inttunpacker->LoadDacMap();
+
   se->registerSubsystem(inttunpacker);
 }
 void Intt_Clustering()

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -69,13 +69,32 @@ void Intt_HitUnpacking()
 
   auto inttunpacker = new InttCombinedRawDataDecoder;
   inttunpacker->Verbosity(verbosity);
-  inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
+
+  inttunpacker->runInttStandalone(G4INTT::RunStandalone);
+  inttunpacker->writeInttEventHeader(G4INTT::WriteEvtHeader);
+
+  if(G4INTT::UseBadMap) {
+	  inttunpacker->LoadHotChannelMapRemote(G4INTT::BadMapTag);
+  }
+  if(G4INTT::UseBcoMap) {
+	  inttunpacker->SetCalibBCO(G4INTT::BcoMapTag);
+  }
+  if(G4INTT::UseDacMap) {
+	  inttunpacker->SetCalibDAC(G4INTT::DacMapTag);
+  }
   se->registerSubsystem(inttunpacker);
 }
 void Intt_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
+
+  if(G4INTT::UseSurvey) {
+	  Enable::INTT = true;
+	  G4Init();
+	  G4Setup();
+	  ClusteringInit(); // ActsGeomInit() is called here
+  }
 
   InttClusterizer* inttclusterizer = new InttClusterizer("InttClusterizer", G4MVTX::n_maps_layer, G4MVTX::n_maps_layer + G4INTT::n_intt_layer - 1);
   inttclusterizer->Verbosity(verbosity);

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -5,6 +5,7 @@
 
 #include <G4_ActsGeom.C>
 #include <G4_TrkrVariables.C>
+#include <G4Setup_sPHENIX.C>
 
 #include <intt/InttCombinedRawDataDecoder.h>
 #include <micromegas/MicromegasCombinedDataDecoder.h>


### PR DESCRIPTION
Collected configuration flags being used in the InttProduction macro and moved them to G4_TrkrVariables and Trkr_Clustering; updated the methods in Trkr_Clustering to reflect this, and use the updated method in the unpacking.

If  the removal of the enu_InttDeadMapType "breaks" anything, whatever depended on it should not be used--to my knowledge that was never correct or meaningful.