### PR TITLE
Macro to run InttHitMap InttBCOFinder modules added

### DIFF
--- a/calibrations/intt/Fun4All_Intt_BCOFinder.C
+++ b/calibrations/intt/Fun4All_Intt_BCOFinder.C
@@ -1,0 +1,72 @@
+#ifndef FUN4ALL_INTT_BCOFINDER_C
+#define FUN4ALL_INTT_BCOFINDER_C
+
+#include <intt/InttMapping.h>
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+
+#include <phool/recoConsts.h>
+
+#include <iostream>
+#include <string>
+
+#include <G4Setup_sPHENIX.C>
+#include <inttbcofinder/InttBCOFinder.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libfun4allraw.so)
+R__LOAD_LIBRARY(libffarawmodules.so)
+R__LOAD_LIBRARY(libinttbcofinder.so)
+
+
+void Fun4All_Intt_BCOFinder(int run_num = 41297, int nevents = 500000,
+                            std::string in_file = "/sphenix/lustre01/sphnxpro/commissioning/slurp/inttbeam/run_00041200_00041300/DST_INTT_RAW_beam_new_2023p011-00041297-0000.root")
+// nevents : # of event used to make BCO distribution
+// in_file : input DST file
+{      
+          //--output file path
+        std::string string_num = std::to_string(run_num);
+        string_num = std::string(8 - string_num.length(), '0') + string_num;
+        std::string cdb_output_path = "./";
+        std::string QA_output_path = "./";
+        std::string QA_out_file = QA_output_path + "QA_bco_" + string_num + ".root";
+        std::string cdb_out_file = cdb_output_path + "cdb_bco_" + string_num + ".root";
+
+
+        Fun4AllServer *se = Fun4AllServer::instance();
+        // se->Verbosity(5);
+                // just if we set some flags somewhere in this macro
+        recoConsts *rc = recoConsts::instance();
+
+        Enable::CDB = true;
+        // global tag
+        rc->set_StringFlag("CDB_GLOBALTAG", CDB::global_tag);
+        //
+        // 64 bit timestamp
+        rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+
+        //--input
+        Fun4AllInputManager *in = new Fun4AllDstInputManager("DSTin");
+        in->Verbosity(2);
+        in->fileopen(in_file);
+        se->registerInputManager(in);
+
+
+        InttBCOFinder *inttbcofinder = new InttBCOFinder("inttbcofinder",
+                                                         QA_out_file.c_str(),
+                                                         cdb_out_file.c_str(),
+                                                         nevents);
+        inttbcofinder-> WriteCDBTTree(true);
+        inttbcofinder-> WriteQAFile(true); 
+        se->registerSubsystem(inttbcofinder);
+
+        se->run(nevents);
+        se->End();
+
+        delete se;
+}
+
+#endif // FUN4ALL_INTT_BCOFINDER.C

