### PR TITLE
feat: zero field tracking function

### DIFF
--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -1,0 +1,187 @@
+/*
+ * This macro shows a minimum working example of running the tracking
+ * hit unpackers with some basic seeding algorithms to try to put together
+ * tracks. There are some analysis modules run at the end which package
+ * hits, clusters, and clusters on tracks into trees for analysis.
+ */
+
+#include <fun4all/Fun4AllUtils.h>
+#include <G4_ActsGeom.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <G4_Mbd.C>
+#include <GlobalVariables.C>
+#include <QA.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_Reco.C>
+
+#include <ffamodules/CDBInterface.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <eventdisplay/TrackerEventDisplay.h>
+#include <phool/recoConsts.h>
+#include <trackingqa/InttClusterQA.h>
+
+#include <trackingqa/MicromegasClusterQA.h>
+
+#include <trackingqa/MvtxClusterQA.h>
+
+#include <trackingdiagnostics/TrackResiduals.h>
+#include <trackingdiagnostics/TrkrNtuplizer.h>
+#include <trackingqa/TpcClusterQA.h>
+#include <trackreco/AzimuthalSeeder.h>
+
+#include <stdio.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libmvtx.so)
+R__LOAD_LIBRARY(libintt.so)
+R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libmicromegas.so)
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
+R__LOAD_LIBRARY(libtrackingqa.so)
+R__LOAD_LIBRARY(libEventDisplay.so)
+void Fun4All_ZFAllTrackers(
+    const int nEvents = 0,
+    const std::string tpcfilename = "DST_BEAM_run2pp_new_2023p013-00041626-0000.root",
+    const std::string tpcdir = "/sphenix/lustre01/sphnxpro/commissioning/slurp/tpcbeam/run_00041600_00041700/",
+    const std::string outfilename = "clusters_seeds",
+    const bool convertSeeds = true)
+{
+  std::string inputtpcRawHitFile = tpcdir + tpcfilename;
+
+  G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
+  std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
+  std::pair<int, int>
+      runseg = Fun4AllUtils::GetRunSegment(tpcfilename);
+  int runnumber = runseg.first;
+  int segment = runseg.second;
+
+  TString outfile = outfilename + "_" + runnumber + "-" + segment + ".root";
+  std::string theOutfile = outfile.Data();
+  auto se = Fun4AllServer::instance();
+  se->Verbosity(1);
+  auto rc = recoConsts::instance();
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");
+  rc->set_uint64Flag("TIMESTAMP", 6);
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+  G4TPC::tpc_drift_velocity_reco = (8.0 / 1000) * 107.0 / 105.0;
+  G4MAGNET::magfield = "0.01";
+  G4MAGNET::magfield_tracking = G4MAGNET::magfield;
+  G4MAGNET::magfield_rescale = 1;
+  ACTSGEOM::ActsGeomInit();
+
+  auto hitsin = new Fun4AllDstInputManager("InputManager");
+  hitsin->fileopen(inputtpcRawHitFile);
+  // hitsin->AddFile(inputMbd);
+  se->registerInputManager(hitsin);
+
+  Mvtx_HitUnpacking();
+  Intt_HitUnpacking();
+  Tpc_HitUnpacking();
+  Micromegas_HitUnpacking();
+
+  Mvtx_Clustering();
+  Intt_Clustering();
+
+  auto tpcclusterizer = new TpcClusterizer;
+  tpcclusterizer->Verbosity(0);
+  tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
+  tpcclusterizer->set_rawdata_reco();
+  se->registerSubsystem(tpcclusterizer);
+
+  Micromegas_Clustering();
+
+  Tracking_Reco_TrackSeed_ZeroField();
+
+  if (G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    auto converter = new TrackSeedTrackMapConverter;
+    // Default set to full SvtxTrackSeeds. Can be set to
+    // SiliconTrackSeedContainer or TpcTrackSeedContainer
+    converter->setTrackSeedName("TpcTrackSeedContainer");
+    converter->setFieldMap(G4MAGNET::magfield_tracking);
+    converter->Verbosity(0);
+    converter->constField();
+    se->registerSubsystem(converter);
+  }
+  else
+  {
+    auto deltazcorr = new PHTpcDeltaZCorrection;
+    deltazcorr->Verbosity(0);
+    se->registerSubsystem(deltazcorr);
+
+    // perform final track fit with ACTS
+    auto actsFit = new PHActsTrkFitter;
+    actsFit->Verbosity(0);
+    actsFit->commissioning(G4TRACKING::use_alignment);
+    // in calibration mode, fit only Silicons and Micromegas hits
+    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_use_clustermover(true);  // default is true for now
+    actsFit->useActsEvaluator(false);
+    actsFit->useOutlierFinder(false);
+    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
+    se->registerSubsystem(actsFit);
+  }
+  PHSimpleVertexFinder *finder = new PHSimpleVertexFinder;
+  finder->Verbosity(0);
+  finder->setDcaCut(0.5);
+  finder->setTrackPtCut(-99999.);
+  finder->setBeamLineCut(1);
+  finder->setTrackQualityCut(1000000000);
+  finder->setNmvtxRequired(3);
+  finder->setOutlierPairCut(0.1);
+  se->registerSubsystem(finder);
+
+  TString residoutfile = theOutfile + "_resid.root";
+  std::string residstring(residoutfile.Data());
+
+  auto resid = new TrackResiduals("TrackResiduals");
+  resid->outfileName(residstring);
+  resid->alignment(false);
+  resid->clusterTree();
+  resid->hitTree();
+  resid->zeroField();
+  resid->Verbosity(0);
+  se->registerSubsystem(resid);
+
+  // Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", "/sphenix/tg/tg01/hf/jdosbo/tracking_development/Run24/Beam/41626/hitsets.root");
+  // se->registerOutputManager(out);
+  if (Enable::QA)
+  {
+    se->registerSubsystem(new MvtxClusterQA);
+    se->registerSubsystem(new InttClusterQA);
+    se->registerSubsystem(new TpcClusterQA);
+    se->registerSubsystem(new MicromegasClusterQA);
+  }
+  se->run(nEvents);
+  se->End();
+  se->PrintTimer();
+
+  if (Enable::QA)
+  {
+    TString qaname = theOutfile + "_qa.root";
+    std::string qaOutputFileName(qaname.Data());
+    QAHistManagerDef::saveQARootFile(qaOutputFileName);
+  }
+
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+}


### PR DESCRIPTION
This adds a zero field track seeding function and a macro which runs that seeding function and can run either the seed->track converter or the Acts track fitter on the track seeds. Can be used on the zero field data including all the tracking systems