### PR TITLE
fix: extend strobe to 10 mus

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -97,7 +97,7 @@ void Mvtx_Cells()
   PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
   maps_hits->Verbosity(verbosity);
 
-  double maps_readout_window = 10000.0;  // ns
+  double maps_readout_window = 9900.0;  // ns
   double extended_readout_time = 0.0;
   if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   // override the default timing window - default is +/- 5000 ns

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -97,7 +97,7 @@ void Mvtx_Cells()
   PHG4MvtxHitReco* maps_hits = new PHG4MvtxHitReco("MVTX");
   maps_hits->Verbosity(verbosity);
 
-  double maps_readout_window = 5000.0;  // ns
+  double maps_readout_window = 10000.0;  // ns
   double extended_readout_time = 0.0;
   if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   // override the default timing window - default is +/- 5000 ns


### PR DESCRIPTION
We didn't run any physics data with a 5 mus strobe, so setting 10 mus as the default for now.