### PR TITLE
Trigger mode/streaming mode setup added in InttUnpacker

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -44,7 +44,7 @@ void Mvtx_HitUnpacking(const std::string& felix="")
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
 
-  auto mvtxunpacker = new MvtxCombinedRawDataDecoder;
+  auto mvtxunpacker = new MvtxCombinedRawDataDecoder("MvtxCombinedRawDataDecoder"+felix);
   mvtxunpacker->Verbosity(verbosity);
   if(felix.length() > 0)
     {
@@ -73,16 +73,17 @@ void Intt_HitUnpacking(const std::string& server="")
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
+  Fun4AllServer* se = Fun4AllServer::instance();
   auto rc = recoConsts::instance();
   int runnumber = rc->get_IntFlag("RUNNUMBER");
   InttOdbcQuery query;
   bool isStreaming = true;
-  if(runnumber != -1)
+  if(runnumber != 0)
   {
     query.Query(runnumber);
     isStreaming = query.IsStreaming();
   }
-  auto inttunpacker = new InttCombinedRawDataDecoder;
+  auto inttunpacker = new InttCombinedRawDataDecoder("InttCombinedRawDataDecoder"+server);
   inttunpacker->Verbosity(verbosity);
   inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
   inttunpacker->set_triggeredMode(!isStreaming); 
@@ -118,8 +119,8 @@ void Tpc_HitUnpacking(const std::string& ebdc="")
   Fun4AllServer* se = Fun4AllServer::instance();
   std::string name = "TpcCombinedRawDataUnpacker"+ebdc;
   auto tpcunpacker = new TpcCombinedRawDataUnpacker("TpcCombinedRawDataUnpacker"+ebdc);
-  tpcunpacker->set_t0(TRACKING::reco_t0);
   tpcunpacker->set_presampleShift(TRACKING::reco_tpc_time_presample);
+  tpcunpacker->set_t0(TRACKING::reco_t0);
   if(ebdc.length() > 0)
     {
       tpcunpacker->useRawHitNodeName("TPCRAWHIT_" + ebdc);

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -73,7 +73,6 @@ void Intt_HitUnpacking(const std::string& server="")
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-  Fun4AllServer* se = Fun4AllServer::instance();
   auto rc = recoConsts::instance();
   int runnumber = rc->get_IntFlag("RUNNUMBER");
   InttOdbcQuery query;

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -116,8 +116,9 @@ void Tpc_HitUnpacking(const std::string& ebdc="")
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::TPC_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-
-  auto tpcunpacker = new TpcCombinedRawDataUnpacker;
+  std::string name = "TpcCombinedRawDataUnpacker"+ebdc;
+  auto tpcunpacker = new TpcCombinedRawDataUnpacker("TpcCombinedRawDataUnpacker"+ebdc);
+  tpcunpacker->set_t0(TRACKING::reco_t0);
   tpcunpacker->set_presampleShift(TRACKING::reco_tpc_time_presample);
   if(ebdc.length() > 0)
     {
@@ -127,6 +128,7 @@ void Tpc_HitUnpacking(const std::string& ebdc="")
     {
       tpcunpacker->ReadZeroSuppressedData();
     }
+  tpcunpacker->doBaselineCorr(TRACKING::tpc_baseline_corr);
   tpcunpacker->Verbosity(verbosity);
   se->registerSubsystem(tpcunpacker);
 }

--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -27,12 +27,14 @@
 #include <micromegas/MicromegasClusterizer.h>
 
 #include <fun4all/Fun4AllServer.h>
+#include <phool/recoConsts.h>
 
 R__LOAD_LIBRARY(libmvtx.so)
 R__LOAD_LIBRARY(libintt.so)
 R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libmicromegas.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
+R__LOAD_LIBRARY(libphool.so)
 
 void ClusteringInit()
 {


### PR DESCRIPTION
Trigger mode and streaming mode has to be set before hit unpacking.
In order to use INTT triggered mode data, data taking mode is loaded from database and set the data taking mode in unpacker.