### PR TITLE
Implementation of caloTreeGen Into QA System

### DIFF
--- a/CaloProduction/Fun4All_Year2_Calib.C
+++ b/CaloProduction/Fun4All_Year2_Calib.C
@@ -51,7 +51,7 @@ R__LOAD_LIBRARY(libglobalQA.so)
 R__LOAD_LIBRARY(libcaloTreeGen.so)
 
 void Fun4All_Year2_Calib(int nEvents=100,
-                   const std::string &fname = "/sphenix/lustre01/sphnxpro/physics/slurp/caloy2fitting/ana437_2024p007/run_00047700_00047800/DST_CALOFITTING_run2pp_ana437_2024p007-00047791-00154.root",
+                   const std::string &fname = "DST_CALOFITTING-00000000-000000.root",
                    const std::string& outfile= "DST_CALO-00000000-000000.root",
                    const std::string& outfile_hist= "HIST_CALOQA-00000000-000000.root",
 		   const std::string& outfile_tree= "TREE_CALOQA-00000000-000000.root",

--- a/CaloProduction/Fun4All_Year2_Calib.C
+++ b/CaloProduction/Fun4All_Year2_Calib.C
@@ -34,6 +34,7 @@
 
 #include <calovalid/CaloValid.h>
 #include <globalqa/GlobalQA.h>
+#include <calotreegen/caloTreeGen.h> 
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
@@ -47,11 +48,13 @@ R__LOAD_LIBRARY(libzdcinfo.so)
 R__LOAD_LIBRARY(libglobalvertex.so)
 R__LOAD_LIBRARY(libcalovalid.so)
 R__LOAD_LIBRARY(libglobalQA.so)
+R__LOAD_LIBRARY(libcaloTreeGen.so)
 
 void Fun4All_Year2_Calib(int nEvents=100,
-                   const std::string &fname = "DST_CALOFITTING-00000000-000000.root",
+                   const std::string &fname = "/sphenix/lustre01/sphnxpro/physics/slurp/caloy2fitting/ana437_2024p007/run_00047700_00047800/DST_CALOFITTING_run2pp_ana437_2024p007-00047791-00154.root",
                    const std::string& outfile= "DST_CALO-00000000-000000.root",
                    const std::string& outfile_hist= "HIST_CALOQA-00000000-000000.root",
+		   const std::string& outfile_tree= "TREE_CALOQA-00000000-000000.root",
                    const std::string& dbtag= "ProdA_2024"
   )
 {
@@ -109,6 +112,23 @@ void Fun4All_Year2_Calib(int nEvents=100,
   CaloValid *ca = new CaloValid("CaloValid");
   ca->set_timing_cut_width(200);
   se->registerSubsystem(ca);
+
+  caloTreeGen *caloTree = new caloTreeGen(outfile_tree);
+  //enable subsystems
+  caloTree->doEMCal(1, "TOWERINFO_CALIB_CEMC");
+  caloTree->doClusters(1, "CLUSTERINFO_CEMC");
+  caloTree->doHCals(1, "TOWERINFO_CALIB_HCALOUT", "TOWERINFO_CALIB_HCALIN");
+  caloTree->doZDC(1, "TOWERINFO_CALIB_ZDC");
+  caloTree->doTrig(1, "GL1Packet");
+
+  //set subsystem cuts
+  caloTree->setEMCalThresh(0.7);
+  caloTree->setClusterThresh(0.5);
+  caloTree->doClusterDetails(1);
+  caloTree->setOHCalThresh(0.5);
+  caloTree->setIHCalThresh(0.1);
+  
+  se->registerSubsystem(caloTree);
 
   GlobalQA *gqa = new GlobalQA("GlobalQA");
   se->registerSubsystem(gqa);


### PR DESCRIPTION
This macro takes the previous caloTreeGen and moves it to the QA section of coresoftware, where it can ride alongside the production and produce nTuples for fast analysis. Some specifics:

For Run 22 it will amount to approximately 60TB of additional output, adding an additional 4% of data. It runs over 100 events from each segment. 

It currently gathers tower-by-tower information for the EMCal, HCal, and ZDC, as well as cluster information from the EMCal. In order to decrease data volume, the following thresholds are in place:

EMCal tower: 0.07GeV
EMCal Cluster: 0.500GeV
OHCal Tower: 0.500GeV
IHCal tower: 0.100GeV

With no cuts on the ZDC information because it has so few towers. Really the EMCal benefits from this cut the most. I will merge the corresponding primary macro and production macro after this has been run by Blair and the software meeting. 


