### PR TITLE
Updatematchwindows

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
@@ -258,11 +258,16 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_use_old_matching(true);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);

--- a/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
@@ -258,17 +258,12 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(5.0); // was 2.
-  silicon_match->set_y_search_window(5.5); // was 2.
-  silicon_match->set_z_search_window(7.85); // was 5.
-  silicon_match->set_phi_search_window(0.23); // was 0.2
-  silicon_match->set_eta_search_window(0.12); // was 0.1
-  // turn off the track matching inflation in one of two ways:
-  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
-  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
-  // (or just use both as is done below)
-  silicon_match->set_match_window_function_pars(1., 0., 1000.);
-  silicon_match->set_use_old_matching(true);
+  silicon_match->set_x_search_window(5.3); // was 2.
+  silicon_match->set_y_search_window(5.16); // was 2.
+  silicon_match->set_z_search_window(13.6); // was 5.
+  silicon_match->set_phi_search_window(-0.25,0.05); // was 0.2
+  silicon_match->set_eta_search_window(0.18); // was 0.1
+  // silicon_match->set_use_old_matching(true); // this would 
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -241,11 +241,16 @@ void Fun4All_FullReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -241,16 +241,11 @@ void Fun4All_FullReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(5.0); // was 2.
-  silicon_match->set_y_search_window(5.5); // was 2.
-  silicon_match->set_z_search_window(7.85); // was 5.
-  silicon_match->set_phi_search_window(0.23); // was 0.2
-  silicon_match->set_eta_search_window(0.12); // was 0.1
-  // turn off the track matching inflation in one of two ways:
-  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
-  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
-  // (or just use both as is done below)
-  silicon_match->set_match_window_function_pars(1., 0., 1000.);
+  silicon_match->set_x_search_window(5.3); // was 2.
+  silicon_match->set_y_search_window(5.16); // was 2.
+  silicon_match->set_z_search_window(13.6); // was 5.
+  silicon_match->set_phi_search_window(-0.25,0.05); // was 0.2
+  silicon_match->set_eta_search_window(0.18); // was 0.1
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -221,16 +221,11 @@ void Fun4All_TrackSeeding(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(5.0); // was 2.
-  silicon_match->set_y_search_window(5.5); // was 2.
-  silicon_match->set_z_search_window(7.85); // was 5.
-  silicon_match->set_phi_search_window(0.23); // was 0.2
-  silicon_match->set_eta_search_window(0.12); // was 0.1
-  // turn off the track matching inflation in one of two ways:
-  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
-  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
-  // (or just use both as is done below)
-  silicon_match->set_match_window_function_pars(1., 0., 1000.);
+  silicon_match->set_x_search_window(5.3); // was 2.
+  silicon_match->set_y_search_window(5.16); // was 2.
+  silicon_match->set_z_search_window(13.6); // was 5.
+  silicon_match->set_phi_search_window(-0.25,0.05); // was 0.2
+  silicon_match->set_eta_search_window(0.18); // was 0.1
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -221,11 +221,16 @@ void Fun4All_TrackSeeding(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(2.);
-  silicon_match->set_y_search_window(2.);
-  silicon_match->set_z_search_window(5.);
-  silicon_match->set_phi_search_window(0.2);
-  silicon_match->set_eta_search_window(0.1);
+  silicon_match->set_x_search_window(5.0); // was 2.
+  silicon_match->set_y_search_window(5.5); // was 2.
+  silicon_match->set_z_search_window(7.85); // was 5.
+  silicon_match->set_phi_search_window(0.23); // was 0.2
+  silicon_match->set_eta_search_window(0.12); // was 0.1
+  // turn off the track matching inflation in one of two ways:
+  // 1: ->set_match_window_function_pars(<anynumber>, <anynumber>, 1000.)
+  // 2: ->set_match_window_function_pars(1., 0., <anynumber>)
+  // (or just use both as is done below)
+  silicon_match->set_match_window_function_pars(1., 0., 1000.);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(silicon_match);
 

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -127,11 +127,11 @@ void Fun4All_ZFAllTrackers(
 
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_x_search_window(0.36);
-  silicon_match->set_y_search_window(0.36);
-  silicon_match->set_z_search_window(2.5);
-  silicon_match->set_phi_search_window(0.014);
-  silicon_match->set_eta_search_window(0.0091);
+  silicon_match->set_x_search_window(0.36); // was 0.36
+  silicon_match->set_y_search_window(0.36); // was 0.36
+  silicon_match->set_z_search_window(2.5);  // was 2.5
+  silicon_match->set_phi_search_window(0.014); // was 0.014
+  silicon_match->set_eta_search_window(0.0091); // was 0.0091
   silicon_match->set_test_windows_printout(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   silicon_match->zeroField(true);


### PR DESCRIPTION
as per our group meeting, I did the analysis for +/- 3 sigma for constant width windows, and also added an option to set the phi matching window to have two parameters (be asymmetric). See [slides here](https://indico.bnl.gov/event/26188/contributions/101570/attachments/59507/102239/2025_01_17_Stewart_Tracking.pdf) for the selections.

This is a draft until the PR for core-software is merged which updates the phi search window to take two separate parameters.