### PR TITLE
Set correct TpcClusterZCrossingCorrection::_vdrift in macro level

### DIFF
--- a/common/Trkr_TpcReadoutInit.C
+++ b/common/Trkr_TpcReadoutInit.C
@@ -1,6 +1,7 @@
 #ifndef MACRO_TPCREADOUTINIT_C
 #define MACRO_TPCREADOUTINIT_C
 
+R__LOAD_LIBRARY(libtpc.so)
 R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libtpccalib.so)
 
@@ -49,6 +50,7 @@ void TpcReadoutInit(const int RunNumber = 41989)
     G4TPC::tpc_drift_velocity_reco = cdbttree->GetSingleFloatValue("tpc_drift_velocity");
     std::cout << "Use calibrated TPC drift velocity for Run " << RunNumber << ": " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
   }
+  TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
 
 }
 

--- a/common/Trkr_TpcReadoutInit.C
+++ b/common/Trkr_TpcReadoutInit.C
@@ -10,6 +10,11 @@ R__LOAD_LIBRARY(libtpccalib.so)
 #include <G4_TrkrVariables.C>
 #include <fun4all/Fun4AllServer.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundefined-internal"
+#include <tpc/TpcClusterZCrossingCorrection.h>
+#pragma GCC diagnostic pop
+
 #include <cdbobjects/CDBTTree.h>
 #include <ffamodules/CDBInterface.h>
 void TpcReadoutInit(const int RunNumber = 41989)


### PR DESCRIPTION
As title, the default drift velocity was used in TpcClusterZCrossingCorrection module which should be updated in macro