### PR TITLE
feat: track macro for processing higher level DSTs

### DIFF
--- a/TrackingProduction/Fun4All_TrackAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackAnalysis.C
@@ -31,8 +31,8 @@
 
 #include <tpccalib/PHTpcResiduals.h>
 
-#include <trackingqa/TpcSeedsQA.h>
 #include <trackingqa/SiliconSeedsQA.h>
+#include <trackingqa/TpcSeedsQA.h>
 #include <trackingqa/TpcSiliconQA.h>
 
 #include <trackingdiagnostics/TrackResiduals.h>
@@ -64,12 +64,12 @@ void Fun4All_TrackAnalysis(
   int runnumber = runseg.first;
   int segment = runseg.second;
 
-  TpcReadoutInit( runnumber );
-  std::cout<< " run: " << runnumber
-	   << " samples: " << TRACKING::reco_tpc_maxtime_sample
-	   << " pre: " << TRACKING::reco_tpc_time_presample
-	   << " vdrift: " << G4TPC::tpc_drift_velocity_reco
-	   << std::endl;
+  TpcReadoutInit(runnumber);
+  std::cout << " run: " << runnumber
+            << " samples: " << TRACKING::reco_tpc_maxtime_sample
+            << " pre: " << TRACKING::reco_tpc_time_presample
+            << " vdrift: " << G4TPC::tpc_drift_velocity_reco
+            << std::endl;
 
   // distortion calibration mode
   /*
@@ -112,9 +112,9 @@ void Fun4All_TrackAnalysis(
   }
 
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
-  //to turn on the default static corrections, enable the two lines below
-  //G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  //G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS = false;
+  // to turn on the default static corrections, enable the two lines below
+  // G4TPC::ENABLE_STATIC_CORRECTIONS = true;
+  // G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS = false;
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
@@ -164,22 +164,21 @@ void Fun4All_TrackAnalysis(
     if (G4TRACKING::SC_CALIBMODE)
     {
       /*
-      * in calibration mode, calculate residuals between TPC and fitted tracks,
-      * store in dedicated structure for distortion correction
-      */
+       * in calibration mode, calculate residuals between TPC and fitted tracks,
+       * store in dedicated structure for distortion correction
+       */
       auto residuals = new PHTpcResiduals;
       const TString tpc_residoutfile = theOutfile + "_PhTpcResiduals.root";
       residuals->setOutputfile(tpc_residoutfile.Data());
       residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
 
       // matches Tony's analysis
-      residuals->setMinPt( 0.2 );
+      residuals->setMinPt(0.2);
 
       // reconstructed distortion grid size (phi, r, z)
       residuals->setGridDimensions(36, 48, 80);
       se->registerSubsystem(residuals);
     }
-
   }
 
   auto finder = new PHSimpleVertexFinder;
