### PR TITLE
Load the hot channel map for simulation

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -230,7 +230,7 @@ void Intt_Cells()
   }
   // new storage containers
   PHG4InttHitReco* reco = new PHG4InttHitReco();
-  reco->LoadHotChannelMapRemote("INTT_HotMap");
+  reco->setHotStripMaskFile("INTT_HotMap");
 
   // The timing window defaults are set in the INTT ladder model, they can be overridden here
   double extended_readout_time = 0.0;

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -230,6 +230,7 @@ void Intt_Cells()
   }
   // new storage containers
   PHG4InttHitReco* reco = new PHG4InttHitReco();
+  reco->LoadHotChannelMapRemote("INTT_HotMap");
 
   // The timing window defaults are set in the INTT ladder model, they can be overridden here
   double extended_readout_time = 0.0;


### PR DESCRIPTION
An one-line modification to G4_TrkrSimulation.C to load the hot channel map for simulation