--- a/calibrations/intt/Fun4All_Intt_HitMap.C
+++ b/calibrations/intt/Fun4All_Intt_HitMap.C
@@ -1,0 +1,75 @@
+#ifndef FUN4ALL_INTT_HITMAP_C
+#define FUN4ALL_INTT_HITMAP_C
+
+#include <intt/InttMapping.h>
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+
+#include <phool/recoConsts.h>
+
+#include <iostream>
+#include <string>
+
+#include <G4Setup_sPHENIX.C>
+#include <intthitmap/InttHitMap.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libfun4allraw.so)
+R__LOAD_LIBRARY(libffarawmodules.so)
+R__LOAD_LIBRARY(libintthitmap.so)
+void Fun4All_Intt_HitMap(int run_num = 41297,
+			 int nevents = 500000,
+			 std::string in_file = "/sphenix/lustre01/sphnxpro/commissioning/slurp/inttbeam/run_00041200_00041300/DST_INTT_RAW_beam_new_2023p011-00041297-0000.root")
+{
+        // --output file path
+        std::string string_num = std::to_string(run_num);
+		string_num = std::string(8 - string_num.length(), '0') + string_num;       
+		std::string hitmap_out_file = "./hitmap_run" +string_num + ".root";
+        
+        Fun4AllServer *se = Fun4AllServer::instance();
+        // se->Verbosity(5);
+
+        // just if we set some flags somewhere in this macro
+        recoConsts *rc = recoConsts::instance();
+
+        Enable::CDB = true;
+        // global tag
+        rc->set_StringFlag("CDB_GLOBALTAG", CDB::global_tag);
+        // 64 bit timestamp
+        rc->set_uint64Flag("TIMESTAMP", CDB::timestamp);
+
+		
+        
+        //--input
+        Fun4AllInputManager *in = new Fun4AllDstInputManager("DSTin");
+        in->Verbosity(2);
+        in->fileopen(in_file);
+        se->registerInputManager(in);
+
+        InttHitMap *intthitmap = new InttHitMap("intthitmap",
+                                                              hitmap_out_file.c_str(),
+                                                              nevents);
+        intthitmap->SetRunNumber(run_num);
+        intthitmap->IsBeam(true);
+
+
+		//BCO cut can be applied before making the hitmap. We won't use it for pp run. keep it just in case.		
+		//std::string bco_input_file = "/sphenix/tg/tg01/commissioning/INTT/QA/bco_bcofull_difference/rootfile/2023/ladder_20869_3BCOcut.root";
+        //intthitmap->SetBCOcut(false);
+		//intthitmap->SetBCOFile(bco_input_file.c_str());
+
+        //The case for if InttFeeMap will be updated.
+		//intthitmap->SetFeeMapFile("InttFeeMap.root");
+		se->registerSubsystem(intthitmap);
+
+        se->run(nevents);
+        se->End();
+
+        delete se;
+}
+
+#endif // FUN4ALL_INTT_HITMAP.C