@@ -200,11 +199,13 @@ void Fun4All_TrackAnalysis(
   resid->alignment(false);
 
   // adjust track map name
-  if(G4TRACKING::SC_CALIBMODE && !G4TRACKING::convert_seeds_to_svtxtracks)
+  if (G4TRACKING::SC_CALIBMODE && !G4TRACKING::convert_seeds_to_svtxtracks)
   {
     resid->trackmapName("SvtxSiliconMMTrackMap");
-    if( G4TRACKING::SC_USE_MICROMEGAS )
-    { resid->set_doMicromegasOnly(true); }
+    if (G4TRACKING::SC_USE_MICROMEGAS)
+    {
+      resid->set_doMicromegasOnly(true);
+    }
   }
 
   resid->clusterTree();

--- a/TrackingProduction/Fun4All_TrackAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackAnalysis.C
@@ -1,8 +1,8 @@
 /*
- * This macro shows a minimum working example of running the tracking
- * hit unpackers with some basic seeding algorithms to try to put together
- * tracks. There are some analysis modules run at the end which package
- * hits, clusters, and clusters on tracks into trees for analysis.
+ * This macro shows a minimum working example of running track fitting over
+ * the production cluster and track seed DSTs.. There are some analysis 
+ * modules run at the end which package clusters, and clusters on tracks 
+ * into trees for analysis.
  */
 
 #include <fun4all/Fun4AllUtils.h>
@@ -52,7 +52,7 @@ void Fun4All_TrackAnalysis(
     const std::string clusterfilename = "DST_TRKR_CLUSTER_run2pp_new_2024p007-00051520-00000.root",
     const std::string dir = "/sphenix/lustre01/sphnxpro/physics/slurp/tracking/new_2024p007/run_00051500_00051600/",
     const std::string outfilename = "clusters_seeds",
-    const bool convertSeeds = true)
+    const bool convertSeeds = false)
 {
   std::string inputseedRawHitFile = dir + seedfilename;
   std::string inputclusterRawHitFile = dir + clusterfilename;

--- a/TrackingProduction/Fun4All_TrackAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackAnalysis.C
@@ -31,8 +31,8 @@
 
 #include <tpccalib/PHTpcResiduals.h>
 
-#include <trackingqa/TpcSeedQA.h>
-#include <trackingqa/SiliconSeedQA.h>
+#include <trackingqa/TpcSeedsQA.h>
+#include <trackingqa/SiliconSeedsQA.h>
 #include <trackingqa/TpcSiliconQA.h>
 
 #include <trackingdiagnostics/TrackResiduals.h>
@@ -46,7 +46,7 @@ R__LOAD_LIBRARY(libphool.so)
 R__LOAD_LIBRARY(libcdbobjects.so)
 R__LOAD_LIBRARY(libTrackingDiagnostics.so)
 R__LOAD_LIBRARY(libtrackingqa.so)
-void Fun4All_FieldOnAllTrackers(
+void Fun4All_TrackAnalysis(
     const int nEvents = 10,
     const std::string seedfilename = "DST_TRKR_SEED_run2pp_new_2024p007-00051520-00000.root",
     const std::string clusterfilename = "DST_TRKR_CLUSTER_run2pp_new_2024p007-00051520-00000.root",
@@ -54,7 +54,8 @@ void Fun4All_FieldOnAllTrackers(
     const std::string outfilename = "clusters_seeds",
     const bool convertSeeds = true)
 {
-  std::string inputtpcRawHitFile = dir + seedfilename;
+  std::string inputseedRawHitFile = dir + seedfilename;
+  std::string inputclusterRawHitFile = dir + clusterfilename;
 
   G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
   std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
@@ -118,10 +119,13 @@ void Fun4All_FieldOnAllTrackers(
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 
-  auto hitsin = new Fun4AllDstInputManager("InputManager");
-  hitsin->fileopen(inputtpcRawHitFile);
-  // hitsin->AddFile(inputMbd);
-  se->registerInputManager(hitsin);
+  auto hitsinseed = new Fun4AllDstInputManager("SeedInputManager");
+  hitsinseed->fileopen(inputseedRawHitFile);
+  se->registerInputManager(hitsinseed);
+
+  auto hitsinclus = new Fun4AllDstInputManager("ClusterInputManager");
+  hitsinclus->fileopen(inputclusterRawHitFile);
+  se->registerInputManager(hitsinclus);
 
   /*
    * Either converts seeds to tracks with a straight line/helix fit

--- a/TrackingProduction/Fun4All_TrackAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackAnalysis.C
@@ -1,0 +1,231 @@
+/*
+ * This macro shows a minimum working example of running the tracking
+ * hit unpackers with some basic seeding algorithms to try to put together
+ * tracks. There are some analysis modules run at the end which package
+ * hits, clusters, and clusters on tracks into trees for analysis.
+ */
+
+#include <fun4all/Fun4AllUtils.h>
+#include <G4_ActsGeom.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <GlobalVariables.C>
+#include <QA.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/recoConsts.h>
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <tpccalib/PHTpcResiduals.h>
+
+#include <trackingqa/TpcSeedQA.h>
+#include <trackingqa/SiliconSeedQA.h>
+#include <trackingqa/TpcSiliconQA.h>
+
+#include <trackingdiagnostics/TrackResiduals.h>
+#include <trackingdiagnostics/TrkrNtuplizer.h>
+
+#include <stdio.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+R__LOAD_LIBRARY(libcdbobjects.so)
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
+R__LOAD_LIBRARY(libtrackingqa.so)
+void Fun4All_FieldOnAllTrackers(
+    const int nEvents = 10,
+    const std::string seedfilename = "DST_TRKR_SEED_run2pp_new_2024p007-00051520-00000.root",
+    const std::string clusterfilename = "DST_TRKR_CLUSTER_run2pp_new_2024p007-00051520-00000.root",
+    const std::string dir = "/sphenix/lustre01/sphnxpro/physics/slurp/tracking/new_2024p007/run_00051500_00051600/",
+    const std::string outfilename = "clusters_seeds",
+    const bool convertSeeds = true)
+{
+  std::string inputtpcRawHitFile = dir + seedfilename;
+
+  G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
+  std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
+  std::pair<int, int>
+      runseg = Fun4AllUtils::GetRunSegment(seedfilename);
+  int runnumber = runseg.first;
+  int segment = runseg.second;
+
+  TpcReadoutInit( runnumber );
+  std::cout<< " run: " << runnumber
+	   << " samples: " << TRACKING::reco_tpc_maxtime_sample
+	   << " pre: " << TRACKING::reco_tpc_time_presample
+	   << " vdrift: " << G4TPC::tpc_drift_velocity_reco
+	   << std::endl;
+
+  // distortion calibration mode
+  /*
+   * set to true to enable residuals in the TPC with
+   * TPC clusters not participating to the ACTS track fit
+   */
+  G4TRACKING::SC_CALIBMODE = false;
+
+  ACTSGEOM::mvtxMisalignment = 100;
+  ACTSGEOM::inttMisalignment = 100.;
+  ACTSGEOM::tpotMisalignment = 100.;
+  TString outfile = outfilename + "_" + runnumber + "-" + segment + ".root";
+  std::string theOutfile = outfile.Data();
+  auto se = Fun4AllServer::instance();
+  se->Verbosity(1);
+  auto rc = recoConsts::instance();
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+  CDBInterface *cdb = CDBInterface::instance();
+  std::string tpc_dv_calib_dir = cdb->getUrl("TPC_DRIFT_VELOCITY");
+  if (tpc_dv_calib_dir.empty())
+  {
+    std::cout << "No calibrated TPC drift velocity for Run " << runnumber << ". Use default value " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
+  }
+  else
+  {
+    CDBTTree *cdbttree = new CDBTTree(tpc_dv_calib_dir);
+    cdbttree->LoadCalibrations();
+    G4TPC::tpc_drift_velocity_reco = cdbttree->GetSingleFloatValue("tpc_drift_velocity");
+    std::cout << "Use calibrated TPC drift velocity for Run " << runnumber << ": " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
+  }
+
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+  //to turn on the default static corrections, enable the two lines below
+  //G4TPC::ENABLE_STATIC_CORRECTIONS = true;
+  //G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS = false;
+
+  G4MAGNET::magfield_rescale = 1;
+  TrackingInit();
+
+  auto hitsin = new Fun4AllDstInputManager("InputManager");
+  hitsin->fileopen(inputtpcRawHitFile);
+  // hitsin->AddFile(inputMbd);
+  se->registerInputManager(hitsin);
+
+  /*
+   * Either converts seeds to tracks with a straight line/helix fit
+   * or run the full Acts track kalman filter fit
+   */
+  if (G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    auto converter = new TrackSeedTrackMapConverter;
+    // Default set to full SvtxTrackSeeds. Can be set to
+    // SiliconTrackSeedContainer or TpcTrackSeedContainer
+    converter->setTrackSeedName("SvtxTrackSeedContainer");
+    converter->setFieldMap(G4MAGNET::magfield_tracking);
+    converter->Verbosity(0);
+    se->registerSubsystem(converter);
+  }
+  else
+  {
+    auto deltazcorr = new PHTpcDeltaZCorrection;
+    deltazcorr->Verbosity(0);
+    se->registerSubsystem(deltazcorr);
+
+    // perform final track fit with ACTS
+    auto actsFit = new PHActsTrkFitter;
+    actsFit->Verbosity(0);
+    actsFit->commissioning(G4TRACKING::use_alignment);
+    // in calibration mode, fit only Silicons and Micromegas hits
+    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_use_clustermover(true);  // default is true for now
+    actsFit->useActsEvaluator(false);
+    actsFit->useOutlierFinder(false);
+    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
+    se->registerSubsystem(actsFit);
+
+    if (G4TRACKING::SC_CALIBMODE)
+    {
+      /*
+      * in calibration mode, calculate residuals between TPC and fitted tracks,
+      * store in dedicated structure for distortion correction
+      */
+      auto residuals = new PHTpcResiduals;
+      const TString tpc_residoutfile = theOutfile + "_PhTpcResiduals.root";
+      residuals->setOutputfile(tpc_residoutfile.Data());
+      residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+
+      // matches Tony's analysis
+      residuals->setMinPt( 0.2 );
+
+      // reconstructed distortion grid size (phi, r, z)
+      residuals->setGridDimensions(36, 48, 80);
+      se->registerSubsystem(residuals);
+    }
+
+  }
+
+  auto finder = new PHSimpleVertexFinder;
+  finder->Verbosity(0);
+  finder->setDcaCut(0.5);
+  finder->setTrackPtCut(-99999.);
+  finder->setBeamLineCut(1);
+  finder->setTrackQualityCut(1000000000);
+  finder->setNmvtxRequired(3);
+  finder->setOutlierPairCut(0.1);
+  se->registerSubsystem(finder);
+
+  TString residoutfile = theOutfile + "_resid.root";
+  std::string residstring(residoutfile.Data());
+
+  auto resid = new TrackResiduals("TrackResiduals");
+  resid->outfileName(residstring);
+  resid->alignment(false);
+
+  // adjust track map name
+  if(G4TRACKING::SC_CALIBMODE && !G4TRACKING::convert_seeds_to_svtxtracks)
+  {
+    resid->trackmapName("SvtxSiliconMMTrackMap");
+    if( G4TRACKING::SC_USE_MICROMEGAS )
+    { resid->set_doMicromegasOnly(true); }
+  }
+
+  resid->clusterTree();
+  resid->convertSeeds(G4TRACKING::convert_seeds_to_svtxtracks);
+  resid->Verbosity(0);
+  se->registerSubsystem(resid);
+
+  if (Enable::QA)
+  {
+    se->registerSubsystem(new SiliconSeedsQA);
+    se->registerSubsystem(new TpcSeedsQA);
+    se->registerSubsystem(new TpcSiliconQA);
+  }
+  se->run(nEvents);
+  se->End();
+  se->PrintTimer();
+
+  if (Enable::QA)
+  {
+    TString qaname = theOutfile + "_qa.root";
+    std::string qaOutputFileName(qaname.Data());
+    QAHistManagerDef::saveQARootFile(qaOutputFileName);
+  }
+
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+}


### PR DESCRIPTION
As discussed in last week's tracking meeting, here is a macro that one can use to run over the cluster and track seed DSTs. For people who are less familiar with the details of the tracking code, this is a smaller macro that uses the higher level production DST files and just runs the track fitting + tree dump. It is naturally therefore much faster and simpler. You can still choose whether or not to use Acts or a helix fit in the track fitting.