### PR TITLE
djl -- added trigger runinfo to year2 macro

### DIFF
--- a/CaloProduction/Fun4All_Year2.C
+++ b/CaloProduction/Fun4All_Year2.C
@@ -39,6 +39,7 @@
 
 #include <centrality/CentralityReco.h>
 #include <calotrigger/MinimumBiasClassifier.h>
+#include <calotrigger/TriggerRunInfoReco.h>
 
 #include <calovalid/CaloValid.h>
 #include <globalqa/GlobalQA.h>
@@ -82,6 +83,8 @@ void Fun4All_Year2(int nEvents=100,
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
 
+  TriggerRunInfoReco *triggerruninforeco = new TriggerRunInfoReco();
+  se->registerSubsystem(triggerruninforeco);
   // MBD/BBC Reconstruction
   MbdReco *mbdreco = new MbdReco();
   se->registerSubsystem(mbdreco);

--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -15,14 +15,16 @@
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
 #include <fun4all/SubsysReco.h>
+#include <calotrigger/TriggerRunInfoReco.h>
 
 #include <phool/recoConsts.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
+R__LOAD_LIBRARY(libcalotrigger.so)
 // this pass containis the reco process that's stable wrt time stamps(raw tower building)
 void Fun4All_Year2_Fitting(int nEvents = 100,
-                   const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_new_2024p003-00048185-0000.root",
+			   const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_new_2024p003-00048185-0000.root",
                    const std::string &outfile = "DST_CALOFITTING-00000000-000000.root",
                    const std::string &dbtag = "ProdA_2024")
 {
@@ -41,6 +43,10 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
+
+  // Get info from DB and store in DSTs
+  TriggerRunInfoReco *triggerinfo = new TriggerRunInfoReco();
+  se->registerSubsystem(triggerinfo);
 
   Process_Calo_Fitting();
 


### PR DESCRIPTION
This adds the trigger run info to the Year2 macro. Before anything else to ensure any module that wants to use the trigger info has access to the TriggerRunInfo node. 

At this moment, it prints out the trigger menu with names, prescales and scalers to the output file.