### PR TITLE
Waveform Sim: scale the pedestal noise level to match data

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -244,16 +244,17 @@ void CEMC_Towers()
   int verbosity = std::max(Enable::VERBOSITY, Enable::CEMC_VERBOSITY);
 
   Fun4AllServer *se = Fun4AllServer::instance();
-  if (Enable::CEMC_G4Hit)
-  {
-    RawTowerBuilder *TowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
-    TowerBuilder->Detector("CEMC");
-    TowerBuilder->set_sim_tower_node_prefix("SIM");
-    TowerBuilder->Verbosity(verbosity);
-    se->registerSubsystem(TowerBuilder);
-  }
+
   if (!Enable::CEMC_TOWERINFO)
   {
+    if (Enable::CEMC_G4Hit)
+    {
+      RawTowerBuilder *TowerBuilder = new RawTowerBuilder("EmcRawTowerBuilder");
+      TowerBuilder->Detector("CEMC");
+      TowerBuilder->set_sim_tower_node_prefix("SIM");
+      TowerBuilder->Verbosity(verbosity);
+      se->registerSubsystem(TowerBuilder);
+    }
     double sampling_fraction = 1;
     //      sampling_fraction = 0.02244; //from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.3/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
     //    sampling_fraction = 2.36081e-02;  //from production: /gpfs02/phenix/prod/sPHENIX/preCDR/pro.1-beta.5/single_particle/spacal2d/zerofield/G4Hits_sPHENIX_e-_eta0_8GeV.root
@@ -322,6 +323,15 @@ void CEMC_Towers()
     caloWaveformSim->set_pedestalsamples(12);
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
+    // pedestal scale down for different beam configurations according to Blair
+    if(Input::BEAM_CONFIGURATION == Input::pp_ZEROANGLE)
+    {
+      caloWaveformSim->set_pedestal_scale(0.69);
+    }
+    if(Input::BEAM_CONFIGURATION == Input::pp_COLLISION)
+    {
+      caloWaveformSim->set_pedestal_scale(0.77);
+    }
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
     caloWaveformSim->set_calibName("cemc_pi0_twrSlope_v1_default");
@@ -333,8 +343,8 @@ void CEMC_Towers()
     ca2->set_dataflag(false);
     ca2->set_processing_type(CaloWaveformProcessing::TEMPLATE);
     ca2->set_builder_type(CaloTowerDefs::kWaveformTowerv2);
-    // match our current ZS threshold ~14ADC for emcal
-    ca2->set_softwarezerosuppression(true, 14);
+    // match our current ZS threshold ~60ADC for emcal
+    ca2->set_softwarezerosuppression(true, 60);
     se->registerSubsystem(ca2);
 
     CaloTowerStatus *statusEMC = new CaloTowerStatus("CEMCSTATUS");

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -257,41 +257,42 @@ void HCALInner_Towers()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::HCALIN_VERBOSITY);
   Fun4AllServer *se = Fun4AllServer::instance();
-  if (Enable::HCALIN_G4Hit)
-  {
-    HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalInRawTowerBuilder");
-    TowerBuilder->Detector("HCALIN");
-    TowerBuilder->set_sim_tower_node_prefix("SIM");
-    if (!std::isfinite(G4HCALIN::phistart))
-    {
-      if (Enable::HCALIN_OLD)
-      {
-        G4HCALIN::phistart = 0.0328877688;  // offet in phi (from zero) extracted from geantinos
-      }
-      else
-      {
-        G4HCALIN::phistart = 0.0445549893;  // offet in phi (from zero) extracted from geantinos
-      }
-    }
-    TowerBuilder->set_double_param("phistart", G4HCALIN::phistart);
-    if (std::isfinite(G4HCALIN::tower_emin))
-    {
-      TowerBuilder->set_double_param("emin", G4HCALIN::tower_emin);
-    }
-    if (G4HCALIN::tower_energy_source >= 0)
-    {
-      TowerBuilder->set_int_param("tower_energy_source", G4HCALIN::tower_energy_source);
-    }
-    // this sets specific decalibration factors
-    // for a given cell
-    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
-    // for a whole tower
-    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
-    TowerBuilder->Verbosity(verbosity);
-    se->registerSubsystem(TowerBuilder);
-  }
+  
   if (!Enable::HCALIN_TOWERINFO)
   {
+    if (Enable::HCALIN_G4Hit)
+    {
+      HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalInRawTowerBuilder");
+      TowerBuilder->Detector("HCALIN");
+      TowerBuilder->set_sim_tower_node_prefix("SIM");
+      if (!std::isfinite(G4HCALIN::phistart))
+      {
+        if (Enable::HCALIN_OLD)
+        {
+          G4HCALIN::phistart = 0.0328877688;  // offet in phi (from zero) extracted from geantinos
+        }
+        else
+        {
+          G4HCALIN::phistart = 0.0445549893;  // offet in phi (from zero) extracted from geantinos
+        }
+      }
+      TowerBuilder->set_double_param("phistart", G4HCALIN::phistart);
+      if (std::isfinite(G4HCALIN::tower_emin))
+      {
+        TowerBuilder->set_double_param("emin", G4HCALIN::tower_emin);
+      }
+      if (G4HCALIN::tower_energy_source >= 0)
+      {
+        TowerBuilder->set_int_param("tower_energy_source", G4HCALIN::tower_energy_source);
+      }
+      // this sets specific decalibration factors
+      // for a given cell
+      // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+      // for a whole tower
+      // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+      TowerBuilder->Verbosity(verbosity);
+      se->registerSubsystem(TowerBuilder);
+    }
     // From 2016 Test beam sim
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalInRawTowerDigitizer");
     TowerDigitizer->Detector("HCALIN");

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -290,44 +290,45 @@ void HCALOuter_Towers()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::HCALOUT_VERBOSITY);
   Fun4AllServer *se = Fun4AllServer::instance();
