### PR TITLE
fix: laser identifier before tpc clustering

### DIFF
--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -139,13 +139,14 @@ void Fun4All_FieldOnAllTrackers(
   Mvtx_Clustering();
   Intt_Clustering();
 
+  Tpc_LaserEventIdentifying();
+
   auto tpcclusterizer = new TpcClusterizer;
   tpcclusterizer->Verbosity(0);
   tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
   tpcclusterizer->set_rawdata_reco();
   se->registerSubsystem(tpcclusterizer);
 
-  Tpc_LaserEventIdentifying();
 
   Micromegas_Clustering();
 


### PR DESCRIPTION
This puts the laser identifier in the right place and renames the macro to be more descriptive, pending a new macro to run over higher level DSTs. We'd like to move away from people using this macro to reduce confusion, and to have people run over the higher level fixed build DSTs (e.g. cluster DSTs)