### PR TITLE
Create Jet Production Macro

### DIFF
--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -12,7 +12,9 @@
 
 // coresoftware headers
 #include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllServer.h>
@@ -41,11 +43,11 @@ R__LOAD_LIBRARY(libjetbackground.so)
 R__LOAD_LIBRARY(libqautils.so)
 
 
-// ----------------------------------------------------------------------------
-//! The Year 2 Jet Structure Topical Group production macro
-// ----------------------------------------------------------------------------
+
+// macro body -----------------------------------------------------------------
+
 void Fun4All_JetProductionYear2(
-  const int nEvents = 100,
+  const int nEvents = 0,
   const std::string& infile = "DST_CALO_run2pp_new_2024p001-00042586-0000.root",
   const std::string& outfile = "DST_JET-00042586-0000.root",
   const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
@@ -59,6 +61,10 @@ void Fun4All_JetProductionYear2(
   // turn on pp mode
   HIJETS::is_pp = true;
 
+  // qa options
+  JetQA::HasTracks = false;
+  JetQA::UseTrigger = true;
+
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
@@ -68,7 +74,7 @@ void Fun4All_JetProductionYear2(
   int runnumber = runseg.first;
 
   // set up reconstruction constants, DB tag, timestamp
-  recoconsts* rc = recoConsts::instance();
+  recoConsts* rc = recoConsts::instance();
   rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
   rc -> set_uint64Flag("TIMESTAMP", runnumber);
 
@@ -81,7 +87,7 @@ void Fun4All_JetProductionYear2(
 
   // read in input
   Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddFile(fname);
+  in -> AddFile(infile);
   se -> registerInputManager(in);
 
   // do vertex & centrality reconstruction
@@ -98,7 +104,7 @@ void Fun4All_JetProductionYear2(
   if (Enable::QA)
   {
     DoRhoCalculation();
-    CommonJetQA();
+    Jet_QA();
   }
 
   // if needed, save DST output

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -63,7 +63,8 @@ void Fun4All_JetProductionYear2(
 
   // qa options
   JetQA::HasTracks = false;
-  JetQA::UseTrigger = true;
+  JetQA::DoInclusive = true;
+  JetQA::DoTriggered = true;
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -1,0 +1,139 @@
+#ifndef FUN4ALL_JETPRODUCTIONYEAR2_C
+#define FUN4ALL_JETPRODUCTIONYEAR2_C
+
+
+// c++ utilities
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// coresoftware headers
+#include <ffamodules/CDBInterface.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
+#include <phool/recoConsts.h>
+#include <jetbackground/DetermineTowerRho.h>
+#include <jetbackground/TowerRho.h>
+#include <qautils/QAHistManagerDef.h>
+
+// f4a macros
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+
+// load libraries
+R__LOAD_LIBRARY(libg4centrality.so)
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
+R__LOAD_LIBRARY(libqautils.so)
+
+
+// ----------------------------------------------------------------------------
+//! The Year 2 Jet Structure Topical Group production macro
+// ----------------------------------------------------------------------------
+void Fun4All_JetProductionYear2(
+  const int nEvents = 100,
+  const std::string& infile = "DST_CALO_run2pp_new_2024p001-00042586-0000.root",
+  const std::string& outfile = "DST_JET-00042586-0000.root",
+  const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
+  const std::string& dbtag = "00042586-0000.root"
+) {
+
+  // turn on/off DST output and/or QA
+  Enable::DSTOUT = false;
+  Enable::QA = true;
+
+  // turn on pp mode
+  HIJETS::is_pp = true;
+
+  // initialize F4A server
+  Fun4AllServer* se = Fun4AllServer::instance();
+  se -> Verbosity(1);
+
+  // grab run and segment no.s
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(infile);
+  int runnumber = runseg.first;
+
+  // set up reconstruction constants, DB tag, timestamp
+  recoconsts* rc = recoConsts::instance();
+  rc -> set_StringFlag("CDB_GLOBALTAG", dbtag);
+  rc -> set_uint64Flag("TIMESTAMP", runnumber);
+
+  // connect to conditions database
+  CDBInterface::instance()->Verbosity(1);
+
+  // set up flag handler
+  FlagHandler* flag = new FlagHandler();
+  se -> registerSubsystem(flag);
+
+  // read in input
+  Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
+  in -> AddFile(fname);
+  se -> registerInputManager(in);
+
+  // do vertex & centrality reconstruction
+  Global_Reco();
+  if (!HIJETS::is_pp)
+  {
+    Centrality();
+  }
+
+  // do jet reconstruction & rho calculation
+  HIJetReco();  
+
+  // register modules necessary for QA
+  if (Enable::QA)
+  {
+    DoRhoCalculation();
+    CommonJetQA();
+  }
+
+  // if needed, save DST output
+  if (Enable::DSTOUT)
+  {
+    Fun4AllDstOutputManager* out = new Fun4AllDstOutputManager("DSTOUT", outfile);
+    out -> StripNode("CEMCPackets");
+    out -> StripNode("HCALPackets");
+    out -> StripNode("ZDCPackets");
+    out -> StripNode("SEPDPackets");
+    out -> StripNode("MBDPackets");
+    se -> registerOutputManager(out);
+  }
+
+  // if needed, save QA output
+  if (Enable::QA)
+  {
+    QAHistManagerDef::saveQARootFile(outfile_hist);
+  }
+
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
+  // print used DB files, time elapsed and delete server
+  CDBInterface::instance() -> Print();
+  se -> PrintTimer();
+  delete se;
+
+  // announce end and exit
+  std::cout << "Jets are done!" << std::endl;
+  gSystem -> Exit(0);
+
+}
+
+#endif
+
+// end ------------------------------------------------------------------------

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -51,7 +51,7 @@ void Fun4All_JetProductionYear2(
   const std::string& infile = "DST_CALO_run2pp_new_2024p001-00042586-0000.root",
   const std::string& outfile = "DST_JET-00042586-0000.root",
   const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
-  const std::string& dbtag = "00042586-0000.root"
+  const std::string& dbtag = "ProdA_2024"
 ) {
 
   // turn on/off DST output and/or QA
@@ -119,15 +119,15 @@ void Fun4All_JetProductionYear2(
     se -> registerOutputManager(out);
   }
 
+  // run4all
+  se -> run(nEvents);
+  se -> End();
+
   // if needed, save QA output
   if (Enable::QA)
   {
     QAHistManagerDef::saveQARootFile(outfile_hist);
   }
-
-  // run4all
-  se -> run(nEvents);
-  se -> End();
 
   // print used DB files, time elapsed and delete server
   CDBInterface::instance() -> Print();

--- a/common/HIJetReco.C
+++ b/common/HIJetReco.C
@@ -33,6 +33,7 @@ namespace HIJETS
 {
   bool do_flow = false; // should be set to true once the EPD event plane correction is implemented
   bool do_CS = false;
+  bool is_pp = false;  // turn off functionality only relevant for nucleon collisions
   std::string tower_prefix = "TOWERINFO_CALIB";
 }  // namespace HIJETS
 

--- a/common/HIJetReco.C
+++ b/common/HIJetReco.C
@@ -135,4 +135,34 @@ void HIJetReco()
   return;
 
 }
+
+
+// ----------------------------------------------------------------------------
+//! Determine rho from tower input to jet reco (necessary for jet QA)
+// ----------------------------------------------------------------------------
+void DoRhoCalculation()
+{
+
+  // set verbosity
+  int verbosity = std::max(Enable::VERBOSITY, Enable::HIJETS_VERBOSITY);
+
+  //---------------
+  // Fun4All server
+  //---------------
+  Fun4AllServer* se = Fun4AllServer::instance();
+
+  // run rho calculations w/ default parameters
+  DetermineTowerRho* towRhoCalc = new DetermineTowerRho();
+  towRhoCalc -> add_method(TowerRho::Method::AREA);
+  towRhoCalc -> add_method(TowerRho::Method::MULT);
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::CEMC_TOWERINFO_RETOWER) );
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::HCALIN_TOWERINFO) );
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::HCALOUT_TOWERINFO) );
+  se -> registerSubsystem( towRhoCalc );
+
+  // exit back to main macro
+  return;
+
+}
+
 #endif

