### PR TITLE
Genfit

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -166,6 +166,9 @@ namespace G4TRACKING
   bool use_full_truth_track_seeding = false;  // makes track seeds using truth info, used for both Acts and Genfit
   bool use_truth_vertexing = false;           // if true runs truth vertexing, if false runs PHSimpleVertexFinder
 
+  // genfit track fitter
+  bool use_genfit_track_fitter = false;
+
   // Runs a converter from TrackSeed object to SvtxTrack object to enable
   // use of the various evaluation tools already available
   bool convert_seeds_to_svtxtracks = false;

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -11,6 +11,7 @@
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsVertexPropagator.h>
 #include <trackreco/PHCASeeding.h>
+#include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHMicromegasTpcTrackMatching.h>
 #include <trackreco/PHSiliconSeedMerger.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
@@ -26,6 +27,7 @@
 #include <tpc/TpcLoadDistortionCorrection.h>
 
 #include <tpccalib/PHTpcResiduals.h>
+#include <tpccalib/TpcSpaceChargeReconstruction.h>
 
 #include <trackermillepedealignment/HelicalFitter.h>
 #include <trackermillepedealignment/MakeMilleFiles.h>
@@ -44,10 +46,10 @@ R__LOAD_LIBRARY(libtrackeralign.so)
 
 void convert_seeds()
 {
-  Fun4AllServer* se = Fun4AllServer::instance();
+  auto se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
-  TrackSeedTrackMapConverter* converter = new TrackSeedTrackMapConverter();
+  auto converter = new TrackSeedTrackMapConverter;
   // Default set to full SvtxTrackSeeds. Can be set to
   // SiliconTrackSeedContainer or TpcTrackSeedContainer
   converter->setTrackSeedName("SvtxTrackSeedContainer");
@@ -230,33 +232,58 @@ void Tracking_Reco_TrackFit()
   deltazcorr->Verbosity(verbosity);
   se->registerSubsystem(deltazcorr);
 
-  // perform final track fit with ACTS
-  auto actsFit = new PHActsTrkFitter;
-  actsFit->Verbosity(verbosity);
-  actsFit->commissioning(G4TRACKING::use_alignment);
-  // in calibration mode, fit only Silicons and Micromegas hits
-  actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-  actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-  actsFit->set_pp_mode(TRACKING::pp_mode);
-  actsFit->set_use_clustermover(true); // default is true for now
-  actsFit->useActsEvaluator(false);
-  actsFit->useOutlierFinder(false);
-  actsFit->setFieldMap(G4MAGNET::magfield_tracking);
-  se->registerSubsystem(actsFit);
-
-  if (G4TRACKING::SC_CALIBMODE)
+  if( G4TRACKING::use_genfit_track_fitter )
   {
-    /*
-     * in calibration mode, calculate residuals between TPC and fitted tracks,
-     * store in dedicated structure for distortion correction
-     */
-    auto residuals = new PHTpcResiduals;
-    residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
-    residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    residuals->Verbosity(verbosity);
-    se->registerSubsystem(residuals);
+    // perform final track fit with GENFIT
+    auto genfitFit = new PHGenFitTrkFitter;
+    genfitFit->Verbosity(verbosity);
+    genfitFit->set_fit_silicon_mms(G4TRACKING::SC_CALIBMODE);
+    se->registerSubsystem(genfitFit);
+
+    if( G4TRACKING::SC_CALIBMODE )
+    {
+      // Genfit based Tpc space charge Reconstruction
+      auto tpcSpaceChargeReconstruction = new TpcSpaceChargeReconstruction;
+      tpcSpaceChargeReconstruction->set_use_micromegas(G4TRACKING::SC_USE_MICROMEGAS);
+      tpcSpaceChargeReconstruction->set_outputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
+      // reconstructed distortion grid size (phi, r, z)
+      tpcSpaceChargeReconstruction->set_grid_dimensions(36, 48, 80);
+      se->registerSubsystem(tpcSpaceChargeReconstruction);
+    }
+
+  } else {
+
+    // perform final track fit with ACTS
+    auto actsFit = new PHActsTrkFitter;
+    actsFit->Verbosity(verbosity);
+    actsFit->commissioning(G4TRACKING::use_alignment);
+    // in calibration mode, fit only Silicons and Micromegas hits
+    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_use_clustermover(true); // default is true for now
+    actsFit->useActsEvaluator(false);
+    actsFit->useOutlierFinder(false);
+    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
+    se->registerSubsystem(actsFit);
+
+    if (G4TRACKING::SC_CALIBMODE)
+    {
+      /*
+      * in calibration mode, calculate residuals between TPC and fitted tracks,
+      * store in dedicated structure for distortion correction
+      */
+      auto residuals = new PHTpcResiduals;
+      residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
+      residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+      // reconstructed distortion grid size (phi, r, z)
+      residuals->setGridDimensions(36, 48, 80);
+      residuals->Verbosity(verbosity);
+      se->registerSubsystem(residuals);
+    }
   }
-  else
+
+  if (!G4TRACKING::SC_CALIBMODE)
   {
     /*
      * in full tracking mode, run track cleaner, vertex finder,
@@ -276,21 +303,24 @@ void Tracking_Reco_TrackFit()
 
     vertexing();
 
-    // Propagate track positions to the vertex position
-    auto vtxProp = new PHActsVertexPropagator;
-    vtxProp->Verbosity(verbosity);
-    vtxProp->fieldMap(G4MAGNET::magfield_tracking);
-    se->registerSubsystem(vtxProp);
-
-    // project tracks to EMCAL
-    auto projection = new PHActsTrackProjection;
-    projection->Verbosity(verbosity);
-    double fieldstrength = std::numeric_limits<double>::quiet_NaN();
-    if (isConstantField(G4MAGNET::magfield_tracking,fieldstrength))
+    if( !G4TRACKING::use_genfit_track_fitter )
     {
-      projection->setConstFieldVal(fieldstrength);
+      // Propagate track positions to the vertex position
+      auto vtxProp = new PHActsVertexPropagator;
+      vtxProp->Verbosity(verbosity);
+      vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+      se->registerSubsystem(vtxProp);
+
+      // project tracks to EMCAL
+      auto projection = new PHActsTrackProjection;
+      projection->Verbosity(verbosity);
+      double fieldstrength = std::numeric_limits<double>::quiet_NaN();
+      if (isConstantField(G4MAGNET::magfield_tracking,fieldstrength))
+      {
+        projection->setConstFieldVal(fieldstrength);
+      }
+      se->registerSubsystem(projection);
     }
-    se->registerSubsystem(projection);
   }
 }
 

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -15,6 +15,7 @@
 #include <trackreco/PHActsTrkFitter.h>
 #include <trackreco/PHActsVertexPropagator.h>
 #include <trackreco/PHCASeeding.h>
+#include <trackreco/PHGenFitTrkFitter.h>
 #include <trackreco/PHMicromegasTpcTrackMatching.h>
 #include <trackreco/PHSiliconSeedMerger.h>
 #include <trackreco/PHSiliconTpcTrackMatching.h>
@@ -31,6 +32,7 @@
 #include <tpc/TpcLoadDistortionCorrection.h>
 
 #include <tpccalib/PHTpcResiduals.h>
+#include <tpccalib/TpcSpaceChargeReconstruction.h>
 
 #include <trackermillepedealignment/MakeMilleFiles.h>
 #include <trackermillepedealignment/HelicalFitter.h>
@@ -107,7 +109,7 @@ void Tracking_Reco_TrackSeed()
       double fieldstrength = std::numeric_limits<double>::quiet_NaN(); // set by isConstantField if constant
       bool ConstField = isConstantField(G4MAGNET::magfield_tracking,fieldstrength);
 
-      if (!ConstField))
+      if (!ConstField)
       {
         seeder->set_field_dir(-1 * G4MAGNET::magfield_rescale);
         seeder->useConstBField(false);
@@ -248,38 +250,60 @@ void Tracking_Reco_TrackFit()
   deltazcorr->Verbosity(verbosity);
   se->registerSubsystem(deltazcorr);
 
-
-  // perform final track fit with ACTS
-  auto actsFit = new PHActsTrkFitter;
-  actsFit->Verbosity(verbosity);
-  //actsFit->commissioning(G4TRACKING::use_alignment);
-
-  actsFit->set_use_clustermover(true);
-
-
-  // in calibration mode, fit only Silicons and Micromegas hits
-  actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-  actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-  actsFit->set_pp_mode(TRACKING::pp_mode);
-  actsFit->useActsEvaluator(false);
-  actsFit->useOutlierFinder(false);
-  actsFit->setFieldMap(G4MAGNET::magfield_tracking);
-  se->registerSubsystem(actsFit);
-
-  if (G4TRACKING::SC_CALIBMODE)
+  if( G4TRACKING::use_genfit_track_fitter )
   {
-    /*
-    * in calibration mode, calculate residuals between TPC and fitted tracks,
-    * store in dedicated structure for distortion correction
-    */
-    auto residuals = new PHTpcResiduals;
-    residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
+    // perform final track fit with GENFIT
+    auto genfitFit = new PHGenFitTrkFitter;
+    genfitFit->Verbosity(verbosity);
+    genfitFit->set_fit_silicon_mms(G4TRACKING::SC_CALIBMODE);
+    se->registerSubsystem(genfitFit);
 
-    residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    residuals->Verbosity(verbosity);
-    se->registerSubsystem(residuals);
+    if( G4TRACKING::SC_CALIBMODE )
+    {
+      // Genfit based Tpc space charge Reconstruction
+      auto tpcSpaceChargeReconstruction = new TpcSpaceChargeReconstruction;
+      tpcSpaceChargeReconstruction->set_use_micromegas(G4TRACKING::SC_USE_MICROMEGAS);
+      tpcSpaceChargeReconstruction->set_outputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
+      // reconstructed distortion grid size (phi, r, z)
+      tpcSpaceChargeReconstruction->set_grid_dimensions(36, 48, 80);
+      se->registerSubsystem(tpcSpaceChargeReconstruction);
+    }
+
   } else {
 
+    // perform final track fit with ACTS
+    auto actsFit = new PHActsTrkFitter;
+    actsFit->Verbosity(verbosity);
+    //actsFit->commissioning(G4TRACKING::use_alignment);
+
+    // in calibration mode, fit only Silicons and Micromegas hits
+    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_use_clustermover(true);
+    actsFit->useActsEvaluator(false);
+    actsFit->useOutlierFinder(false);
+    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
+    se->registerSubsystem(actsFit);
+
+    if (G4TRACKING::SC_CALIBMODE)
+    {
+      /*
+      * in calibration mode, calculate residuals between TPC and fitted tracks,
+      * store in dedicated structure for distortion correction
+      */
+      auto residuals = new PHTpcResiduals;
+      residuals->setOutputfile(G4TRACKING::SC_ROOTOUTPUT_FILENAME);
+      residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+      // reconstructed distortion grid size (phi, r, z)
+      residuals->setGridDimensions(36, 48, 80);
+      residuals->Verbosity(verbosity);
+      se->registerSubsystem(residuals);
+    }
+  }
+
+  if (!G4TRACKING::SC_CALIBMODE)
+  {
     /*
      * in full tracking mode, run track cleaner, vertex finder,
      * propagete tracks to vertex
@@ -297,23 +321,25 @@ void Tracking_Reco_TrackFit()
 
     vertexing();
 
-    // Propagate track positions to the vertex position
-    auto vtxProp = new PHActsVertexPropagator;
-    vtxProp->Verbosity(verbosity);
-    vtxProp->fieldMap(G4MAGNET::magfield_tracking);
-    se->registerSubsystem(vtxProp);
-
-    // project tracks to EMCAL
-    auto projection = new PHActsTrackProjection;
-    projection->Verbosity(verbosity);
-    double fieldstrength = std::numeric_limits<double>::quiet_NaN();
-    if (isConstantField(G4MAGNET::magfield_tracking,fieldstrength))
+    if( !G4TRACKING::use_genfit_track_fitter )
     {
-      projection->setConstFieldVal(fieldstrength);
-    }
-    se->registerSubsystem(projection);
-  }
+      // Propagate track positions to the vertex position
+      auto vtxProp = new PHActsVertexPropagator;
+      vtxProp->Verbosity(verbosity);
+      vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+      se->registerSubsystem(vtxProp);
 
+      // project tracks to EMCAL
+      auto projection = new PHActsTrackProjection;
+      projection->Verbosity(verbosity);
+      double fieldstrength = std::numeric_limits<double>::quiet_NaN();
+      if (isConstantField(G4MAGNET::magfield_tracking,fieldstrength))
+      {
+        projection->setConstFieldVal(fieldstrength);
+      }
+      se->registerSubsystem(projection);
+    }
+  }
 }
 
 void Tracking_Reco_CommissioningTrackSeed()


### PR DESCRIPTION
I know I am the only one to still use GENFIT (for debugging the track-based distortion correction machinery), however keeping the flag out-of-tree in sync with the many recent changes to the Trkr_Reco (and TruthReco) macros has turned out to be more difficult and error-prone lately. 
So: putting this back in the git tree, so that it is properly accounted for (even if untested) in future changes. 
Comments welcome.

The default workflow is unchanged. 
Also I have tried to keep the additional clutter to the minumum.