-  // build the raw tower anyways for the geom nodes
-  if (Enable::HCALOUT_G4Hit)
-  {
-    HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalOutRawTowerBuilder");
-    TowerBuilder->Detector("HCALOUT");
-    TowerBuilder->set_sim_tower_node_prefix("SIM");
-    if (!isfinite(G4HCALOUT::phistart))
-    {
-      if (Enable::HCALOUT_OLD)
-      {
-        G4HCALOUT::phistart = 0.026598397;  // offet in phi (from zero) extracted from geantinos
-      }
-      else
-      {
-        G4HCALOUT::phistart = 0.0240615415;  // offet in phi (from zero) extracted from geantinos
-      }
-    }
-    TowerBuilder->set_double_param("phistart", G4HCALOUT::phistart);
-    if (isfinite(G4HCALOUT::tower_emin))
-    {
-      TowerBuilder->set_double_param("emin", G4HCALOUT::tower_emin);
-    }
-    if (G4HCALOUT::tower_energy_source >= 0)
-    {
-      TowerBuilder->set_int_param("tower_energy_source", G4HCALOUT::tower_energy_source);
-    }
-    // this sets specific decalibration factors
-    // for a given cell
-    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
-    // for a whole tower
-    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
-    // TowerBuilder->set_cell_decal_factor(1,10,0.1);
-    // TowerBuilder->set_tower_decal_factor(0,10,0.2);
-    TowerBuilder->Verbosity(verbosity);
-    se->registerSubsystem(TowerBuilder);
-  }
+  
   if (!Enable::HCALOUT_TOWERINFO)
   {
+    // build the raw tower anyways for the geom nodes
+  if (Enable::HCALOUT_G4Hit)
+    {
+      HcalRawTowerBuilder *TowerBuilder = new HcalRawTowerBuilder("HcalOutRawTowerBuilder");
+      TowerBuilder->Detector("HCALOUT");
+      TowerBuilder->set_sim_tower_node_prefix("SIM");
+      if (!isfinite(G4HCALOUT::phistart))
+      {
+        if (Enable::HCALOUT_OLD)
+        {
+          G4HCALOUT::phistart = 0.026598397;  // offet in phi (from zero) extracted from geantinos
+        }
+        else
+        {
+          G4HCALOUT::phistart = 0.0240615415;  // offet in phi (from zero) extracted from geantinos
+        }
+      }
+      TowerBuilder->set_double_param("phistart", G4HCALOUT::phistart);
+      if (isfinite(G4HCALOUT::tower_emin))
+      {
+        TowerBuilder->set_double_param("emin", G4HCALOUT::tower_emin);
+      }
+      if (G4HCALOUT::tower_energy_source >= 0)
+      {
+        TowerBuilder->set_int_param("tower_energy_source", G4HCALOUT::tower_energy_source);
+      }
+      // this sets specific decalibration factors
+      // for a given cell
+      // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+      // for a whole tower
+      // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+      // TowerBuilder->set_cell_decal_factor(1,10,0.1);
+      // TowerBuilder->set_tower_decal_factor(0,10,0.2);
+      TowerBuilder->Verbosity(verbosity);
+      se->registerSubsystem(TowerBuilder);
+    }
     // From 2016 Test beam sim
     RawTowerDigitizer *TowerDigitizer = new RawTowerDigitizer("HcalOutRawTowerDigitizer");
     TowerDigitizer->Detector("HCALOUT");


### PR DESCRIPTION
The current real data based pedestal is an over estimate for the noise level we have in data, this PR scales the pedestal noise level to match the data for 0 mrad and 1.5 mrad crossing data.