### PR TITLE
2024 beam xing angle and vertex distribution

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -89,7 +89,7 @@ namespace Input
   bool COSMIC = false;
   double COSMIC_R = 650.;
 
-  //! apply reference sPHENIX nominal beam parameter with 2mrad crossing as defined in sPH-TRG-2022-001 and past RHIC experience
+  //! apply reference sPHENIX nominal beam parameter with 1.5mrad crossing as used in 2024
   //! \param[in] HepMCGen any HepMC generator, e.g. Fun4AllHepMCInputManager, Fun4AllHepMCPileupInputManager, PHPythia8, PHPythia6, ReadEICFiles
   //! \param[in] collision_type select the beam configuration with Input::BeamConfiguration
   void ApplysPHENIXBeamParameter(PHHepMCGenHelper *HepMCGen, const Input::BeamConfiguration & beam_config)
@@ -99,40 +99,55 @@ namespace Input
       std::cout << "ApplysPHENIXBeamParameter(): Fatal Error - null input pointer HepMCGen" << std::endl;
       exit(1);
     }
-    HepMCGen->set_beam_direction_theta_phi(1e-3, 0, M_PI - 1e-3, 0);  //2mrad x-ing of sPHENIX per sPH-TRG-2022-001
 
     switch (beam_config)
     {
     case AA_COLLISION:
       // heavy ion mode
 
+      // 1.5mRad is split among both beams, means set to 0.75 mRad
+      HepMCGen->set_beam_direction_theta_phi(0.75e-3, 0, M_PI - 0.75e-3, 0);  //1.5mrad x-ing of sPHENIX
       HepMCGen->set_vertex_distribution_width(
-          100e-4,         // approximation from past STAR/Run16 AuAu data
-          100e-4,         // approximation from past STAR/Run16 AuAu data
-          7,              // sPH-TRG-2022-001. Fig B.2
-          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+	100e-4,         // approximation from past STAR/Run16 AuAu data
+	100e-4,         // approximation from past STAR/Run16 AuAu data
+	7,              // sPH-TRG-2022-001. Fig B.2
+	20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
     case pA_COLLISION:
 
       // pA mode
 
+      // 1.5mRad is split among both beams, means set to 0.75 mRad
+      HepMCGen->set_beam_direction_theta_phi(0.75e-3, 0, M_PI - 0.75e-3, 0);  //1.5mrad x-ing of sPHENIX
       HepMCGen->set_vertex_distribution_width(
-          100e-4,         // set to be similar to AA
-          100e-4,         // set to be similar to AA
-          8,              // sPH-TRG-2022-001. Fig B.4
-          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+	100e-4,         // set to be similar to AA
+	100e-4,         // set to be similar to AA
+	8,              // sPH-TRG-2022-001. Fig B.4
+	20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
     case pp_COLLISION:
 
       // pp mode
+      // 1.5mRad is split among both beams, means set to 0.75 mRad
+      HepMCGen->set_beam_direction_theta_phi(0.75e-3, 0, M_PI - 0.75e-3, 0);  //1.5mrad x-ing of sPHENIX
+      HepMCGen->set_vertex_distribution_width(
+	120e-4,         // approximation from past PHENIX data
+	120e-4,         // approximation from past PHENIX data
+	16,              // measured in 2024 for 1.5mrad Xing angle
+	20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+
+      break;
+    case pp_ZEROANGLE:
+
+      // pp mode
 
       HepMCGen->set_vertex_distribution_width(
-          120e-4,         // approximation from past PHENIX data
-          120e-4,         // approximation from past PHENIX data
-          10,              // sPH-TRG-2022-001. Fig B.3
-          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+	120e-4,         // approximation from past PHENIX data
+	120e-4,         // approximation from past PHENIX data
+	65,              // measured in 2024 for 0 Xing angle
+	20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
     default:
@@ -143,10 +158,10 @@ namespace Input
     }
 
     HepMCGen->set_vertex_distribution_function(
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus,
-        PHHepMCGenHelper::Gaus);
+      PHHepMCGenHelper::Gaus,
+      PHHepMCGenHelper::Gaus,
+      PHHepMCGenHelper::Gaus,
+      PHHepMCGenHelper::Gaus);
   }
 
   //! apply sPHENIX nominal beam parameter according to the beam collision setting of Input::IS_PP_COLLISION

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -22,8 +22,9 @@ namespace Input
   enum BeamConfiguration
   {
     AA_COLLISION = 0,
-    pA_COLLISION,
-    pp_COLLISION
+    pA_COLLISION = 1,
+    pp_COLLISION = 2,
+    pp_ZEROANGLE = 3
   };
 
   BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;


### PR DESCRIPTION
This PR sets the beam crossing angle to what was used in 2024 (1.5mRad), adds zero crossing angle selection (pp_ZEROANGLE) to select the no crossing angle for our jet triggered calo only dataset