### PR TITLE
fix: call tracking init

### DIFF
--- a/MvtxProduction/Fun4All_MvtxVertex.C
+++ b/MvtxProduction/Fun4All_MvtxVertex.C
@@ -9,6 +9,7 @@
 #include <G4_Magnet.C>
 #include <GlobalVariables.C>
 #include <Trkr_Clustering.C>
+#include <Trkr_RecoInit.C>
 #include <Trkr_Reco.C>
 
 #include <ffamodules/CDBInterface.h>
@@ -65,7 +66,7 @@ void Fun4All_MvtxVertex(
   G4MAGNET::magfield = "0.01";
   G4MAGNET::magfield_tracking = G4MAGNET::magfield;
   G4MAGNET::magfield_rescale = 1;
-  ACTSGEOM::ActsGeomInit();
+  TrackingInit();
 
   auto hitsin = new Fun4AllDstInputManager("InputManager");
   hitsin->fileopen(inputRawHitFile);

--- a/TrackingProduction/Fun4All_FieldOnAllTrackers.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers.C
@@ -12,6 +12,7 @@
 #include <G4_Mbd.C>
 #include <GlobalVariables.C>
 #include <QA.C>
+#include <Trkr_RecoInit.C>
 #include <Trkr_Clustering.C>
 #include <Trkr_Reco.C>
 
@@ -85,7 +86,7 @@ void Fun4All_FieldOnAllTrackers(
   G4TPC::tpc_drift_velocity_reco = (8.0 / 1000) * 107.0 / 105.0;
 
   G4MAGNET::magfield_rescale = 1;
-  ACTSGEOM::ActsGeomInit();
+  TrackingInit();
 
   auto hitsin = new Fun4AllDstInputManager("InputManager");
   hitsin->fileopen(inputtpcRawHitFile);
@@ -115,7 +116,7 @@ void Fun4All_FieldOnAllTrackers(
     auto converter = new TrackSeedTrackMapConverter;
     // Default set to full SvtxTrackSeeds. Can be set to
     // SiliconTrackSeedContainer or TpcTrackSeedContainer
-    converter->setTrackSeedName("TpcTrackSeedContainer");
+    converter->setTrackSeedName("SiliconTrackSeedContainer");
     converter->setFieldMap(G4MAGNET::magfield_tracking);
     converter->Verbosity(0);
     se->registerSubsystem(converter);
@@ -159,6 +160,7 @@ void Fun4All_FieldOnAllTrackers(
   resid->clusterTree();
   resid->hitTree();
   resid->Verbosity(0);
+  resid->linefitAll();
   se->registerSubsystem(resid);
 
   // Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", "/sphenix/tg/tg01/hf/jdosbo/tracking_development/Run24/Beam/41626/hitsets.root");

--- a/TrackingProduction/Fun4All_FieldOnAllTrackers.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers.C
@@ -116,7 +116,7 @@ void Fun4All_FieldOnAllTrackers(
     auto converter = new TrackSeedTrackMapConverter;
     // Default set to full SvtxTrackSeeds. Can be set to
     // SiliconTrackSeedContainer or TpcTrackSeedContainer
-    converter->setTrackSeedName("SiliconTrackSeedContainer");
+    converter->setTrackSeedName("TpcTrackSeedContainer");
     converter->setFieldMap(G4MAGNET::magfield_tracking);
     converter->Verbosity(0);
     se->registerSubsystem(converter);
@@ -160,7 +160,6 @@ void Fun4All_FieldOnAllTrackers(
   resid->clusterTree();
   resid->hitTree();
   resid->Verbosity(0);
-  resid->linefitAll();
   se->registerSubsystem(resid);
 
   // Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", "/sphenix/tg/tg01/hf/jdosbo/tracking_development/Run24/Beam/41626/hitsets.root");

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -12,6 +12,7 @@
 #include <G4_Mbd.C>
 #include <GlobalVariables.C>
 #include <QA.C>
+#include <Trkr_RecoInit.C>
 #include <Trkr_Clustering.C>
 #include <Trkr_Reco.C>
 
@@ -63,6 +64,9 @@ void Fun4All_ZFAllTrackers(
   int runnumber = runseg.first;
   int segment = runseg.second;
 
+  ACTSGEOM::mvtxMisalignment = 100;
+  ACTSGEOM::inttMisalignment = 1000.;
+  ACTSGEOM::tpotMisalignment = 100.;
   TString outfile = outfilename + "_" + runnumber + "-" + segment + ".root";
   std::string theOutfile = outfile.Data();
   auto se = Fun4AllServer::instance();
@@ -83,7 +87,7 @@ void Fun4All_ZFAllTrackers(
   G4MAGNET::magfield = "0.01";
   G4MAGNET::magfield_tracking = G4MAGNET::magfield;
   G4MAGNET::magfield_rescale = 1;
-  ACTSGEOM::ActsGeomInit();
+  TrackingInit();
 
   auto hitsin = new Fun4AllDstInputManager("InputManager");
   hitsin->fileopen(inputtpcRawHitFile);
@@ -113,7 +117,7 @@ void Fun4All_ZFAllTrackers(
     auto converter = new TrackSeedTrackMapConverter;
     // Default set to full SvtxTrackSeeds. Can be set to
     // SiliconTrackSeedContainer or TpcTrackSeedContainer
-    converter->setTrackSeedName("TpcTrackSeedContainer");
+    converter->setTrackSeedName("SvtxTrackSeedContainer");
     converter->setFieldMap(G4MAGNET::magfield_tracking);
     converter->Verbosity(0);
     converter->constField();


### PR DESCRIPTION
Call `TrackingInit` instead of just the acts geometry initialization, which includes the distortion initialization also.