--- a/common/HIJetReco.C
+++ b/common/HIJetReco.C
@@ -10,10 +10,12 @@
 
 #include <jetbackground/CopyAndSubtractJets.h>
 #include <jetbackground/DetermineTowerBackground.h>
+#include <jetbackground/DetermineTowerRho.h>
 #include <jetbackground/FastJetAlgoSub.h>
 #include <jetbackground/RetowerCEMC.h>
 #include <jetbackground/SubtractTowers.h>
 #include <jetbackground/SubtractTowersCS.h>
+#include <jetbackground/TowerRho.h>
 
 #include <fun4all/Fun4AllServer.h>
 

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -2,13 +2,13 @@
 #define MACRO_JETQA_C
 
 #include <fun4all/Fun4AllServer.h>
-#include </sphenix/u/danderson/install/include/jetqa/ConstituentsinJets.h>
-#include </sphenix/u/danderson/install/include/jetqa/JetKinematicCheck.h>
-#include </sphenix/u/danderson/install/include/jetqa/JetQADefs.h>
-#include </sphenix/u/danderson/install/include/jetqa/JetSeedCount.h>
-#include </sphenix/u/danderson/install/include/jetqa/RhosinEvent.h>
-#include </sphenix/u/danderson/install/include/jetqa/StructureinJets.h>
-#include </sphenix/u/danderson/install/include/jetqa/TrksInJetQA.h>
+#include <jetqa/ConstituentsinJets.h>
+#include <jetqa/JetKinematicCheck.h>
+#include <jetqa/JetQADefs.h>
+#include <jetqa/JetSeedCount.h>
+#include <jetqa/RhosinEvent.h>
+#include <jetqa/StructureinJets.h>
+#include <jetqa/TrksInJetQA.h>
 
 #include <HIJetReco.C>
 #include <QA.C>

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -1,0 +1,148 @@
+#ifndef MACRO_JETQA_C
+#define MACRO_JETQA_C
+
+#include <fun4all/Fun4AllServer.h>
+#include </sphenix/u/danderson/install/include/jetqa/ConstituentsinJets.h>
+#include </sphenix/u/danderson/install/include/jetqa/JetKinematicCheck.h>
+#include </sphenix/u/danderson/install/include/jetqa/JetQADefs.h>
+#include </sphenix/u/danderson/install/include/jetqa/JetSeedCount.h>
+#include </sphenix/u/danderson/install/include/jetqa/RhosinEvent.h>
+#include </sphenix/u/danderson/install/include/jetqa/StructureinJets.h>
+#include </sphenix/u/danderson/install/include/jetqa/TrksInJetQA.h>
+
+#include <HIJetReco.C>
+#include <QA.C>
+
+R__LOAD_LIBRARY(/sphenix/u/danderson/install/lib/libjetqa.so)
+
+
+
+// ----------------------------------------------------------------------------
+//! Namespace to collect various enums, default arguments, etc.
+// ----------------------------------------------------------------------------
+namespace JetQA
+{
+
+  /* TODO will go here */
+
+}  // end JetQA namespace
+
+
+// ----------------------------------------------------------------------------
+//! QA for all jets, regardless of constituents
+// ----------------------------------------------------------------------------
+// TODO factorize so that you can specify
+//   a trigger, and it will create all
+//   the relevant modules
+//
+// TODO clean-up by
+//   (1) moving all tags to vectors
+//   (2) moving default cuts to a struct
+void CommonJetQA()
+{
+
+  // FIXME select on max of verbosities
+  Enable::QA_VERBOSITY = 10;
+
+  // connect to f4a server
+  Fun4AllServer* se = Fun4AllServer::instance();
+
+  // initialize and register mass, eta, and pt qa module 
+  JetKinematicCheck* kinematicQA = new JetKinematicCheck(
+    "JetKinematicCheck",
+    "AntiKt_Tower_r02_Sub1",
+    "AntiKt_Tower_r03_Sub1",
+    "AntiKt_Tower_r04_Sub1",
+    "AntiKt_Tower_r05_Sub1"
+  );
+  kinematicQA -> setHistTag("AntiKt_Tower_AllTrig");
+  kinematicQA -> setPtRange(10., 100.);
+  kinematicQA -> setEtaRange(-1.1, 1.1);
+  se          -> registerSubsystem(kinematicQA);
+
+  // initialize and register jet seed counter qa module
+  JetSeedCount* jetSeedQA = new JetSeedCount(
+    "JetSeedCount",
+    "AntiKt_Tower_r04_Sub1",
+    "AntiKt_TowerInfo_HIRecoSeedsRaw_r02",
+    "AntiKt_TowerInfo_HIRecoSeedsSub_r02"
+  );
+  jetSeedQA -> setHistTag("r04_AntiKt_Tower_Sub1_AllTrig");
+  jetSeedQA -> setPtRange(5., 100.);
+  jetSeedQA -> setEtaRange(-1.1, 1.1);
+  jetSeedQA -> setWriteToOutputFile(false);
+  jetSeedQA -> setPPMode(HIJETS::is_pp);
+  se        -> registerSubsystem( jetSeedQA );
+
+  // initialize and register constituent checks
+  ConstituentsinJets* jetCstsQAR03Jet1 = new ConstituentsinJets(
+    "ConstituentsInJetsR03Jet1",
+    "AntiKt_Tower_r03_Sub1",
+    "TowerInfoBackground_Sub1",
+    "r03_AntiKt_Tower_Jet1"
+  );
+  jetCstsQAR03Jet1 -> setTrgToSelect(JetQADefs::GL1::MBDNSJet1);
+  jetCstsQAR03Jet1 -> setPtRange(5., 100.);
+  jetCstsQAR03Jet1 -> setEtaRange(-1.1, 1.1);
+  se               -> registerSubsystem( jetCstsQAR03Jet1 );
+
+  // initialize and register constituent checks
+  ConstituentsinJets* jetCstsQA = new ConstituentsinJets(
+    "ConstituentsInJetsR04Jet4",
+    "AntiKt_Tower_r04_Sub1",
+    "r04_AntiKt_Tower_Jet4"
+  );
+  jetCstsQA -> setTrgToSelect(JetQADefs::GL1::MBDNSJet4);
+  jetCstsQA -> setPtRange(5., 100.);
+  jetCstsQA -> setEtaRange(-1.1, 1.1);
+  se        -> registerSubsystem( jetCstsQA );
+
+  // initialize and register event-wise rho check
+  RhosinEvent* evtRhoQA = new RhosinEvent("EventWiseRho", "AllTrig");
+  evtRhoQA -> add_area_rho_node("TowerRho_AREA");
+  evtRhoQA -> add_mult_rho_node("TowerRho_MULT");
+  se       -> registerSubsystem( evtRhoQA );
+
+}  // end 'CommonJetQA()'
+
+
+
+// ----------------------------------------------------------------------------
+//! QA for jets with tracks
+// ----------------------------------------------------------------------------
+void JetsWithTracksQA()
+{
+
+  // connect to f4a server
+  Fun4AllServer* se = Fun4AllServer::instance();
+
+  // intialize and register sum track vs. jet pt qa module
+  StructureinJets* jetStructQA = new StructureinJets("AntiKt_Tower_r04_Sub1", "");
+  jetStructQA -> writeToOutputFile(false);
+  se          -> registerSubsystem(jetStructQA);
+
+  // initialize and register track jet qa module
+  TrksInJetQA* trksInJetQA = new TrksInJetQA("TrksInJetQANode_ClustJets");
+  trksInJetQA -> SetHistSuffix("TowerJetSub1");
+  trksInJetQA -> Configure(
+    {
+      .outMode     = TrksInJetQA::OutMode::QA,
+      .verbose     = Enable::QA_VERBOSITY,
+      .doDebug     = false,
+      .doInclusive = false,
+      .doInJet     = true,
+      .doHitQA     = false,
+      .doClustQA   = true,
+      .doTrackQA   = true,
+      .doJetQA     = true,
+      .rJet        = 0.4,
+      .jetInNode   = "AntiKt_Tower_r04_Sub1"
+    }
+  );
+  se -> registerSubsystem(trksInJetQA);
+
+}  // end 'JetWithTracksQA()'
+
+#endif
+
+// end ---------------------------------------------

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -33,8 +33,11 @@ namespace JetQA
   //! Set to true if input jets utilize tracks (e.g. via particle flow)
   bool HasTracks = false;
 
