### PR TITLE
Update the track matching windows:

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
@@ -258,11 +258,16 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_use_old_matching(true);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -241,11 +241,16 @@ void Fun4All_FullReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -221,11 +221,16 @@ void Fun4All_TrackSeeding(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 


### PR DESCRIPTION
Matching windows are set to capture about 2xSigma of a Guassiang+constant fit from 0 and are now constant in pT. See presentation file at https://indico.bnl.gov/event/26187/sessions/7878/attachments/59489/102212/2025_01_16_Stewart_TrackingQoverpT.pdf