### PR TITLE
fix: run without db tag

### DIFF
--- a/StreamingProduction/Fun4All_Stream_Combiner.C
+++ b/StreamingProduction/Fun4All_Stream_Combiner.C
@@ -127,11 +127,10 @@ void Fun4All_Stream_Combiner(int nEvents = 5, int RunNumber = 41989,
   vector<string> tpot_infile;
   tpot_infile.push_back(input_tpotfile);
 
-  TpcReadoutInit( RunNumber );
+  TpcSampleInit( RunNumber );
   std::cout<< " run: " << RunNumber
 	   << " samples: " << TRACKING::reco_tpc_maxtime_sample
 	   << " pre: " << TRACKING::reco_tpc_time_presample
-	   << " vdrift: " << G4TPC::tpc_drift_velocity_reco
 	   << std::endl;
 
   Fun4AllServer *se = Fun4AllServer::instance();

--- a/common/Trkr_TpcReadoutInit.C
+++ b/common/Trkr_TpcReadoutInit.C
@@ -11,6 +11,21 @@ R__LOAD_LIBRARY(libtpccalib.so)
 
 #include <cdbobjects/CDBTTree.h>
 #include <ffamodules/CDBInterface.h>
+
+void TpcSampleInit(const int RunNumber = 41989)
+{
+  if(RunNumber>=41624)
+  {
+    TRACKING::reco_tpc_maxtime_sample = 425;
+    TRACKING::reco_tpc_time_presample = 40;//120 - 80
+  }
+  else
+    {
+      TRACKING::reco_tpc_maxtime_sample = 420;
+      TRACKING::reco_tpc_time_presample = 0;// 80
+    }
+}
+
 void TpcReadoutInit(const int RunNumber = 41989)
 {
 


### PR DESCRIPTION
This separates the tpc readout init part to only include the relevant pieces for the event combiner, so that we don't have to have a db tag for the event combining