-  //! Set to true to select a particular set of triggers
-  bool UseTrigger = true;
+  //! Set to true to generate histograms for no trigger selection
+  bool DoInclusive = true;
+
+  //! Set to true to generate histograms a specified set of triggers
+  bool DoTriggered = true;
 
 
 
@@ -60,6 +63,9 @@ namespace JetQA
 
   //! Max eta acceptance
   double MaxAcceptEta = 1.1;
+
+  //! Inclusive tag
+  std::string InclusiveTag = "inclusive";
 
 
 
@@ -246,11 +252,16 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
   // set verbosity
   int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HIJETS_VERBOSITY);
 
-  // make trigger tag
+  // if selecting a trigger, add correpsonding tag
+  //   otherwise label as "inclusive"
   std::string trig_tag("");
   if (trg.has_value())
   {
     trig_tag.append("_" + JetQA::GL1Tag[trg.value()]);
+  }
+  else
+  {
+    trig_tag.append("_" + JetQA::InclusiveTag);
   }
 
   // grab default pt, eta ranges
@@ -350,11 +361,16 @@ void JetsWithTracksQA(std::optional<uint32_t> trg = std::nullopt)
   // set verbosity
   int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HIJETS_VERBOSITY);
 
-  // make trigger tag
+  // if selecting a trigger, add correpsonding tag
+  //   otherwise label as "inclusive"
   std::string trig_tag("");
   if (trg.has_value())
   {
     trig_tag.append("_" + JetQA::GL1Tag[trg.value()]);
+  }
+  else
+  {
+    trig_tag.append("_" + JetQA::InclusiveTag);
   }
 
   // grab default pt, eta ranges
