### PR TITLE
Integrate 07.10 JS TG, 07.12 PCM, and 08.12 Production Meeting Feedback

### DIFF
--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -65,6 +65,8 @@ void Fun4All_JetProductionYear2(
   JetQA::HasTracks = false;
   JetQA::DoInclusive = true;
   JetQA::DoTriggered = true;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR = true;
 
   // initialize F4A server
   Fun4AllServer* se = Fun4AllServer::instance();

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -48,7 +48,7 @@ R__LOAD_LIBRARY(libqautils.so)
 
 void Fun4All_JetProductionYear2(
   const int nEvents = 0,
-  const std::string& infile = "DST_CALO_run2pp_new_2024p001-00042586-0000.root",
+  const std::string& inlist = "TestListInput.list",
   const std::string& outfile = "DST_JET-00042586-0000.root",
   const std::string& outfile_hist = "HIST_JETQA-00042586-0000.root",
   const std::string& dbtag = "ProdA_2024"
@@ -72,8 +72,13 @@ void Fun4All_JetProductionYear2(
   Fun4AllServer* se = Fun4AllServer::instance();
   se -> Verbosity(1);
 
+  // grab 1st file from input list
+  ifstream    files(inlist);
+  std::string first("");
+  std::getline(files, first);
+
   // grab run and segment no.s
-  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(infile);
+  pair<int, int> runseg = Fun4AllUtils::GetRunSegment(first);
   int runnumber = runseg.first;
 
   // set up reconstruction constants, DB tag, timestamp
@@ -90,7 +95,7 @@ void Fun4All_JetProductionYear2(
 
   // read in input
   Fun4AllInputManager* in = new Fun4AllDstInputManager("in");
-  in -> AddFile(infile);
+  in -> AddListFile(inlist);
   se -> registerInputManager(in);
 
   // do vertex & centrality reconstruction

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -134,6 +134,31 @@ namespace JetQA
   // methods ------------------------------------------------------------------
 
   // --------------------------------------------------------------------------
+  //! Get trigger tag
+  // --------------------------------------------------------------------------
+  /*! If a trigger index is provided (i.e. a trigger is being selected),
+   *  function returns the correpsonding tag. Otherwise (i.e. NO trigger
+   *  is being selected), returns the inclusive tag.
+   */
+  inline std::string GetTriggerTag(std::optional<uint32_t> trg = std::nullopt)
+  {
+
+    std::string tag("");
+    if (trg.has_value())
+    {
+      tag.append("_" + GL1Tag[trg.value()]);
+    }
+    else
+    {
+      tag.append("_" + InclusiveTag);
+    }
+    return tag;
+
+  }  // end 'GetTriggerTag(std::optional<uint32_t>)'
+
+
+
+  // --------------------------------------------------------------------------
   //! Get minimum jet pt based on which trigger fired
   // --------------------------------------------------------------------------
   // FIXME it might be prudent to allow for thresholds to change vs. run
@@ -268,17 +293,8 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
   // set verbosity
   int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HIJETS_VERBOSITY);
 
-  // if selecting a trigger, add correpsonding tag
-  //   otherwise label as "inclusive"
-  std::string trig_tag("");
-  if (trg.has_value())
-  {
-    trig_tag.append("_" + JetQA::GL1Tag[trg.value()]);
-  }
-  else
-  {
-    trig_tag.append("_" + JetQA::InclusiveTag);
-  }
+  // grab appropriate trigger tag
+  std::string trig_tag = JetQA::GetTriggerTag(trg);
 
   // grab default pt, eta ranges
   std::pair<double, double> ptJetRange = JetQA::GetDefaultJetPtRange(trg);
@@ -377,17 +393,8 @@ void JetsWithTracksQA(std::optional<uint32_t> trg = std::nullopt)
   // set verbosity
   int verbosity = std::max(Enable::QA_VERBOSITY, Enable::HIJETS_VERBOSITY);
 
-  // if selecting a trigger, add correpsonding tag
-  //   otherwise label as "inclusive"
-  std::string trig_tag("");
-  if (trg.has_value())
-  {
-    trig_tag.append("_" + JetQA::GL1Tag[trg.value()]);
-  }
-  else
-  {
-    trig_tag.append("_" + JetQA::InclusiveTag);
-  }
+  // grab appropriate trigger tag
+  std::string trig_tag = JetQA::GetTriggerTag(trg);
 
   // grab default pt, eta ranges
   std::pair<double, double> ptJetRange = JetQA::GetDefaultJetPtRange(trg);

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -39,6 +39,9 @@ namespace JetQA
   //! Set to true to generate histograms for a specified set of triggers
   bool DoTriggered = true;
 
+  //! Set to true to restrict jet eta acceptance by resolution parameter
+  bool RestrictEtaByR = true;
+
 
 
   // enums --------------------------------------------------------------------
@@ -329,6 +332,7 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
   );
   kinematicQA -> Verbosity(verbosity);
   kinematicQA -> setHistTag("");
+  kinematicQA -> setRestrictEtaRange(JetQA::RestrictEtaByR);
   kinematicQA -> setPtRange(ptJetRange.first, ptJetRange.second);
   kinematicQA -> setEtaRange(etaJetRange.first, etaJetRange.second);
   if (trg.has_value())

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -71,6 +71,7 @@ namespace JetQA
 
   // maps ---------------------------------------------------------------------
 
+  //! Map from trigger to histogram tag
   std::map<uint32_t, std::string> GL1Tag = {
     {JetQADefs::GL1::Clock, "clock"},
     {JetQADefs::GL1::ZDCS, "zdcs"},
@@ -104,6 +105,7 @@ namespace JetQA
     {JetQADefs::GL1::Photon4, "photon4"} 
   };
 
+  //! Map from jet type to input node
   std::map<uint32_t, std::string> JetInput = {
     {Type::AntiKtTowerSubR02, "AntiKt_Tower_r02_Sub1"},
     {Type::AntiKtTowerSubR03, "AntiKt_Tower_r03_Sub1"},
@@ -111,11 +113,20 @@ namespace JetQA
     {Type::AntiKtTowerSubR05, "AntiKt_Tower_r05_Sub1"}
   };
 
+  //! Map from jet type to histogram tag
   std::map<uint32_t, std::string> JetTag = {
     {Type::AntiKtTowerSubR02, "towersub1_antikt_r02"},
     {Type::AntiKtTowerSubR03, "towersub1_antikt_r03"},
     {Type::AntiKtTowerSubR04, "towersub1_antikt_r04"},
     {Type::AntiKtTowerSubR05, "towersub1_antikt_r05"}
+  };
+
+  //! Map from jet type to resolution parameter
+  std::map<uint32_t, double> JetRes = {
+    {Type::AntiKtTowerSubR02, 0.2},
+    {Type::AntiKtTowerSubR03, 0.3},
+    {Type::AntiKtTowerSubR04, 0.4},
+    {Type::AntiKtTowerSubR05, 0.5}
   };
 
 
@@ -216,7 +227,11 @@ namespace JetQA
       JetQADefs::GL1::MBDNSJet1,
       JetQADefs::GL1::MBDNSJet2,
       JetQADefs::GL1::MBDNSJet3,
-      JetQADefs::GL1::MBDNSJet4
+      JetQADefs::GL1::MBDNSJet4,
+      JetQADefs::GL1::Jet1,
+      JetQADefs::GL1::Jet2,
+      JetQADefs::GL1::Jet3,
+      JetQADefs::GL1::Jet4
     };
     return vecDefaultTrigs;
 

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -211,7 +211,7 @@ namespace JetQA
   // --------------------------------------------------------------------------
   //! Get default jet pt range
   // --------------------------------------------------------------------------
-  inline std::pair<double, double> GetDefaultJetPtRange(std::optional<uint32_t> trg = std::nullopt)
+  inline std::pair<double, double> GetJetPtRange(std::optional<uint32_t> trg = std::nullopt)
   {
 
     std::pair<double, double> ptJetRange;
@@ -225,14 +225,14 @@ namespace JetQA
     }
     return ptJetRange;
 
-  }  // end 'GetDefaultJetPtRange(std::optional<uint32_t>)'
+  }  // end 'GetJetPtRange(std::optional<uint32_t>)'
 
 
 
   // --------------------------------------------------------------------------
   //! Get default jet eta range
   // --------------------------------------------------------------------------
