### PR TITLE
I modified the Intt_HitUnpacking to make it able to handle different coll…

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -88,10 +88,16 @@ void Intt_HitUnpacking(const std::string& server="")
   inttunpacker->Verbosity(verbosity);
   inttunpacker->LoadHotChannelMapRemote("INTT_HotMap");
   inttunpacker->set_triggeredMode(!isStreaming); 
-   if(server.length() > 0)
-    {
-      inttunpacker->useRawHitNodeName("INTTRAWHIT_" + server);
-    }
+  if (TRACKING::pp_mode == false) // note : false -> AuAu
+  {
+    inttunpacker->writeInttEventHeader(true);
+    inttunpacker->set_bcoFilter(true); // default : false
+    inttunpacker->runInttStandalone(true); // default: false
+  }
+  if(server.length() > 0)
+  {
+    inttunpacker->useRawHitNodeName("INTTRAWHIT_" + server);
+  }
   se->registerSubsystem(inttunpacker);
 }
 void Intt_Clustering()


### PR DESCRIPTION
…ision type.

The build-in switch `TRACKING::pp_mode` is used to set the collision type. And if the `pp_mode == false`, currently we disable the time_bucket information for the `TrkrHitSets`, and we apply the bco_diff cut to reject the background hits. 