### PR TITLE
Removed flags to set the MVTX to triggered mode

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -11,8 +11,6 @@ namespace Enable
   bool MVTX = false;
   bool MVTX_OVERLAPCHECK = false;
 
-  bool MVTX_TRIGGERED = false; // triggered mode or not (default is streaming mode)
-
   bool MVTX_CELL = false;
   bool MVTX_CLUSTER = false;
   bool MVTX_QA = false;

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -45,8 +45,6 @@ void Mvtx_HitUnpacking(const std::string& felix="")
 
   auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
   mvtxunpacker->Verbosity(verbosity);
-  std::cout << "MvtxCombineRawDataDecoder: run triggered mode? " << Enable::MVTX_TRIGGERED << std::endl;
-  mvtxunpacker->runMvtxTriggered(Enable::MVTX_TRIGGERED);
   if(felix.length() > 0)
     {
       mvtxunpacker->useRawHitNodeName("MVTXRAWHIT_" + felix);


### PR DESCRIPTION
Now that we automatically run a DB query for the MVTX to figure out if it is in triggered or streamed mode as part of the pooling and unpacking modules, we should remove this call from the macros