### PR TITLE
fix: give unique name to each hit unpacker

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -109,7 +109,6 @@ void Tpc_HitUnpacking(const std::string& ebdc="")
   int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
   std::string name = "TpcCombinedRawDataUnpacker"+ebdc;
-  std::cout << "tpc module name " << name <<std::endl;
   auto tpcunpacker = new TpcCombinedRawDataUnpacker("TpcCombinedRawDataUnpacker"+ebdc);
   tpcunpacker->set_presampleShift(TRACKING::reco_tpc_time_presample);
   if(ebdc.length() > 0)

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -43,7 +43,7 @@ void Mvtx_HitUnpacking(const std::string& felix="")
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
+  auto mvtxunpacker = new MvtxCombinedRawDataDecoder("MvtxCombinedRawDataDecoder"+felix);
   mvtxunpacker->Verbosity(verbosity);
   std::cout << "MvtxCombineRawDataDecoder: run triggered mode? " << Enable::MVTX_TRIGGERED << std::endl;
   mvtxunpacker->runMvtxTriggered(Enable::MVTX_TRIGGERED);
@@ -75,7 +75,7 @@ void Intt_HitUnpacking(const std::string& server="")
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  auto inttunpacker = new InttCombinedRawDataDecoder;
+  auto inttunpacker = new InttCombinedRawDataDecoder("InttCombinedRawDataDecoder"+server);
   inttunpacker->Verbosity(verbosity);
   inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
    if(server.length() > 0)
@@ -108,8 +108,9 @@ void Tpc_HitUnpacking(const std::string& ebdc="")
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-
-  auto tpcunpacker = new TpcCombinedRawDataUnpacker;
+  std::string name = "TpcCombinedRawDataUnpacker"+ebdc;
+  std::cout << "tpc module name " << name <<std::endl;
+  auto tpcunpacker = new TpcCombinedRawDataUnpacker("TpcCombinedRawDataUnpacker"+ebdc);
   tpcunpacker->set_presampleShift(TRACKING::reco_tpc_time_presample);
   if(ebdc.length() > 0)
     {


### PR DESCRIPTION
This PR gives a unique name to each hit unpacker, in the event that it is needed (e.g. for running parallel streams)