### PR TITLE
use quotes for include, put include guard around sphenix style C macro

### DIFF
--- a/common/sPhenixStyle.C
+++ b/common/sPhenixStyle.C
@@ -1,8 +1,11 @@
+#ifndef MACRO_SPHENIXSTYLE_C
+#define MACRO_SPHENIXSTYLE_C
+
 //
 // sPHENIX Style, based on a style file from BaBar, v0.1
 //
 
-#include <sPhenixStyle.h>
+#include "sPhenixStyle.h"
 
 #include <TColor.h>
 #include <TROOT.h>
@@ -113,3 +116,5 @@ TStyle* sPhenixStyle()
 
   return sphenixStyle;
 }
+
+#endif

--- a/common/sPhenixStyle.h
+++ b/common/sPhenixStyle.h
@@ -10,8 +10,8 @@
 //
 //   Version 0.1
 
-#ifndef  __SPHENIXSTYLE_H
-#define __SPHENIXSTYLE_H
+#ifndef MACRO_SPHENIXSTYLE_H
+#define MACRO_SPHENIXSTYLE_H
 
 #include <TStyle.h>
 
@@ -48,4 +48,4 @@ void SetsPhenixStyle();
 
 TStyle* sPhenixStyle(); 
 
-#endif // __SPHENIXSTYLE_H
+#endif // MACRO_SPHENIXSTYLE_H


### PR DESCRIPTION
This PR fixes the sPHENIX style macro so it can be included by our code (QAhtml so far)