### PR TITLE
use same Micromegas matching cuts accross all macros.

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
@@ -65,10 +65,10 @@ std::string GetFirstLine(std::string listname);
 // > /sphenix/lustre01/sphnxpro/physics/slurp/caloy2test/run_00046700_00046800/DST_CALO_run2pp_new_2024p004-00046730-00001.root
 
 void Fun4All_FieldOnAllTrackersCalos(
-    const int nEvents = 10, 
+    const int nEvents = 10,
     vector<string> myInputLists = {
         "run46730_0000_trkr.txt",
-        "run46730_calo.list"}, 
+        "run46730_calo.list"},
     bool doTpcOnlyTracking = true,
     bool doEMcalRadiusCorr = true,
     const bool convertSeeds = false)
@@ -270,10 +270,10 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
-  mm_match->set_rphi_search_window_lyr1(0.4);
-  mm_match->set_rphi_search_window_lyr2(13.0);
-  mm_match->set_z_search_window_lyr1(26.0);
-  mm_match->set_z_search_window_lyr2(0.4);
+  mm_match->set_rphi_search_window_lyr1(3);
+  mm_match->set_rphi_search_window_lyr2(15);
+  mm_match->set_z_search_window_lyr1(30);
+  mm_match->set_z_search_window_lyr2(3);
 
   mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
   mm_match->set_test_windows_printout(false);  // used for tuning search windows only

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -252,11 +252,10 @@ void Fun4All_FullReconstruction(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
-  mm_match->set_rphi_search_window_lyr1(3.);
-  mm_match->set_rphi_search_window_lyr2(15.0);
-  mm_match->set_z_search_window_lyr1(30.0);
-  mm_match->set_z_search_window_lyr2(3.);
-
+  mm_match->set_rphi_search_window_lyr1(3);
+  mm_match->set_rphi_search_window_lyr2(15);
+  mm_match->set_z_search_window_lyr1(30);
+  mm_match->set_z_search_window_lyr2(3);
   mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
   mm_match->set_test_windows_printout(false);  // used for tuning search windows only
   se->registerSubsystem(mm_match);

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -232,10 +232,10 @@ void Fun4All_TrackSeeding(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
-  mm_match->set_rphi_search_window_lyr1(3.);
-  mm_match->set_rphi_search_window_lyr2(15.0);
-  mm_match->set_z_search_window_lyr1(30.0);
-  mm_match->set_z_search_window_lyr2(3.);
+  mm_match->set_rphi_search_window_lyr1(3);
+  mm_match->set_rphi_search_window_lyr2(15);
+  mm_match->set_z_search_window_lyr1(30);
+  mm_match->set_z_search_window_lyr2(3);
 
   mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
   mm_match->set_test_windows_printout(false);  // used for tuning search windows only
@@ -281,7 +281,7 @@ void Fun4All_TrackSeeding(
 
     auto cleaner = new PHTrackCleaner();
     cleaner->Verbosity(0);
-    cleaner->set_pp_mode(TRACKING::pp_mode);    
+    cleaner->set_pp_mode(TRACKING::pp_mode);
     se->registerSubsystem(cleaner);
 
     if (G4TRACKING::SC_CALIBMODE)
@@ -319,7 +319,7 @@ void Fun4All_TrackSeeding(
      Global_Reco();
 
   //KFParticle setup
-  
+
   KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("myKShortReco");
   kfparticle->Verbosity(1);
   kfparticle->setDecayDescriptor("K_S0 -> pi^+ pi^-");

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -143,7 +143,7 @@ void Fun4All_ZFAllTrackers(
   silicon_match->Verbosity(0);
   silicon_match->set_x_search_window(0.36);
   silicon_match->set_y_search_window(0.36);
-  silicon_match->set_z_search_window(2.5); 
+  silicon_match->set_z_search_window(2.5);
   silicon_match->set_phi_search_window(0.014);
   silicon_match->set_eta_search_window(0.0091);
   silicon_match->set_test_windows_printout(false);
@@ -155,10 +155,10 @@ void Fun4All_ZFAllTrackers(
   mm_match->Verbosity(0);
 
   // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
-  mm_match->set_rphi_search_window_lyr1(0.4);
-  mm_match->set_rphi_search_window_lyr2(13.0);
-  mm_match->set_z_search_window_lyr1(26.0);
-  mm_match->set_z_search_window_lyr2(0.4);
+  mm_match->set_rphi_search_window_lyr1(3);
+  mm_match->set_rphi_search_window_lyr2(15);
+  mm_match->set_z_search_window_lyr1(30);
+  mm_match->set_z_search_window_lyr2(3);
 
   mm_match->set_min_tpc_layer(38);            // layer in TPC to start projection fit
   mm_match->set_test_windows_printout(true);  // used for tuning search windows only

--- a/calibrations/tpc/TpcDVCalib/Fun4All_FieldOnAllTrackersCalos.C
+++ b/calibrations/tpc/TpcDVCalib/Fun4All_FieldOnAllTrackersCalos.C
@@ -58,7 +58,7 @@ void Fun4All_FieldOnAllTrackersCalos(
     const int nEvents = 10,
     vector<string> myInputLists = {
         "run46730_0000_trkr.txt",
-        "run46730_calo.list"}, 
+        "run46730_calo.list"},
     std::string outDir = "./",
     bool doTpcOnlyTracking = true,
     float initial_driftvelocity = 0.00710,
@@ -250,11 +250,10 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(verbosity);
-  mm_match->set_rphi_search_window_lyr1(0.4);
-  mm_match->set_rphi_search_window_lyr2(13.0);
-  mm_match->set_z_search_window_lyr1(26.0);
-  mm_match->set_z_search_window_lyr2(0.4);
-
+  mm_match->set_rphi_search_window_lyr1(3);
+  mm_match->set_rphi_search_window_lyr2(15);
+  mm_match->set_z_search_window_lyr1(30);
+  mm_match->set_z_search_window_lyr2(3);
   mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
   mm_match->set_test_windows_printout(false);  // used for tuning search windows only
   se->registerSubsystem(mm_match);

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -404,22 +404,10 @@ void Tracking_Reco_TrackSeed()
     // Match TPC track stubs from CA seeder to clusters in the micromegas layers
     auto mm_match = new PHMicromegasTpcTrackMatching;
     mm_match->Verbosity(verbosity);
-    if (G4TRACKING::SC_CALIBMODE)
-    {
-      // configuration is potentially with different search windows
-      mm_match->set_rphi_search_window_lyr1(0.2);
-      mm_match->set_rphi_search_window_lyr2(13.0);
-      mm_match->set_z_search_window_lyr1(26.0);
-      mm_match->set_z_search_window_lyr2(0.2);
-    }
-    else
-    {
-      // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
-      mm_match->set_rphi_search_window_lyr1(0.2);
-      mm_match->set_rphi_search_window_lyr2(13.0);
-      mm_match->set_z_search_window_lyr1(26.0);
-      mm_match->set_z_search_window_lyr2(0.2);
-    }
+    mm_match->set_rphi_search_window_lyr1(3);
+    mm_match->set_rphi_search_window_lyr2(15);
+    mm_match->set_z_search_window_lyr1(30);
+    mm_match->set_z_search_window_lyr2(3);
     mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
     mm_match->set_test_windows_printout(false);  // used for tuning search windows only
     se->registerSubsystem(mm_match);
@@ -766,12 +754,10 @@ void Tracking_Reco_CommissioningTrackSeed()
     // Match TPC track stubs from CA seeder to clusters in the micromegas layers
     auto mm_match = new PHMicromegasTpcTrackMatching;
     mm_match->Verbosity(verbosity);
-
-    mm_match->set_rphi_search_window_lyr1(0.4);
-    mm_match->set_rphi_search_window_lyr2(13.0);
-    mm_match->set_z_search_window_lyr1(26.0);
-    mm_match->set_z_search_window_lyr2(0.2);
-
+    mm_match->set_rphi_search_window_lyr1(3);
+    mm_match->set_rphi_search_window_lyr2(15);
+    mm_match->set_z_search_window_lyr1(30);
+    mm_match->set_z_search_window_lyr2(3);
     mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
     mm_match->set_test_windows_printout(false);  // used for tuning search windows only
     se->registerSubsystem(mm_match);

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -249,20 +249,10 @@ void Tracking_Reco_TrackSeed()
       // Match TPC track stubs from CA seeder to clusters in the micromegas layers
       auto mm_match = new PHMicromegasTpcTrackMatching;
       mm_match->Verbosity(verbosity);
-      if (G4TRACKING::SC_CALIBMODE)
-      {
-        // configuration is potentially with different search windows
-        mm_match->set_rphi_search_window_lyr1(0.2);
-        mm_match->set_rphi_search_window_lyr2(13.0);
-        mm_match->set_z_search_window_lyr1(26.0);
-        mm_match->set_z_search_window_lyr2(0.2);
-      } else {
-        // baseline configuration is (0.2, 13.0, 26, 0.2) and is the default
-        mm_match->set_rphi_search_window_lyr1(0.2);
-        mm_match->set_rphi_search_window_lyr2(13.0);
-        mm_match->set_z_search_window_lyr1(26.0);
-        mm_match->set_z_search_window_lyr2(0.2);
-      }
+      mm_match->set_rphi_search_window_lyr1(3);
+      mm_match->set_rphi_search_window_lyr2(15);
+      mm_match->set_z_search_window_lyr1(30);
+      mm_match->set_z_search_window_lyr2(3);
       mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
       mm_match->set_test_windows_printout(false);  // used for tuning search windows only
       se->registerSubsystem(mm_match);
@@ -451,7 +441,7 @@ void Tracking_Reco_CommissioningTrackSeed()
   seeder->SetMinClustersPerTrack(3);
   seeder->useConstBField(false);
   seeder->useFixedClusterError(true);
- 
+
   if (G4TPC::TPC_GAS_MIXTURE == "NeCF4")
   {
     seeder->setNeonFraction(G4TPC::NeCF4_Ne_frac);
@@ -565,12 +555,10 @@ void Tracking_Reco_CommissioningTrackSeed()
       // Match TPC track stubs from CA seeder to clusters in the micromegas layers
       auto mm_match = new PHMicromegasTpcTrackMatching;
       mm_match->Verbosity(verbosity);
-
-      mm_match->set_rphi_search_window_lyr1(0.4);
-      mm_match->set_rphi_search_window_lyr2(13.0);
-      mm_match->set_z_search_window_lyr1(26.0);
-      mm_match->set_z_search_window_lyr2(0.2);
-
+      mm_match->set_rphi_search_window_lyr1(3);
+      mm_match->set_rphi_search_window_lyr2(15);
+      mm_match->set_z_search_window_lyr1(30);
+      mm_match->set_z_search_window_lyr2(3);
       mm_match->set_min_tpc_layer(38);             // layer in TPC to start projection fit
       mm_match->set_test_windows_printout(false);  // used for tuning search windows only
       se->registerSubsystem(mm_match);


### PR DESCRIPTION
Title says it all. 
The cuts are set to match study presented at https://indico.bnl.gov/event/25004/contributions/97983/attachments/58028/99657/tpot_matching.pdf