### PR TITLE
adding calo reco macro with only waveform/signal extraction for ADC s…

### DIFF
--- a/CaloProduction/Fun4All_WaveformFit.C
+++ b/CaloProduction/Fun4All_WaveformFit.C
@@ -1,0 +1,127 @@
+#include <caloreco/CaloTowerBuilder.h>
+#include <caloreco/CaloWaveformProcessing.h>
+
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+#include <ffamodules/HeadReco.h>
+#include <ffamodules/SyncReco.h>
+
+#include <fun4allraw/Fun4AllPrdfInputManager.h>
+
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <fun4all/SubsysReco.h>
+
+#include <phool/recoConsts.h>
+
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libfun4allraw.so)
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libffamodules.so)
+
+void Fun4All_WaveformFit(const std::string &fname = "/sphenix/lustre01/sphnxpro/commissioning/slurp/calobeam/run_00040700_00040800/DST_TRIGGERED_RAW_beam_new_2023p015-00040797-0001.root", int nEvents = 10)
+{
+  // v1 uncomment:
+  // CaloTowerDefs::BuilderType buildertype = CaloTowerDefs::kPRDFTowerv1;
+  // v2 uncomment:
+   CaloTowerDefs::BuilderType buildertype = CaloTowerDefs::kWaveformTowerv2;
+  // v3 uncomment:
+  // CaloTowerDefs::BuilderType buildertype = CaloTowerDefs::kPRDFWaveform;
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(0);
+
+  recoConsts *rc = recoConsts::instance();
+
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(fname);
+  int runnumber = runseg.first;
+  int segment = runseg.second;
+  char outfile[100];
+  char outfile_hist[100];
+  sprintf(outfile, "DST_CALOR-%08d-%04d.root", runnumber, segment);
+  sprintf(outfile_hist, "HIST_CALOR-%08d-%04d.root", runnumber, segment);
+  string fulloutfile = string("./") + outfile;
+  string fulloutfile_hist = string("./") + outfile_hist;
+  //===============
+  // conditions DB flags
+  //===============
+  // ENABLE::CDB = true;
+  // global tag
+  rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");
+  // // 64 bit timestamp
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+  CDBInterface::instance()->Verbosity(1);
+
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
+
+
+
+  /////////////////
+  // build towers
+  CaloTowerBuilder *ctbEMCal = new CaloTowerBuilder("EMCalBUILDER");
+  ctbEMCal->set_detector_type(CaloTowerDefs::CEMC);
+  ctbEMCal->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+  ctbEMCal->set_builder_type(buildertype);
+  ctbEMCal->set_offlineflag(true);
+  ctbEMCal->set_nsamples(12);
+  se->registerSubsystem(ctbEMCal);
+
+  CaloTowerBuilder *ctbIHCal = new CaloTowerBuilder("HCALINBUILDER");
+  ctbIHCal->set_detector_type(CaloTowerDefs::HCALIN);
+  ctbIHCal->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+  ctbIHCal->set_builder_type(buildertype);
+  ctbIHCal->set_offlineflag();
+  ctbIHCal->set_nsamples(12);
+  se->registerSubsystem(ctbIHCal);
+
+  CaloTowerBuilder *ctbOHCal = new CaloTowerBuilder("HCALOUTBUILDER");
+  ctbOHCal->set_detector_type(CaloTowerDefs::HCALOUT);
+  ctbOHCal->set_processing_type(CaloWaveformProcessing::TEMPLATE);
+  ctbOHCal->set_builder_type(buildertype);
+  ctbOHCal->set_offlineflag();
+  ctbOHCal->set_nsamples(12);
+  se->registerSubsystem(ctbOHCal);
+
+  CaloTowerBuilder *caZDC = new CaloTowerBuilder("ZDCBUILDER");
+  caZDC->set_detector_type(CaloTowerDefs::ZDC);
+  caZDC->set_builder_type(buildertype);
+  caZDC->set_processing_type(CaloWaveformProcessing::FAST);
+  caZDC->set_nsamples(16);
+  caZDC->set_offlineflag();
+  se->registerSubsystem(caZDC);
+
+  CaloTowerBuilder *caEPD = new CaloTowerBuilder("SEPDBUILDER");
+  caEPD->set_detector_type(CaloTowerDefs::SEPD);
+  caEPD->set_builder_type(buildertype);
+  caEPD->set_processing_type(CaloWaveformProcessing::FAST);
+  caEPD->set_nsamples(12);
+  caEPD->set_offlineflag();
+  se->registerSubsystem(caEPD);
+
+  Fun4AllInputManager *In = new Fun4AllDstInputManager("in");
+  In->AddFile(fname);
+  se->registerInputManager(In);
+
+  Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", fulloutfile);
+  out->StripNode("CEMCPackets");
+  out->StripNode("HCALPackets");
+  out->StripNode("ZDCPackets");
+  out->StripNode("SEPDPackets");
+  se->registerOutputManager(out);
+
+  se->run(nEvents);
+  se->End();
+
+  CDBInterface::instance()->Print();  // print used DB files
+  se->PrintTimer();
+  delete se;
+  std::cout << "All done!" << std::endl;
+  gSystem->Exit(0);
+}
+


### PR DESCRIPTION
…ystem except mbd

This is the  node output

TOP (PHCompositeNode)/
   DST (PHCompositeNode)/
      MBD (PHCompositeNode)/
         MBDPackets (IO,CaloPacketContainerv1)
      ZDC (PHCompositeNode)/
         ZDCPackets (IO,CaloPacketContainerv1)
         TOWERS_ZDC (IO,TowerInfoContainerv2)
      SEPD (PHCompositeNode)/
         SEPDPackets (IO,CaloPacketContainerv1)
         TOWERS_SEPD (IO,TowerInfoContainerv2)
      HCAL (PHCompositeNode)/
         HCALPackets (IO,CaloPacketContainerv1)
      CEMC (PHCompositeNode)/
         CEMCPackets (IO,CaloPacketContainerv1)
         TOWERS_CEMC (IO,TowerInfoContainerv2)
      Sync (IO,SyncObjectv1)
      EventHeader (IO,EventHeaderv1)
      HCALIN (PHCompositeNode)/
         TOWERS_HCALIN (IO,TowerInfoContainerv2)
      HCALOUT (PHCompositeNode)/
         TOWERS_HCALOUT (IO,TowerInfoContainerv2)
   RUN (PHCompositeNode)/
      RunHeader (IO,RunHeaderv1)
      Flags (IO,FlagSavev1)
   PAR (PHCompositeNode)/
