### PR TITLE
Revert "Turn on diffuse laser clustering"

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -133,7 +133,7 @@ namespace G4TPC
   std::string average_correction_filename;
 
   // enable central membrane g4hits generation
-  bool ENABLE_CENTRAL_MEMBRANE_HITS = true;
+  bool ENABLE_CENTRAL_MEMBRANE_HITS = false;
 
   // enable direct laser g4hits generation
   bool ENABLE_DIRECT_LASER_HITS = false;


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/macros#932 as it wreaks havoc on the QA, need to understand why