### PR TITLE
extended radians and interpolation flags to be distortion dependent.

### DIFF
--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -22,7 +22,10 @@ void TrackingInit()
   {
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
-    tpcLoadDistortionCorrection->set_read_phi_as_radians( G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
+
+    tpcLoadDistortionCorrection->set_read_phi_as_radians(TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS );
+    tpcLoadDistortionCorrection->set_interpolate_2D_to_zero(TpcLoadDistortionCorrection::DistortionType_ModuleEdge, false);
+
 
     if( G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_ModuleEdge, G4TPC::module_edge_correction_filename );
     if( G4TPC::ENABLE_STATIC_CORRECTIONS ) tpcLoadDistortionCorrection->set_correction_filename( TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::static_correction_filename );


### PR DESCRIPTION
This matches the coresoftware PR of the same name.  Code will /run/ without this update, but it will mishandle the TPC module edge correction.

With this correction, radian and interpolation flags are now applied per-correction rather than one flag covering all of them simultaneously..