--- a/calibrations/intt/G4Setup_sPHENIX.C
+++ b/calibrations/intt/G4Setup_sPHENIX.C
@@ -1,0 +1,229 @@
+#ifndef MACRO_G4SETUPSPHENIX_C
+#define MACRO_G4SETUPSPHENIX_C
+
+#include <GlobalVariables.C>
+
+#include <G4_Mbd.C>
+#include <G4_BlackHole.C>
+#include <G4_CEmc_Albedo.C>
+#include <G4_CEmc_Spacal.C>
+#include <G4_EPD.C>
+#include <G4_HcalIn_ref.C>
+#include <G4_HcalOut_ref.C>
+#include <G4_BeamLine.C>
+#include <G4_Magnet.C>
+/*#include <G4_Mvtx.C>
+#include <G4_Intt.C>
+#include <G4_TPC.C>
+#include <G4_Micromegas.C>
+*/
+#include <G4_TrkrSimulation.C>
+#include <G4_PSTOF.C>
+#include <G4_Pipe.C>
+#include <G4_PlugDoor.C>
+#include <G4_User.C>
+#include <G4_World.C>
+#include <G4_ZDC.C>
+
+#include <g4detectors/PHG4CylinderSubsystem.h>
+
+#include <g4eval/PHG4DstCompressReco.h>
+
+#include <g4main/PHG4Reco.h>
+#include <g4main/PHG4TruthSubsystem.h>
+
+#include <phfield/PHFieldConfig.h>
+
+#include <g4decayer/EDecayType.hh>
+
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+R__LOAD_LIBRARY(libg4decayer.so)
+R__LOAD_LIBRARY(libg4detectors.so)
+
+void G4Init()
+{
+  // Check on invalid combinations
+  if (Enable::CEMC && Enable::CEMCALBEDO)
+  {
+      cout << "Enable::CEMCALBEDO and Enable::CEMC cannot be set simultanously" << endl;
+      gSystem->Exit(1);
+  }
+  // load detector/material macros and execute Init() function
+
+  if (Enable::PIPE) PipeInit();
+  if (Enable::MVTX) MvtxInit();
+  if (Enable::INTT) InttInit();
+  if (Enable::TPC) TPCInit();
+  if (Enable::MICROMEGAS) MicromegasInit();
+  if (Enable::MBD) MbdInit();
+  if (Enable::CEMCALBEDO) CEmcAlbedoInit();
+  if (Enable::CEMC) CEmcInit();
+  if (Enable::HCALIN) HCalInnerInit();
+  if (Enable::MAGNET) MagnetInit();
+  MagnetFieldInit(); // We want the field - even if the magnet volume is disabled
+  if (Enable::HCALOUT) HCalOuterInit();
+  if (Enable::PLUGDOOR) PlugDoorInit();
+  if (Enable::EPD) EPDInit();
+  if (Enable::BEAMLINE)
+  {
+    BeamLineInit();
+    if (Enable::ZDC)
+    {
+      ZDCInit();
+    }
+  }
+  if (Enable::USER) UserInit();
+  if (Enable::BLACKHOLE) BlackHoleInit();
+}
+
+int G4Setup()
+{
+  //---------------
+  // Fun4All server
+  //---------------
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4Reco *g4Reco = new PHG4Reco();
+  g4Reco->set_rapidity_coverage(1.1);  // according to drawings
+  WorldInit(g4Reco);
+  //PYTHIA 6
+  if (G4P6DECAYER::decayType != EDecayType::kAll)
+  {
+    g4Reco->set_force_decay(G4P6DECAYER::decayType);
+  }
+  //EvtGen 
+  g4Reco->CustomizeEvtGenDecay(EVTGENDECAYER::DecayFile); 
+
+  double fieldstrength;
+  istringstream stringline(G4MAGNET::magfield);
+  stringline >> fieldstrength;
+  if (stringline.fail())
+  {  // conversion to double fails -> we have a string
+
+    if (G4MAGNET::magfield.find("sphenix3dbigmapxyz") != string::npos ||
+        G4MAGNET::magfield == "CDB")
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::Field3DCartesian);
+    }
+    else
+    {
+      g4Reco->set_field_map(G4MAGNET::magfield, PHFieldConfig::kField2D);
+    }
+  }
+  else
+  {
+    g4Reco->set_field(fieldstrength);  // use const soleniodal field
+  }
+  g4Reco->set_field_rescale(G4MAGNET::magfield_rescale);
+
+// the radius is an older protection against overlaps, it is not
+// clear how well this works nowadays but it doesn't hurt either
+  double radius = 0.;
+
+  if (Enable::PIPE) radius = Pipe(g4Reco, radius);
+  if (Enable::MVTX) radius = Mvtx(g4Reco, radius);
+  if (Enable::INTT) radius = Intt(g4Reco, radius);
+  if (Enable::TPC) radius = TPC(g4Reco, radius);
+  if (Enable::MICROMEGAS) Micromegas(g4Reco);
+  if (Enable::MBD) Mbd(g4Reco);
+  if (Enable::CEMCALBEDO) CEmcAlbedo(g4Reco);
+  if (Enable::CEMC) radius = CEmc(g4Reco, radius, 8);
+  if (Enable::HCALIN) radius = HCalInner(g4Reco, radius, 4);
+  if (Enable::MAGNET) radius = Magnet(g4Reco, radius);
+  if (Enable::HCALOUT) radius = HCalOuter(g4Reco, radius, 4);
+  if (Enable::PLUGDOOR) PlugDoor(g4Reco);
+  if (Enable::EPD) EPD(g4Reco);
+  if (Enable::BEAMLINE)
+  {
+    BeamLineDefineMagnets(g4Reco);
+    BeamLineDefineBeamPipe(g4Reco);
+    if (Enable::ZDC)
+    {
+      ZDCSetup(g4Reco);
+    }
+  }
+  if (Enable::USER) UserDetector(g4Reco);
+
+
+  //----------------------------------------
+  // BLACKHOLE
+
+  if (Enable::BLACKHOLE) BlackHole(g4Reco, radius);
+
+  PHG4TruthSubsystem *truth = new PHG4TruthSubsystem();
+  g4Reco->registerSubsystem(truth);
+
+  // finally adjust the world size in case the default is too small
+  WorldSize(g4Reco, radius);
+
+  se->registerSubsystem(g4Reco);
+  return 0;
+}
+
+void ShowerCompress(int verbosity = 0)
+{
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  PHG4DstCompressReco *compress = new PHG4DstCompressReco("PHG4DstCompressReco");
+  compress->AddHitContainer("G4HIT_PIPE");
+  compress->AddHitContainer("G4HIT_SVTXSUPPORT");
+  compress->AddHitContainer("G4HIT_CEMC_ELECTRONICS");
+  compress->AddHitContainer("G4HIT_CEMC");
+  compress->AddHitContainer("G4HIT_ABSORBER_CEMC");
+  compress->AddHitContainer("G4HIT_CEMC_SPT");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN");
+  compress->AddHitContainer("G4HIT_HCALIN_SPT");
+  compress->AddHitContainer("G4HIT_MAGNET");
+  compress->AddHitContainer("G4HIT_ABSORBER_HCALOUT");
+  compress->AddHitContainer("G4HIT_HCALOUT");
+  compress->AddHitContainer("G4HIT_BH_1");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_PLUS");
+  compress->AddHitContainer("G4HIT_BH_FORWARD_NEG");
+  compress->AddHitContainer("G4HIT_MBD");
+  compress->AddCellContainer("G4CELL_CEMC");
+  compress->AddCellContainer("G4CELL_HCALIN");
+  compress->AddCellContainer("G4CELL_HCALOUT");
+  compress->AddTowerContainer("TOWER_SIM_CEMC");
+  compress->AddTowerContainer("TOWER_RAW_CEMC");
+  compress->AddTowerContainer("TOWER_CALIB_CEMC");
+  compress->AddTowerContainer("TOWER_SIM_HCALIN");
+  compress->AddTowerContainer("TOWER_RAW_HCALIN");
+  compress->AddTowerContainer("TOWER_CALIB_HCALIN");
+  compress->AddTowerContainer("TOWER_SIM_HCALOUT");
+  compress->AddTowerContainer("TOWER_RAW_HCALOUT");
+  compress->AddTowerContainer("TOWER_CALIB_HCALOUT");
+  se->registerSubsystem(compress);
+
+  return;
+}
+
+void DstCompress(Fun4AllDstOutputManager *out)
+{
+  if (out)
+  {
+    out->StripNode("G4HIT_PIPE");
+    out->StripNode("G4HIT_SVTXSUPPORT");
+    out->StripNode("G4HIT_CEMC_ELECTRONICS");
+    out->StripNode("G4HIT_CEMC");
+    out->StripNode("G4HIT_ABSORBER_CEMC");
+    out->StripNode("G4HIT_CEMC_SPT");
+    out->StripNode("G4HIT_ABSORBER_HCALIN");
+    out->StripNode("G4HIT_HCALIN");
+    out->StripNode("G4HIT_HCALIN_SPT");
+    out->StripNode("G4HIT_MAGNET");
+    out->StripNode("G4HIT_ABSORBER_HCALOUT");
+    out->StripNode("G4HIT_HCALOUT");
+    out->StripNode("G4HIT_BH_1");
+    out->StripNode("G4HIT_BH_FORWARD_PLUS");
+    out->StripNode("G4HIT_BH_FORWARD_NEG");
+    out->StripNode("G4HIT_MBD");
+    out->StripNode("G4CELL_CEMC");
+    out->StripNode("G4CELL_HCALIN");
+    out->StripNode("G4CELL_HCALOUT");
+  }
+}
+#endif


### PR DESCRIPTION
InttBCOFinder
https://github.com/sPHENIX-Collaboration/coresoftware/tree/master/calibrations/intt/InttBCOFinder

InttHitMap
https://github.com/sPHENIX-Collaboration/coresoftware/tree/master/calibrations/intt/InttHitMap

InttBCOFinder won't be used for streaming readout mode.
InttHitMap creates the hitmap distribution and hitmap is used to classify hot/dead/cold channel and so on.

ROOT macro to pick up the bad channel will be added.
