### PR TITLE
allowing radian vs cm control for both static and average maps

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackers.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers.C
@@ -124,7 +124,13 @@ void Fun4All_FieldOnAllTrackers(
 
   //to turn on the default static corrections, enable the two lines below
   //G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  //G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS = false;
+  //G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
+
+  //to turn on the average corrections derived from simulation, enable the three lines below
+  //note: these are designed to be used only if static corrections are also applied
+  //G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
+  //G4TPC::USE_PHI_AS_RAD_AVERAGE_CORRECTIONS = false;
+/ //G4TPC:average_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/average_minus_static_distortion_inverted_10-new.root";
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();

--- a/TrackingProduction/Fun4All_FieldOnAllTrackers.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers.C
@@ -130,7 +130,7 @@ void Fun4All_FieldOnAllTrackers(
   //note: these are designed to be used only if static corrections are also applied
   //G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
   //G4TPC::USE_PHI_AS_RAD_AVERAGE_CORRECTIONS = false;
-/ //G4TPC:average_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/average_minus_static_distortion_inverted_10-new.root";
+  //G4TPC:average_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/average_minus_static_distortion_inverted_10-new.root";
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -110,13 +110,12 @@ namespace G4TPC
   // distortions
   bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
 
-  // static distortions
+  // apply static distortions in simulations
   bool ENABLE_STATIC_DISTORTIONS = false;
-  bool USE_PHI_AS_RAD_STATIC_CORRECTIONS = true;
 
   std::string static_distortion_filename = "TPC_STATIC_DISTORTION";
 
-  // time-ordered distortion fluctuations
+  // apply time-ordered distortion fluctuations in simulation
   bool ENABLE_TIME_ORDERED_DISTORTIONS = false;
   std::string time_ordered_distortion_filename = "TPC_TIMEORDERED_DISTORTION";
 
@@ -129,6 +128,7 @@ namespace G4TPC
   // static distortion corrections
   bool ENABLE_STATIC_CORRECTIONS = false;
   std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
+  bool USE_PHI_AS_RAD_STATIC_CORRECTIONS = true;
 
   // average distortion corrections
   bool ENABLE_AVERAGE_CORRECTIONS = false;

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -107,8 +107,9 @@ namespace G4TPC
   // use simple clusterizer
   bool USE_SIMPLE_CLUSTERIZER = false;
 
-  // distortions
-  //bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
+  // distortions in simulation
+  // set how to interpret the magnitude of phi distortions in simulation
+  bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
 
   // apply static distortions in simulations
   bool ENABLE_STATIC_DISTORTIONS = false;
@@ -119,6 +120,7 @@ namespace G4TPC
   bool ENABLE_TIME_ORDERED_DISTORTIONS = false;
   std::string time_ordered_distortion_filename = "TPC_TIMEORDERED_DISTORTION";
 
+  // allow distortions to remove electrons that 
   bool ENABLE_REACHES_READOUT = true;
 
   // module edge distortion corrections

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -108,7 +108,7 @@ namespace G4TPC
   bool USE_SIMPLE_CLUSTERIZER = false;
 
   // distortions
-  bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
+  //bool DISTORTIONS_USE_PHI_AS_RADIANS = true;
 
   // apply static distortions in simulations
   bool ENABLE_STATIC_DISTORTIONS = false;

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -112,6 +112,8 @@ namespace G4TPC
 
   // static distortions
   bool ENABLE_STATIC_DISTORTIONS = false;
+  bool USE_PHI_AS_RAD_STATIC_CORRECTIONS = true;
+
   std::string static_distortion_filename = "TPC_STATIC_DISTORTION";
 
   // time-ordered distortion fluctuations
@@ -131,6 +133,7 @@ namespace G4TPC
   // average distortion corrections
   bool ENABLE_AVERAGE_CORRECTIONS = false;
   std::string average_correction_filename;
+  bool USE_PHI_AS_RAD_AVERAGE_CORRECTIONS = true;
 
   // enable central membrane g4hits generation
   bool ENABLE_CENTRAL_MEMBRANE_HITS = true;

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -26,7 +26,9 @@ void TrackingInit()
     auto se = Fun4AllServer::instance();
     auto tpcLoadDistortionCorrection = new TpcLoadDistortionCorrection;
 
-    tpcLoadDistortionCorrection->set_read_phi_as_radians(TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS);
+    tpcLoadDistortionCorrection->set_read_phi_as_radians(TpcLoadDistortionCorrection::DistortionType_Static, G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS);
+    tpcLoadDistortionCorrection->set_read_phi_as_radians(TpcLoadDistortionCorrection::DistortionType_Average, G4TPC::USE_PHI_AS_RAD_AVERAGE_CORRECTIONS);
+
     tpcLoadDistortionCorrection->set_interpolate_2D_to_zero(TpcLoadDistortionCorrection::DistortionType_ModuleEdge, false);
 
     if (G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS)


### PR DESCRIPTION
We didn't anticipate using the simulated average spacecharge correction, which is intended to come from direct processing of data, so this pull req adds flags to control reading those files, which were not previously present in the macros.  This also harmonize the naming of the flags used to control the input type for the static correction with those used for the average correction.

