### PR TITLE
initialize magnetic field in ActsGeomInit in case we do not run the sims

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -41,6 +41,8 @@ namespace ACTSGEOM
       G4MICROMEGAS::n_micromegas_layer = 0;
     }
 
+    MagnetFieldInit();
+
     // Build the Acts geometry
     auto se = Fun4AllServer::instance();
     int verbosity = Enable::VERBOSITY;


### PR DESCRIPTION
The magnetic field needed initializing in G4_ActsGeom.C if run outside of the sims (where the magnet will initialize the field)