@@ -423,7 +439,8 @@ void JetsWithTracksQA(std::optional<uint32_t> trg = std::nullopt)
 void Jet_QA(std::vector<uint32_t> vecTrigsToUse = JetQA::GetDefaultTriggerList())
 {
 
-  if (!JetQA::UseTrigger)
+  // run in inclusive mode if needed
+  if (JetQA::DoInclusive)
   {
     CommonJetQA();
     if (JetQA::HasTracks)
@@ -431,7 +448,10 @@ void Jet_QA(std::vector<uint32_t> vecTrigsToUse = JetQA::GetDefaultTriggerList()
       JetsWithTracksQA();
     }
   }
-  else
+
+
+  // run in triggered mode if needed
+  if (JetQA::DoTriggered)
   {
     for (uint32_t trg : vecTrigsToUse)
     {

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -36,7 +36,7 @@ namespace JetQA
   //! Set to true to generate histograms for no trigger selection
   bool DoInclusive = true;
 
-  //! Set to true to generate histograms a specified set of triggers
+  //! Set to true to generate histograms for a specified set of triggers
   bool DoTriggered = true;
 
 
@@ -117,6 +117,7 @@ namespace JetQA
     {Type::AntiKtTowerSubR04, "towersub1_antikt_r04"},
     {Type::AntiKtTowerSubR05, "towersub1_antikt_r05"}
   };
+
 
 
   // methods ------------------------------------------------------------------
@@ -448,7 +449,6 @@ void Jet_QA(std::vector<uint32_t> vecTrigsToUse = JetQA::GetDefaultTriggerList()
       JetsWithTracksQA();
     }
   }
-
 
   // run in triggered mode if needed
   if (JetQA::DoTriggered)

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -54,13 +54,7 @@ void Fun4All_CaloOnlyJetValid(
   const int  nEvts  = 10,
   const int  nSkip  = 0,
   const SVec inputs = {
-    "../input/dst_global.list",
-    "../input/dst_mbd_epd.list",
-    "../input/dst_calo_cluster.list",
-    "../input/dst_trkr_hit.list",
-    "../input/dst_trkr_cluster.list",
-    "../input/dst_trackseeds.list",
-    "../input/dst_tracks.list"
+    "./lists/runs/dst_calo_run2pp-00042586.list"
   },
   const std::string  qaBase = "HIST_JET_QA",
   std::optional<int> run    = std::nullopt

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -18,6 +18,7 @@
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
 #include <phool/recoConsts.h>
+#include <jetqa/JetKinematicCheck.h>
 #include <jetqa/JetSeedCount.h>
 #include <jetqa/StructureinJets.h>
 #include <jetqa/TrksInJetQA.h>

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -68,7 +68,7 @@ void Fun4All_CaloOnlyJetValid(
 
   // announce start of macro
   std::cout << "\n -------- OwO -- Starting Jet QA Macro -- OwO -------- \n "
-            << "                 [Using Calo-only Jets]               "
+            << "                [Using Calo-only Jets]\n"
             << std::endl;
 
   // grab instances f4a, the cdb, etc.

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -137,9 +137,10 @@ void Fun4All_CaloOnlyJetValid(
   // register qa modules ------------------------------------------------------
 
   // initialize and register jet seed counter qa module
-  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "seed_test.root");
+  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "");
   jetSeedQA -> setPtRange(5., 100.);
   jetSeedQA -> setEtaRange(-1.1, 1.1);
+  jetSeedQA -> setWriteToOutputFile(false);
   se        -> registerSubsystem( jetSeedQA );
 
   // initialize and register mass, eta, and pt qa module 

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -62,7 +62,8 @@ void Fun4All_CaloOnlyJetValid(
 
   // qa options
   JetQA::HasTracks = false;
-  JetQA::UseTrigger = true;
+  JetQA::DoInclusive = true;
+  JetQA::DoTriggered = true;
 
   // initialize fun4all ------------------------------------------------------
 

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -60,6 +60,10 @@ void Fun4All_CaloOnlyJetValid(
   // turn on pp mode
   HIJETS::is_pp = true;
 
+  // qa options
+  JetQA::HasTracks = false;
+  JetQA::UseTrigger = true;
+
   // initialize fun4all ------------------------------------------------------
 
   // announce start of macro
@@ -119,7 +123,7 @@ void Fun4All_CaloOnlyJetValid(
 
   // register qa modules ------------------------------------------------------
 
-  CommonJetQA();
+  Jet_QA();
 
   // run modules and exit -----------------------------------------------------
 

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -10,16 +10,20 @@
 #include <vector>
 
 // coresoftware headers
-#include <g4centrality/PHG4CentralityReco.h>
 #include <ffamodules/CDBInterface.h>
 #include <fun4all/Fun4AllDstInputManager.h>
 #include <fun4all/Fun4AllInputManager.h>
 #include <fun4all/Fun4AllRunNodeInputManager.h>
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
+#include <g4centrality/PHG4CentralityReco.h>
 #include <phool/recoConsts.h>
+#include <jetbackground/DetermineTowerRho.h>
+#include <jetbackground/TowerRho.h>
+#include <jetqa/ConstituentsinJets.h>
 #include <jetqa/JetKinematicCheck.h>
 #include <jetqa/JetSeedCount.h>
+#include <jetqa/RhosinEvent.h>
 #include <qautils/QAHistManagerDef.h>
 
 // f4a macros
@@ -34,6 +38,7 @@
 R__LOAD_LIBRARY(libg4centrality.so)
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libjetbackground.so)
 R__LOAD_LIBRARY(libjetqa.so)
 R__LOAD_LIBRARY(libqautils.so)
 
@@ -108,6 +113,7 @@ void Fun4All_CaloOnlyJetValid(
 
   // register & run necessary reconstruction ----------------------------------
 
+  // do vertex reconstruction
   Global_Reco(); 
 
   // initialize and register centrality calculator
@@ -122,16 +128,19 @@ void Fun4All_CaloOnlyJetValid(
   );
   se -> registerSubsystem( centReco );
 
+  // do jet reconstruction
   HIJetReco();  
 
-  // register qa modules ------------------------------------------------------
+  // run rho calculations w/ default parameters
+  DetermineTowerRho* towRhoCalc = new DetermineTowerRho();
+  towRhoCalc -> add_method(TowerRho::Method::AREA);
+  towRhoCalc -> add_method(TowerRho::Method::MULT);
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::CEMC_TOWERINFO_RETOWER) );
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::HCALIN_TOWERINFO) );
+  towRhoCalc -> add_tower_input( new TowerJetInput(Jet::HCALOUT_TOWERINFO) );
+  se         -> registerSubsystem( towRhoCalc );
 
-  // initialize and register jet seed counter qa module
-  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "");
-  jetSeedQA -> setPtRange(5., 100.);
-  jetSeedQA -> setEtaRange(-1.1, 1.1);
-  jetSeedQA -> setWriteToOutputFile(false);
-  se        -> registerSubsystem( jetSeedQA );
+  // register qa modules ------------------------------------------------------
 
   // initialize and register mass, eta, and pt qa module 
   JetKinematicCheck* kinematicQA = new JetKinematicCheck(
@@ -142,6 +151,25 @@ void Fun4All_CaloOnlyJetValid(
   kinematicQA -> setPtRange(10., 100.);
   kinematicQA -> setEtaRange(-1.1, 1.1);
   se          -> registerSubsystem(kinematicQA);
+
+  // initialize and register jet seed counter qa module
+  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "");
+  jetSeedQA -> setPtRange(5., 100.);
+  jetSeedQA -> setEtaRange(-1.1, 1.1);
+  jetSeedQA -> setWriteToOutputFile(false);
+  se        -> registerSubsystem( jetSeedQA );
+
+  // initialize and register constituent checks
+  ConstituentsinJets* jetCstsQA = new ConstituentsinJets("AntiKt_Tower_r04");
+  jetCstsQA -> setPtRange(5., 100.);
+  jetCstsQA -> setEtaRange(-1.1, 1.1);
+  se        -> registerSubsystem( jetCstsQA );
+
+  // initialize and register event-wise rho check
+  RhosinEvent* evtRhoQA = new RhosinEvent("EventWiseRho");
+  evtRhoQA -> add_area_rho_node("TowerRho_AREA");
+  evtRhoQA -> add_mult_rho_node("TowerRho_MULT");
+  se       -> registerSubsystem( evtRhoQA );
 
   // run modules and exit -----------------------------------------------------
 

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -20,8 +20,6 @@
 #include <phool/recoConsts.h>
 #include <jetqa/JetKinematicCheck.h>
 #include <jetqa/JetSeedCount.h>
-#include <jetqa/StructureinJets.h>
-#include <jetqa/TrksInJetQA.h>
 #include <qautils/QAHistManagerDef.h>
 
 // f4a macros
@@ -31,7 +29,6 @@
 #include <GlobalVariables.C>
 #include <HIJetReco.C>
 #include <QA.C>
-#include <Trkr_Clustering.C>
 
 // load libraries
 R__LOAD_LIBRARY(libg4centrality.so)
@@ -102,20 +99,12 @@ void Fun4All_CaloOnlyJetValid(
   rc -> set_StringFlag("CDB_GLOBALTAG", "ProdA_2023");
   rc -> set_uint64Flag("TIMESTAMP", runNum);
 
-  // get url of geo file
-  const std::string inGeoFile = cb -> getUrl("Tracking_Geometry");
-
   // register dst input managers
   for (size_t iInput = 0; iInput < inputs.size(); ++iInput) {
     Fun4AllDstInputManager* inManager = new Fun4AllDstInputManager("InputManager" + std::to_string(iInput));
     inManager -> AddListFile(inputs[iInput], 1);
     se        -> registerInputManager(inManager);
   }
-
-  // register geometry manager
-  Fun4AllRunNodeInputManager* geoManager = new Fun4AllRunNodeInputManager("GeometryManager");
-  geoManager -> AddFile(inGeoFile.data());
-  se         -> registerInputManager(geoManager);
 
   // register & run necessary reconstruction ----------------------------------
 

--- a/validation/jet/Fun4All_TrackAndCaloJetValid.C
+++ b/validation/jet/Fun4All_TrackAndCaloJetValid.C
@@ -18,6 +18,7 @@
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
 #include <phool/recoConsts.h>
+#include <jetqa/JetKinematicCheck.h>
 #include <jetqa/JetSeedCount.h>
 #include <jetqa/StructureinJets.h>
 #include <jetqa/TrksInJetQA.h>

--- a/validation/jet/Fun4All_TrackAndCaloJetValid.C
+++ b/validation/jet/Fun4All_TrackAndCaloJetValid.C
@@ -73,6 +73,11 @@ void Fun4All_TrackAndCaloJetValid(
   // turn on pp mode
   HIJETS::is_pp = true;
 
+  // qa options
+  JetQA::HasTracks = false;
+  JetQA::DoInclusive = true;
+  JetQA::DoTriggered = true;
+
   // initialize fun4all ------------------------------------------------------
 
   // announce start of macro

--- a/validation/jet/Fun4All_TrackAndCaloJetValid.C
+++ b/validation/jet/Fun4All_TrackAndCaloJetValid.C
@@ -143,14 +143,16 @@ void Fun4All_TrackAndCaloJetValid(
   // register qa modules ------------------------------------------------------
 
   // initialize and register jet seed counter qa module
-  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "seed_test.root");
+  JetSeedCount* jetSeedQA = new JetSeedCount("AntiKt_Tower_r04_Sub1", "", "");
   jetSeedQA -> setPtRange(5., 100);
   jetSeedQA -> setEtaRange(-1.1, 1.1);
+  jetSeedQA -> setWriteToOutputFile(false);
   se        -> registerSubsystem( jetSeedQA );
 
   // intialize and register sum track vs. jet pt qa module
-  StructureinJets* jetStructQA = new StructureinJets("AntiKt_Tower_r04_Sub1", "trk_sum_test.root");
-  //se -> registerSubsystem(jetStructQA);  // FIXME uncomment when file-writing issue is resolved 
+  StructureinJets* jetStructQA = new StructureinJets("AntiKt_Tower_r04_Sub1", "");
+  jetStructQA -> writeToOutputFile(false);
+  se          -> registerSubsystem(jetStructQA);
 
   // initialize and register track jet qa module
   TrksInJetQA* trksInJetQA = new TrksInJetQA("TrksInJetQANode_ClustJets");

--- a/validation/jet/Fun4All_TrackAndCaloJetValid.C
+++ b/validation/jet/Fun4All_TrackAndCaloJetValid.C
@@ -68,7 +68,7 @@ void Fun4All_TrackAndCaloJetValid(
 
   // announce start of macro
   std::cout << "\n -------- OwO -- Starting Jet QA Macro -- OwO -------- \n "
-            << "              [Using Track-and-Calo Jets]               "
+            << "              [Using Track-and-Calo Jets]\n"
             << std::endl;
 
   // grab instances f4a, the cdb, etc.


### PR DESCRIPTION
This PR introduces two new changes:
1. Introduces the `Fun4All_JetProductionYear2.C` macro and makes relevant changes to `HIJetReco.C`;
2. Factorizes the jet QA into `Jet_QA.C`, which consolidates all jet-QA related routines into a single macro which can be deployed across multiple Fun4All macros; and finally
3. Updates both example jet QA macros to include modules recently added to the jet QA package in `coresoftware` as well as propagate changes to exisiting modules.