### PR TITLE
Laser Clustering

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -102,6 +102,8 @@ namespace G4TPC
   int n_gas_layer = n_tpc_layer_inner + n_tpc_layer_mid + n_tpc_layer_outer;
   double tpc_outer_radius = 77. + 2.;
 
+  float laser_pedestal_threshold = 0.0;
+
   // use simple clusterizer
   bool USE_SIMPLE_CLUSTERIZER = false;
 
@@ -132,6 +134,8 @@ namespace G4TPC
 
   // enable central membrane g4hits generation
   bool ENABLE_CENTRAL_MEMBRANE_HITS = false;
+
+  std::string laserClustering_debugName = "LaserCluster_debug.root";
 
   // enable direct laser g4hits generation
   bool ENABLE_DIRECT_LASER_HITS = false;

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -125,7 +125,7 @@ namespace G4TPC
   std::string module_edge_correction_filename = "";
 
   // static distortion corrections
-  bool ENABLE_STATIC_CORRECTIONS = true;
+  bool ENABLE_STATIC_CORRECTIONS = false;
   std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
 
   // average distortion corrections

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -125,7 +125,7 @@ namespace G4TPC
   std::string module_edge_correction_filename = "";
 
   // static distortion corrections
-  bool ENABLE_STATIC_CORRECTIONS = false;
+  bool ENABLE_STATIC_CORRECTIONS = true;
   std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
 
   // average distortion corrections
@@ -133,7 +133,7 @@ namespace G4TPC
   std::string average_correction_filename;
 
   // enable central membrane g4hits generation
-  bool ENABLE_CENTRAL_MEMBRANE_HITS = false;
+  bool ENABLE_CENTRAL_MEMBRANE_HITS = true;
 
   std::string laserClustering_debugName = "LaserCluster_debug.root";
 

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -21,6 +21,7 @@
 #pragma GCC diagnostic pop
 
 #include <tpc/TpcClusterCleaner.h>
+#include <tpc/LaserClusterizer.h>
 
 #include <micromegas/MicromegasClusterizer.h>
 
@@ -125,6 +126,27 @@ void TPC_Clustering()
   tpcclustercleaner->Verbosity(verbosity);
   se->registerSubsystem(tpcclustercleaner);
 }
+
+void TPC_LaserClustering()
+{
+  //only cluster if turned on
+  if( G4TPC::ENABLE_CENTRAL_MEMBRANE_HITS )
+  {
+    //int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
+    int verbosity = 5;
+    ACTSGEOM::ActsGeomInit();
+    Fun4AllServer* se = Fun4AllServer::instance();
+
+    auto laserClusterizer = new LaserClusterizer;
+    laserClusterizer->Verbosity(verbosity);
+    laserClusterizer->set_max_time_samples(TRACKING::reco_tpc_maxtime_sample);
+    laserClusterizer->set_pedestal(G4TPC::laser_pedestal_threshold);
+    laserClusterizer->set_debug(true);
+    laserClusterizer->set_debug_name(G4TPC::laserClustering_debugName);
+    se->registerSubsystem(laserClusterizer);
+  }
+}
+
 
 void Micromegas_HitUnpacking()
 {


### PR DESCRIPTION
Adds laser clustering to main clustering macro so that it will be run with Job 0 by default. Turned on the laser clustering by default (static correction is needed for the laser matching, which is not done in Job 0, so it is left off by default)