### PR TITLE
Fix tpc geometry

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -133,7 +133,7 @@ void InttInit()
     G4INTT::sensor_radius[1] = 7.732 - 36e-4;
     G4INTT::sensor_radius[2] = 9.680 - 36e-4;
     G4INTT::sensor_radius[3] = 10.262 - 36e-4;
-  
+
   }
 }
 
@@ -428,7 +428,10 @@ void TPC_Cells()
   padplane->Verbosity(verbosity);
   double extended_readout_time = 0.0;
   if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+
   padplane->SetReadoutTime(extended_readout_time);
+  padplane->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);
+  padplane->SetDriftVelocity(G4TPC::tpc_drift_velocity_sim);
 
   auto edrift = new PHG4TpcElectronDrift;
   edrift->Detector("TPC");
@@ -468,7 +471,6 @@ void TPC_Cells()
 
   // override the default drift velocity parameter specification
   edrift->set_double_param("drift_velocity", G4TPC::tpc_drift_velocity_sim);
-  padplane->SetDriftVelocity(G4TPC::tpc_drift_velocity_sim);
 
   // fudge factors to get drphi 150 microns (in mid and outer Tpc) and dz 500 microns cluster resolution
   // They represent effects not due to ideal gas properties and ideal readout plane behavior

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -94,7 +94,9 @@ namespace G4INTT
 namespace G4TPC
 {
   int n_tpc_layer_inner = 16;
-  int tpc_layer_rphi_count_inner = 1152;
+
+  int tpc_layer_rphi_count_inner = 1128; // 94 * 12
+
   int n_tpc_layer_mid = 16;
   int n_tpc_layer_outer = 16;
   int n_gas_layer = n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer;


### PR DESCRIPTION
This makes sure that wathever value is set to G4TPC::tpc_layer_rphi_count_inner is applied consistently to both PHG4TpcSubsystem and PHG4TpcPadPlaneReadout. 
@mohaas33 please double check the value.