### PR TITLE
Revert "feat: remove MVTX pruner"

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -15,6 +15,7 @@
 
 #include <intt/InttClusterizer.h>
 #include <mvtx/MvtxClusterizer.h>
+#include <mvtx/MvtxHitPruner.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundefined-internal"
@@ -58,6 +59,11 @@ void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   Fun4AllServer* se = Fun4AllServer::instance();
+
+  // prune the extra MVTX hits due to multiple strobes per hit
+  MvtxHitPruner* mvtxhitpruner = new MvtxHitPruner();
+  mvtxhitpruner->Verbosity(verbosity);
+  se->registerSubsystem(mvtxhitpruner);
 
   // For the Mvtx layers
   //================


### PR DESCRIPTION
Reverts sPHENIX-Collaboration/macros#1056
This apparently breaks the QA, meaning we aren't ready to remove it from the simulation yet. Will update the corresponding data macros so that they get into the new build