### PR TITLE
fix: qa include paths

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -22,7 +22,7 @@
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawClusterPositionCorrection.h>
 #include <caloreco/RawTowerCalibration.h>
-#include <qa_modules/QAG4SimulationCalorimeter.h>
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -22,7 +22,7 @@
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
-#include <qa_modules/QAG4SimulationCalorimeter.h>
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -20,7 +20,7 @@
 #include <caloreco/RawClusterBuilderTemplate.h>
 #include <caloreco/RawTowerCalibration.h>
 
-#include <qa_modules/QAG4SimulationCalorimeter.h>
+#include <simqa_modules/QAG4SimulationCalorimeter.h>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/G4_Jets.C
+++ b/common/G4_Jets.C
@@ -12,7 +12,7 @@
 #include <g4jets/TruthJetInput.h>
 
 #include <g4eval/JetEvaluator.h>
-#include <qa_modules/QAG4SimulationJet.h>
+#include <simqa_modules/QAG4SimulationJet.h>
 
 #include <fun4all/Fun4AllServer.h>
 


### PR DESCRIPTION
Somehow the CI did not (and has not?) caught that these include paths are wrong. This apparently only comes up when running some individual macros... this fixes the include paths