-  inline std::pair<double, double> GetDefaultJetEtaRange(const double res = 0.)
+  inline std::pair<double, double> GetJetEtaRange(const double res = 0.)
   {
 
     const double etaMin = MinAcceptEta + res;
@@ -240,7 +240,7 @@ namespace JetQA
     std::pair<double, double> etaJetRange = {etaMin, etaMax};
     return etaJetRange;
 
-  }  // end 'GetDefaultJetEtaRange(double)'
+  }  // end 'GetJetEtaRange(double)'
 
 
 
@@ -300,8 +300,8 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
   std::string trig_tag = JetQA::GetTriggerTag(trg);
 
   // grab default pt, eta ranges
-  std::pair<double, double> ptJetRange = JetQA::GetDefaultJetPtRange(trg);
-  std::pair<double, double> etaJetRange = JetQA::GetDefaultJetEtaRange();
+  std::pair<double, double> ptJetRange = JetQA::GetJetPtRange(trg);
+  std::pair<double, double> etaJetRange = JetQA::GetJetEtaRange();
 
   // get list of jet nodes to analyze
   std::vector<uint32_t> vecJetsToQA = JetQA::GetJetsToQA();
@@ -401,8 +401,8 @@ void JetsWithTracksQA(std::optional<uint32_t> trg = std::nullopt)
   std::string trig_tag = JetQA::GetTriggerTag(trg);
 
   // grab default pt, eta ranges
