### PR TITLE
Intt pool flag

### DIFF
--- a/StreamingProduction/Fun4All_Stream_Combiner.C
+++ b/StreamingProduction/Fun4All_Stream_Combiner.C
@@ -8,6 +8,7 @@
 #include <fun4allraw/InputManagerType.h>
 #include <fun4allraw/SingleGl1PoolInput.h>
 #include <fun4allraw/SingleInttPoolInput.h>
+#include <fun4allraw/SingleInttEventInput.h>
 #include <fun4allraw/SingleMicromegasPoolInput.h>
 #include <fun4allraw/SingleMvtxPoolInput.h>
 #include <fun4allraw/SingleTpcPoolInput.h>
@@ -28,6 +29,7 @@ R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libffarawmodules.so)
 
 bool isGood(const string &infile);
+bool use_inttpool = true; // set to false if you want to use the intt event input mgr
 
 void Fun4All_Stream_Combiner(int nEvents = 5, int RunNumber = 41989,
                              const string &input_gl1file = "gl1daq.list",
@@ -155,19 +157,41 @@ void Fun4All_Stream_Combiner(int nEvents = 5, int RunNumber = 41989,
   i = 0;
 
 
-  for (auto iter : intt_infile)
+  if (use_inttpool)
   {
-    if (isGood(iter))
+    for (auto iter : intt_infile)
     {
-    SingleInttPoolInput *intt_sngl = new SingleInttPoolInput("INTT_" + to_string(i));
+      if (isGood(iter))
+      {
+	cout << "opening file " << iter << endl;
+	SingleInttPoolInput *intt_sngl = new SingleInttPoolInput("INTT_" + to_string(i));
 //    intt_sngl->Verbosity(3);
-    intt_sngl->SetNegativeBco(1);
-    intt_sngl->SetBcoRange(2);
-    intt_sngl->AddListFile(iter);
-    in->registerStreamingInput(intt_sngl, InputManagerType::INTT);
-    i++;
+	intt_sngl->SetNegativeBco(1);
+	intt_sngl->SetBcoRange(2);
+	intt_sngl->AddListFile(iter);
+	in->registerStreamingInput(intt_sngl, InputManagerType::INTT);
+	i++;
+      }
     }
   }
+  else
+  {
+    for (auto iter : intt_infile)
+    {
+      if (isGood(iter))
+      {
+	cout << "opening file " << iter << endl;
+	SingleInttEventInput *intt_sngl = new SingleInttEventInput("INTT_" + to_string(i));
+//    intt_sngl->Verbosity(3);
+	intt_sngl->SetNegativeBco(1);
+	intt_sngl->SetBcoRange(2);
+	intt_sngl->AddListFile(iter);
+	in->registerStreamingInput(intt_sngl, InputManagerType::INTT);
+	i++;
+      }
+    }
+  }
+
   i = 0;
   for (auto iter : mvtx_infile)
   {

--- a/StreamingProduction/make_list.sh
+++ b/StreamingProduction/make_list.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+# creates file lists from known locations in lustre
+# run number is the input argument
+
+if [ $# -eq 0 ]
+  then
+    echo "Creates needed lists of input files for a given run"
+    echo "Usage: make_lists.sh <type> <run number> "
+    exit 1
+fi
+
+if [ $# -eq 1 ]
+then
+  echo "No type or runnumber supplied"
+  exit 0
+fi
+
+sh gl1_makelist.sh $1 $2
+sh mvtx_makelist.sh $1 $2
+sh intt_makelist.sh $1 $2
+sh tpc_makelist.sh $1 $2
+sh tpot_makelist.sh $1 $2


### PR DESCRIPTION
This PR adds a flag to select either the pool based intt input manager or the rcdaq based one. Default is pool based, so this macro will work as before (and therefore doesn't need my PR)