### PR TITLE
new input file, remove obsolete set_debug call

### DIFF
--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -1,8 +1,12 @@
 #ifndef FUN4ALL_YEAR2_FITTING_C
 #define FUN4ALL_YEAR2_FITTING_C
 
-#include <QA.C>
 #include <Calo_Fitting.C>
+#include <QA.C>
+
+#include <calotrigger/TriggerRunInfoReco.h>
+
+#include <calovalid/CaloFittingQA.h>
 
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
@@ -16,24 +20,22 @@
 #include <fun4all/Fun4AllServer.h>
 #include <fun4all/Fun4AllUtils.h>
 #include <fun4all/SubsysReco.h>
-#include <calotrigger/TriggerRunInfoReco.h>
 
 #include <phool/recoConsts.h>
 
-#include <calovalid/CaloFittingQA.h>
-
-R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libcalovalid.so)
 R__LOAD_LIBRARY(libcalotrigger.so)
-  
+
 // this pass containis the reco process that's stable wrt time stamps(raw tower building)
 void Fun4All_Year2_Fitting(int nEvents = 100,
-			   const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_new_2024p003-00048185-0000.root",
-                   const std::string &outfile = "DST_CALOFITTING-00000000-000000.root",
-                   const std::string& outfile_hist= "HIST_CALOFITTINGQA-00000000-000000.root",
-                   const std::string &dbtag = "ProdA_2024")
+                           const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_ana451_2024p009-00047748-00000.root",
+                           const std::string &outfile = "DST_CALOFITTING_run2pp_ana451_2024p009-00047748-00000.root",
+                           const std::string &outfile_hist = "HIST_CALOFITTINGQA_run2pp_ana451_2024p009-00047748-00000.root",
+                           const std::string &dbtag = "ProdA_2024")
 {
+  gSystem->Load("libg4dst.so");
+
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
 
@@ -57,9 +59,8 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
   Process_Calo_Fitting();
 
   ///////////////////////////////////
-  // Validation 
+  // Validation
   CaloFittingQA *ca = new CaloFittingQA("CaloFittingQA");
-  ca->set_debug(false);
   se->registerSubsystem(ca);
 
   Fun4AllInputManager *In = new Fun4AllDstInputManager("in");


### PR DESCRIPTION
This PR updates the Fun4All_Year2_Fitting.C to use a more recent input file which doesn't generate tons of warnings about missing objects. Removes obsolete set_debug() call (replaced by Verbosity())