### PR TITLE
new options for TopoCluster reconstruction

### DIFF
--- a/common/G4_TopoClusterReco.C
+++ b/common/G4_TopoClusterReco.C
@@ -37,6 +37,8 @@ void TopoClusterReco()
   ClusterBuilder->set_do_split(true);
   ClusterBuilder->set_minE_local_max(1.0, 2.0, 0.5);
   ClusterBuilder->set_R_shower(0.025);
+  ClusterBiilder->set_use_only_good_towers(true);
+  ClusterBuilder->set_absE(true);
   se->registerSubsystem(ClusterBuilder);
 
   // topoClustering only in EMCal (needed for particle flow)
@@ -51,6 +53,8 @@ void TopoClusterReco()
   ClusterBuilder1->set_do_split(true);
   ClusterBuilder1->set_minE_local_max(1.0, 2.0, 0.5);
   ClusterBuilder1->set_R_shower(0.025);
+  ClusterBiilder1->set_use_only_good_towers(true);
+  ClusterBuilder1->set_absE(true);
   se->registerSubsystem(ClusterBuilder1);
 
   // topoClustering only in I+OHCal (needed for particle flow)
@@ -65,6 +69,8 @@ void TopoClusterReco()
   ClusterBuilder2->set_do_split(true);
   ClusterBuilder2->set_minE_local_max(1.0, 2.0, 0.5);
   ClusterBuilder2->set_R_shower(0.025);
+  ClusterBiilder2->set_use_only_good_towers(true);
+  ClusterBuilder2->set_absE(true);
   se->registerSubsystem(ClusterBuilder2);
 
   return;


### PR DESCRIPTION
New options for TopoCluster reconstruction:
* ignore hot towers as inputs to TC reconstruction (thanks Antonio!)
* include negative-energy towers (by considering |E| rather than E for the purpose of thresholds)

These have default parameters if not specified by the analyzer, but I make them explicit here in the macro for transparency.