### PR TITLE
Add macro to plot the h_nodes histogram with labelled nodes per bin

### DIFF
--- a/validation/calo/plot_nodes.C
+++ b/validation/calo/plot_nodes.C
@@ -1,0 +1,39 @@
+void plot_nodes()
+{
+	TFile *file = new TFile("HIST_CALOR_QA-00043901-0004.root", "READ");
+	
+	TString name = "h_CaloValid_nodes_exists";
+	TH1F *hist = (TH1F*)file->Get(name.Data());
+
+	TCanvas *c1 = new TCanvas("c1", "Histogram with Bin Labels", 800, 600);
+
+	hist->Draw();
+
+	//label each bin
+	
+	std::string binNames[] = {"GlobalVertexMap", "TOWERINFO_CALIB_CEMC", "TOWERINFO_CALIB_HCALIN", "TOWERINFO_CALIB_HCALOUT", "TOWERINFO_CALIB_ZDC", "TOWERS_ZDC", "TOWERS_CEMC", "TOWERS_HCALOUT", "TOWERS_HCALIN", "MbdPmtContainer", "CLUSTERINFO_POS_COR_CEMC"};
+
+	int size = sizeof(binNames)/sizeof(binNames[0]);
+	
+	for (int i=0; i<size; i++)
+	{
+		std::cout << binNames[i] << std::endl;
+	}
+
+	for (int i = 1; i <= hist->GetNbinsX(); i++)
+	{
+		float binCenter = hist->GetBinCenter(i);
+		float binContent = hist->GetBinContent(i);
+		// Create a TText object
+		TText *text = new TText(binCenter, binContent + 1, binNames[i-1].c_str());
+		//TText *text = new TText(binCenter, binContent + 1, Form(binNames[i-1].c_str()));
+		//TText *text = new TText(binCenter, binContent + 1, Form("Bin %d", i));
+		// Set text alignment (centered)
+		text->SetTextAlign(22);
+		text->SetTextSize(0.04);
+		text->SetTextAngle(90);
+		text->Draw();
+	}
+
+	c1->Update();
+}


### PR DESCRIPTION
Companion macro to make the h_nodes_exists histogram that has the label of nodes for each bins. There are 11 bins with each bin dedicated to nodes name for this histogram. For each event, if the node exists, then the count on that corresponding bins increases by 1. 
Related coresoftware PR: [master](https://github.com/sPHENIX-Collaboration/coresoftware) ([#2789](https://github.com/sPHENIX-Collaboration/coresoftware/pull/2789))