### PR TITLE
feat: remove MVTX pruner

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -15,7 +15,6 @@
 
 #include <intt/InttClusterizer.h>
 #include <mvtx/MvtxClusterizer.h>
-#include <mvtx/MvtxHitPruner.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundefined-internal"
@@ -59,11 +58,6 @@ void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
-
-  // prune the extra MVTX hits due to multiple strobes per hit
-  MvtxHitPruner* mvtxhitpruner = new MvtxHitPruner();
-  mvtxhitpruner->Verbosity(verbosity);
-  se->registerSubsystem(mvtxhitpruner);
 
   // For the Mvtx layers
   //================


### PR DESCRIPTION
This PR removes the pruning module from the clustering, as discussed today. It goes with https://github.com/sPHENIX-Collaboration/coresoftware/pull/3409 to produce the results showed in the tracking meeting