-  std::pair<double, double> ptJetRange = JetQA::GetDefaultJetPtRange(trg);
-  std::pair<double, double> etaJetRange = JetQA::GetDefaultJetEtaRange();
+  std::pair<double, double> ptJetRange = JetQA::GetJetPtRange(trg);
+  std::pair<double, double> etaJetRange = JetQA::GetJetEtaRange();
 
   // get list of jet nodes to analyze
   std::vector<uint32_t> vecJetsToQA = JetQA::GetJetsToQA();

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -39,6 +39,9 @@ namespace JetQA
   //! Set to true to generate histograms for a specified set of triggers
   bool DoTriggered = true;
 
+  //! Set to true to restrict minimum jet pt to trigger threshold
+  bool RestrictPtToTrig = false;
+
   //! Set to true to restrict jet eta acceptance by resolution parameter
   bool RestrictEtaByR = true;
 
@@ -57,6 +60,9 @@ namespace JetQA
 
 
   // constants ----------------------------------------------------------------
+
+  //! Min jet pt in GeV/c
+  double MinJetPt = 6.;
 
   //! Max jet pt in GeV/c
   double MaxJetPt = 100.;
@@ -169,38 +175,44 @@ namespace JetQA
   inline double GetMinJetPt(const uint32_t trg = JetQADefs::GL1::MBDNSJet1)
   {
 
-    double ptJetMin;
-    switch (trg)
+    // by defult, set min to global constant
+    double ptJetMin = MinJetPt;
+
+    // if restricting pt to trigger threhsold, pick out relevant threshold
+    if (RestrictPtToTrig)
     {
-      // Jet4 threshold
-      case JetQADefs::GL1::MBDNSJet4:
-        [[fallthrough]];
-      case JetQADefs::GL1::Jet4:
-        ptJetMin = 11.;
-        break;
+      switch (trg)
+      {
+        // Jet4 threshold
+        case JetQADefs::GL1::MBDNSJet4:
+          [[fallthrough]];
+        case JetQADefs::GL1::Jet4:
+          ptJetMin = 11.;
+          break;
 
-      // Jet3 threshold
-      case JetQADefs::GL1::MBDNSJet3:
-        [[fallthrough]];
-      case JetQADefs::GL1::Jet3:
-        ptJetMin = 10.;
-        break;
+        // Jet3 threshold
+        case JetQADefs::GL1::MBDNSJet3:
+          [[fallthrough]];
+        case JetQADefs::GL1::Jet3:
+          ptJetMin = 10.;
+          break;
 
-      // Jet2 threshold
-      case JetQADefs::GL1::MBDNSJet2:
-        [[fallthrough]];
-      case JetQADefs::GL1::Jet2:
-        ptJetMin = 9.;
-        break;
+        // Jet2 threshold
+        case JetQADefs::GL1::MBDNSJet2:
+          [[fallthrough]];
+        case JetQADefs::GL1::Jet2:
+          ptJetMin = 9.;
+          break;
 
-      // Jet1 threshold (default value)
-      case JetQADefs::GL1::MBDNSJet1:
-        [[fallthrough]];
-      case JetQADefs::GL1::Jet1:
-        [[fallthrough]];
-      default:
-        ptJetMin = 6.;
-        break;
+        // Jet1 threshold (default value)
+        case JetQADefs::GL1::MBDNSJet1:
+          [[fallthrough]];
+        case JetQADefs::GL1::Jet1:
+          [[fallthrough]];
+        default:
+          ptJetMin = 6.;
+          break;
+      }
     }
     return ptJetMin;
 

--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -247,8 +247,11 @@ namespace JetQA
   inline std::pair<double, double> GetJetEtaRange(const double res = 0.)
   {
 
-    const double etaMin = MinAcceptEta + res;
-    const double etaMax = MaxAcceptEta - res;
+    // determine relevant min/max
+    const double etaMin = RestrictEtaByR ? MinAcceptEta + res : MinAcceptEta;
+    const double etaMax = RestrictEtaByR ? MaxAcceptEta - res : MaxAcceptEta;
+
+    // return range
     std::pair<double, double> etaJetRange = {etaMin, etaMax};
     return etaJetRange;
 
@@ -313,7 +316,7 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
 
   // grab default pt, eta ranges
   std::pair<double, double> ptJetRange = JetQA::GetJetPtRange(trg);
-  std::pair<double, double> etaJetRange = JetQA::GetJetEtaRange();
+  std::pair<double, double> etaJetMaxRange = JetQA::GetJetEtaRange();
 
   // get list of jet nodes to analyze
   std::vector<uint32_t> vecJetsToQA = JetQA::GetJetsToQA();
@@ -346,7 +349,7 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
   kinematicQA -> setHistTag("");
   kinematicQA -> setRestrictEtaRange(JetQA::RestrictEtaByR);
   kinematicQA -> setPtRange(ptJetRange.first, ptJetRange.second);
-  kinematicQA -> setEtaRange(etaJetRange.first, etaJetRange.second);
+  kinematicQA -> setEtaRange(etaJetMaxRange.first, etaJetMaxRange.second);
   if (trg.has_value())
   {
     kinematicQA -> setTrgToSelect(trg.value());
@@ -357,6 +360,9 @@ void CommonJetQA(std::optional<uint32_t> trg = std::nullopt)
 
   for (uint32_t jet : vecJetsToQA)
   {
+
+    // get R-dependent eta range
+    std::pair<double, double> etaJetRange = JetQA::GetJetEtaRange(JetQA::JetRes[jet]);
 
     // initialize and register jet seed counter qa module
     JetSeedCount* jetSeedQA = new JetSeedCount(

--- a/validation/jet/Fun4All_CaloOnlyJetValid.C
+++ b/validation/jet/Fun4All_CaloOnlyJetValid.C
@@ -57,6 +57,9 @@ void Fun4All_CaloOnlyJetValid(
   std::optional<int> run    = std::nullopt
 ) {
 
+  // turn on QA
+  Enable::QA = true;
+
   // turn on pp mode
   HIJETS::is_pp = true;
 
@@ -64,6 +67,8 @@ void Fun4All_CaloOnlyJetValid(
   JetQA::HasTracks = false;
   JetQA::DoInclusive = true;
   JetQA::DoTriggered = true;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR = true;
 
   // initialize fun4all ------------------------------------------------------
 

--- a/validation/jet/Fun4All_TrackAndCaloJetValid.C
+++ b/validation/jet/Fun4All_TrackAndCaloJetValid.C
@@ -70,6 +70,9 @@ void Fun4All_TrackAndCaloJetValid(
   std::optional<int> run    = std::nullopt
 ) {
 
+  // turn on QA
+  Enable::QA = true;
+
   // turn on pp mode
   HIJETS::is_pp = true;
 
@@ -77,6 +80,8 @@ void Fun4All_TrackAndCaloJetValid(
   JetQA::HasTracks = false;
   JetQA::DoInclusive = true;
   JetQA::DoTriggered = true;
+  JetQA::RestrictPtToTrig = false;
+  JetQA::RestrictEtaByR = true;
 
   // initialize fun4all ------------------------------------------------------
 


### PR DESCRIPTION
This PR integrates feedback received during the 07.10.2024 Jet Structure TG, 07.12.2024 Physics Coordination, and 08.12.2024 Production meetings. Also implements a few minor improvements.

**Changes:**
- Moved trigger tag selection to dedicated function
- Added jet singles to default trigger selection
- Added ability to either use a flat minimum jet pt or tie the minimum to the trigger threshold
- Added ability to restrict eta acceptance by jet resolution parameter
- Updated production macro to ingest input lists rather than single files