### PR TITLE
do not use quotes for includes in root macros

### DIFF
--- a/detectors/sPHENIX/G4Setup_sPHENIX.C
+++ b/detectors/sPHENIX/G4Setup_sPHENIX.C
@@ -13,7 +13,7 @@
 #include <G4_BeamLine.C>
 #include <G4_Magnet.C>
 #include <G4_PSTOF.C>
-#include "G4_Pipe.C"
+#include <G4_Pipe.C>
 #include <G4_PlugDoor.C>
 #include <G4_TrkrSimulation.C>
 #include <G4_User.C>


### PR DESCRIPTION
Please do not use #include "" for root macros, this breaks our scheme to override default includes with local copies. Always use #include <>