### PR TITLE
create TowerInfoV2 by default

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -77,7 +77,7 @@ namespace G4CEMC
   enu_Cemc_clusterizer Cemc_clusterizer = kCemcTemplateClusterizer;
   //! graph clusterizer, RawClusterBuilderGraph
   // enu_Cemc_clusterizer Cemc_clusterizer = kCemcGraphClusterizer;
-  bool useTowerInfoV2 = false;
+  bool useTowerInfoV2 = true;
 
 }  // namespace G4CEMC
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -84,7 +84,7 @@ namespace G4HCALIN
     kHCalInTemplateClusterizer
   };
   
-  bool useTowerInfoV2 = false;
+  bool useTowerInfoV2 = true;
   //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
   enu_HCalIn_clusterizer HCalIn_clusterizer = kHCalInTemplateClusterizer;
   //! graph clusterizer, RawClusterBuilderGraph

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -71,7 +71,7 @@ namespace G4HCALOUT
     kHCalOutTemplateClusterizer
   };
 
-  bool useTowerInfoV2 = false;
+  bool useTowerInfoV2 = true;
 
   //! template clusterizer, RawClusterBuilderTemplate, as developed by Sasha Bazilevsky
   enu_HCalOut_clusterizer HCalOut_clusterizer = kHCalOutTemplateClusterizer;


### PR DESCRIPTION
As agreed in the software meeting - we make the TowerInfov2 the default for the sims. It's needed for the embedding and since it is a superset of v1, code assuming a v1 TowerInfo will keep working with it