### PR TITLE
making tower prefix configurable

### DIFF
--- a/common/HIJetReco.C
+++ b/common/HIJetReco.C
@@ -33,6 +33,7 @@ namespace HIJETS
 {
   bool do_flow = false; // should be set to true once the EPD event plane correction is implemented
   bool do_CS = false;
+  std::string tower_prefix = "TOWERINFO_CALIB";
 }  // namespace HIJETS
 
 
@@ -65,26 +66,29 @@ void HIJetReco()
   RetowerCEMC *rcemc = new RetowerCEMC(); 
   rcemc->Verbosity(verbosity); 
   rcemc->set_towerinfo(true);
- se->registerSubsystem(rcemc);
+  rcemc->set_frac_cut(0.5); //fraction of retower that must be masked to mask the full retower
+  rcemc->set_towerNodePrefix(HIJETS::tower_prefix);
+  se->registerSubsystem(rcemc);
 
 
   JetReco *towerjetreco = new JetReco();
-  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWERINFO_RETOWER));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWERINFO));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWERINFO));
+  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWERINFO_RETOWER,HIJETS::tower_prefix));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWERINFO,HIJETS::tower_prefix));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWERINFO,HIJETS::tower_prefix));
   towerjetreco->add_algo(new FastJetAlgo(Jet::ANTIKT, 0.2), "AntiKt_TowerInfo_HIRecoSeedsRaw_r02");
   towerjetreco->set_algo_node("ANTIKT");
   towerjetreco->set_input_node("TOWER");
-  towerjetreco->Verbosity(verbosity); 
+  towerjetreco->Verbosity(verbosity);
   se->registerSubsystem(towerjetreco);
 
- DetermineTowerBackground *dtb = new DetermineTowerBackground();
+  DetermineTowerBackground *dtb = new DetermineTowerBackground();
   dtb->SetBackgroundOutputName("TowerInfoBackground_Sub1");
   dtb->SetFlow(HIJETS::do_flow);
   dtb->SetSeedType(0);
   dtb->SetSeedJetD(3);
   dtb->set_towerinfo(true);
   dtb->Verbosity(verbosity); 
+  dtb->set_towerNodePrefix(HIJETS::tower_prefix);
   se->registerSubsystem(dtb);
 
 
@@ -93,6 +97,7 @@ void HIJetReco()
   casj->SetFlowModulation(HIJETS::do_flow);
   casj->Verbosity(verbosity); 
   casj->set_towerinfo(true);
+  casj->set_towerNodePrefix(HIJETS::tower_prefix);
   se->registerSubsystem(casj);
   
   
@@ -103,6 +108,7 @@ void HIJetReco()
   dtb2->SetSeedJetPt(7);
   dtb2->Verbosity(verbosity); 
   dtb2->set_towerinfo(true);
+  dtb2->set_towerNodePrefix(HIJETS::tower_prefix);
   se->registerSubsystem(dtb2);
   
 
@@ -110,16 +116,17 @@ void HIJetReco()
   st->SetFlowModulation(HIJETS::do_flow);
   st->Verbosity(verbosity);
   st->set_towerinfo(true);
+  st->set_towerNodePrefix(HIJETS::tower_prefix);
   se->registerSubsystem(st);
   
   towerjetreco = new JetReco();
-  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWERINFO_SUB1));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWERINFO_SUB1));
-  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWERINFO_SUB1));
-  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.2, 1), "AntiKt_Tower_r02_Sub1");
-  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.3, 1), "AntiKt_Tower_r03_Sub1");
-  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.4, 1), "AntiKt_Tower_r04_Sub1");
-  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.5, 1), "AntiKt_Tower_r05_Sub1");
+  towerjetreco->add_input(new TowerJetInput(Jet::CEMC_TOWERINFO_SUB1,HIJETS::tower_prefix));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALIN_TOWERINFO_SUB1,HIJETS::tower_prefix));
+  towerjetreco->add_input(new TowerJetInput(Jet::HCALOUT_TOWERINFO_SUB1,HIJETS::tower_prefix));
+  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.2, verbosity), "AntiKt_Tower_r02_Sub1");
+  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.3, verbosity), "AntiKt_Tower_r03_Sub1");
+  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.4, verbosity), "AntiKt_Tower_r04_Sub1");
+  towerjetreco->add_algo(new FastJetAlgoSub(Jet::ANTIKT, 0.5, verbosity), "AntiKt_Tower_r05_Sub1");
   towerjetreco->set_algo_node("ANTIKT");
   towerjetreco->set_input_node("TOWER");
   towerjetreco->Verbosity(verbosity);


### PR DESCRIPTION
updating the HIJetReco.C macro to allow for user configured tower node names. This requires the changes in coresoftware in: https://github.com/sPHENIX-Collaboration/coresoftware/pull/2803