### PR TITLE
Update to Fun4All_Year2_Fitting macro to include QA module 

### DIFF
--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -23,7 +23,7 @@
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
-R__LOAD_LIBRARY(libcalofittingqa.so)
+R__LOAD_LIBRARY(libcalovalid.so)
 // this pass containis the reco process that's stable wrt time stamps(raw tower building)
 void Fun4All_Year2_Fitting(int nEvents = 100,
                    const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_new_2024p003-00048185-0000.root",

--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -1,6 +1,7 @@
 #ifndef FUN4ALL_YEAR2_FITTING_C
 #define FUN4ALL_YEAR2_FITTING_C
 
+#include <QA.C>
 #include <Calo_Fitting.C>
 
 #include <ffamodules/CDBInterface.h>
@@ -18,16 +19,20 @@
 
 #include <phool/recoConsts.h>
 
+#include <calovalid/CaloFittingQA.h>
+
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
+R__LOAD_LIBRARY(libcalofittingqa.so)
 // this pass containis the reco process that's stable wrt time stamps(raw tower building)
 void Fun4All_Year2_Fitting(int nEvents = 100,
                    const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_new_2024p003-00048185-0000.root",
                    const std::string &outfile = "DST_CALOFITTING-00000000-000000.root",
+                   const std::string& outfile_hist= "HIST_CALOFITTINGQA-00000000-000000.root",
                    const std::string &dbtag = "ProdA_2024")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(1);
+  se->Verbosity(0);
 
   recoConsts *rc = recoConsts::instance();
 
@@ -37,12 +42,18 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
   // conditions DB flags and timestamp
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag);
   rc->set_uint64Flag("TIMESTAMP", runnumber);
-  CDBInterface::instance()->Verbosity(1);
+  CDBInterface::instance()->Verbosity(0);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);
 
   Process_Calo_Fitting();
+
+  ///////////////////////////////////
+  // Validation 
+  CaloFittingQA *ca = new CaloFittingQA("CaloFittingQA");
+  ca->set_debug(false);
+  se->registerSubsystem(ca);
 
   Fun4AllInputManager *In = new Fun4AllDstInputManager("in");
   In->AddFile(fname);
@@ -57,6 +68,8 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
 
   se->run(nEvents);
   se->End();
+
+  QAHistManagerDef::saveQARootFile(outfile_hist);
 
   CDBInterface::instance()->Print();  // print used DB files
   se->PrintTimer();

--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -32,7 +32,7 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
                    const std::string &dbtag = "ProdA_2024")
 {
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(0);
+  se->Verbosity(1);
 
   recoConsts *rc = recoConsts::instance();
 
@@ -42,7 +42,7 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
   // conditions DB flags and timestamp
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag);
   rc->set_uint64Flag("TIMESTAMP", runnumber);
-  CDBInterface::instance()->Verbosity(0);
+  CDBInterface::instance()->Verbosity(1);
 
   FlagHandler *flag = new FlagHandler();
   se->registerSubsystem(flag);


### PR DESCRIPTION
QA module CaloFittingQA (included in coresoftware [here](https://github.com/sPHENIX-Collaboration/coresoftware/pull/3196)) to now be included in Fun4All_Year2_Fitting pass of calorimeter production. Changes to the macro arguments to allow for histogram QA file name in same manner as Fun4All_Year2_Calib macro.