### PR TITLE
Calo_Calib.C - Added MC Tower Status for CEMC

### DIFF
--- a/common/Calo_Calib.C
+++ b/common/Calo_Calib.C
@@ -47,6 +47,20 @@ void Process_Calo_Calib()
   CaloTowerStatus *statusEMC = new CaloTowerStatus("CEMCSTATUS");
   statusEMC->set_detector_type(CaloTowerDefs::CEMC);
   statusEMC->set_time_cut(1);
+  // MC Towers Status
+  if(isSim) {
+    // Uses threshold of 50% for towers be considered frequently bad.
+    std::string calibName_hotMap = "CEMC_hotTowers_status";
+    /* Systematic options (to be used as needed). */
+    /* Uses threshold of 40% for towers be considered frequently bad. */
+    // std::string calibName_hotMap = "CEMC_hotTowers_status_40";
+
+    /* Uses threshold of 60% for towers be considered frequently bad. */
+    // std::string calibName_hotMap = "CEMC_hotTowers_status_60";
+
+    std::string calibdir = CDBInterface::instance()->getUrl(calibName_hotMap);
+    statusEMC->set_directURL_hotMap(calibdir);
+  }
   se->registerSubsystem(statusEMC);
 
   CaloTowerStatus *statusHCalIn = new CaloTowerStatus("HCALINSTATUS");


### PR DESCRIPTION
- For simulation runs added a default bad tower map that is generated from the average live area of the EMCal over run 24 pp.
- Use of systematic variations are also possible as detailed in the comments.
- Reference (JS TG Update 01/22/25): https://indico.bnl.gov/event/26310/contributions/101677/attachments/59550/102310/01-22-25-Hot-Tower.pdf
- Reference (Calorimeter Calibrations Update 12/09/24): https://indico.bnl.gov/event/25840/contributions/100349/attachments/59034/101381/12-09-24-Hot-Tower.pdf 