### PR TITLE
feat: set MVTX BCO range automatically

### DIFF
--- a/StreamingProduction/Fun4All_SingleStream_Combiner.C
+++ b/StreamingProduction/Fun4All_SingleStream_Combiner.C
@@ -120,8 +120,6 @@ void Fun4All_SingleStream_Combiner(int nEvents = 0,
       readoutNumber = "MVTX"+felix;
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
 //    mvtx_sngl->Verbosity(5);
-    mvtx_sngl->SetBcoRange(100);
-    mvtx_sngl->SetNegativeBco(100);
 
     mvtx_sngl->setHitContainerName("MVTXRAWHIT_" + felix);
     mvtx_sngl->setRawEventHeaderName("MVTXRAWEVTHEADER_" + felix);

--- a/StreamingProduction/Fun4All_Stream_Combiner.C
+++ b/StreamingProduction/Fun4All_Stream_Combiner.C
@@ -200,9 +200,7 @@ void Fun4All_Stream_Combiner(int nEvents = 5, int RunNumber = 41989,
     if (isGood(iter))
     {
     SingleMvtxPoolInput *mvtx_sngl = new SingleMvtxPoolInput("MVTX_" + to_string(i));
-//    mvtx_sngl->Verbosity(5);
-    mvtx_sngl->SetBcoRange(100);
-    mvtx_sngl->SetNegativeBco(500);
+    //mvtx_sngl->Verbosity(5);
     mvtx_sngl->AddListFile(iter);
     in->registerStreamingInput(mvtx_sngl, InputManagerType::MVTX);
     i++;


### PR DESCRIPTION
The bco ranges are set automatically based on the strobe width extracted from the daq db now, in conjunction with 
https://github.com/sPHENIX-Collaboration/coresoftware/pull/3211