### PR TITLE
added steering macro lines to turn on static corrections

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackers.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers.C
@@ -81,6 +81,10 @@ void Fun4All_FieldOnAllTrackers(
 
   G4TPC::tpc_drift_velocity_reco = (8.0 / 1000) * 107.0 / 105.0;
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  //to turn on the default static corrections, enable the two lines below
+  //G4TPC::ENABLE_STATIC_CORRECTIONS = true;
+  //G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS = false;
+
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 


### PR DESCRIPTION
Per posted slides at https://indico.bnl.gov/event/23720/ , this gives two lines in the default macro that can be uncommented to turn on the TPC static corrections.  The TPC module edge corrections are already enabled by default.