### PR TITLE
Implement TPC time zero offset via alignment transforms in macros

### DIFF
--- a/TrackingProduction/Fun4All_TrackAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackAnalysis.C
@@ -97,6 +97,10 @@ void Fun4All_TrackAnalysis(
   se->registerInputManager(ingeo);
 
   TpcReadoutInit( runnumber );
+  // these lines show how to override the drift velocity and time offset values set in TpcReadoutInit
+  // G4TPC::tpc_drift_velocity_reco = 0.0073844; // cm/ns
+  // TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
+  // G4TPC::tpc_tzero_reco = -5*50;  // ns
 
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -76,6 +76,10 @@ void Fun4All_TrackSeeding(
   std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
 
   TpcReadoutInit(runnumber);
+ // these lines show how to override the drift velocity and time offset values set in TpcReadoutInit
+  // G4TPC::tpc_drift_velocity_reco = 0.0073844; // cm/ns
+  // TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
+  // G4TPC::tpc_tzero_reco = -5*50;  // ns
   std::cout << " run: " << runnumber
             << " samples: " << TRACKING::reco_tpc_maxtime_sample
             << " pre: " << TRACKING::reco_tpc_time_presample

--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -52,6 +52,7 @@ namespace ACTSGEOM
     // Geometry must be built before any Acts modules
     MakeActsGeometry* geom = new MakeActsGeometry();
     geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
+    geom->set_tpc_tzero(G4TPC::tpc_tzero_reco);
     geom->Verbosity(verbosity);
     for (int i = 0; i < 57; i++)
     {

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -107,6 +107,7 @@ namespace G4MICROMEGAS
 namespace G4TPC
 {
   double tpc_drift_velocity_reco = 8.0 / 1000.0;  // cm/ns   // this is the Ne version of the gas, it is very close to our Ar-CF4 mixture
+  double tpc_tzero_reco = 0.0;  // ns  
 }
 
 namespace G4TRACKING

--- a/common/Trkr_TpcReadoutInit.C
+++ b/common/Trkr_TpcReadoutInit.C
@@ -60,18 +60,31 @@ void TpcReadoutInit(const int RunNumber = 41989)
 
   std::string tpc_dv_calib_dir = CDBInterface::instance()->getUrl("TPC_DRIFT_VELOCITY");
   if (tpc_dv_calib_dir.empty())
-  {
-    std::cout << "No calibrated TPC drift velocity for Run " << RunNumber << ". Use default value " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
-  }
+    {
+      std::cout << "No calibrated TPC drift velocity for Run " << RunNumber << ". Use default value " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
+    }
   else
-  {
-    CDBTTree *cdbttree = new CDBTTree(tpc_dv_calib_dir);
-    cdbttree->LoadCalibrations();
-    G4TPC::tpc_drift_velocity_reco = cdbttree->GetSingleFloatValue("tpc_drift_velocity");
-    std::cout << "Use calibrated TPC drift velocity for Run " << RunNumber << ": " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
-  }
+    {
+      CDBTTree *cdbttree = new CDBTTree(tpc_dv_calib_dir);
+      cdbttree->LoadCalibrations();
+      G4TPC::tpc_drift_velocity_reco = cdbttree->GetSingleFloatValue("tpc_drift_velocity");
+      std::cout << "Use calibrated TPC drift velocity for Run " << RunNumber << ": " << G4TPC::tpc_drift_velocity_reco << " cm/ns" << std::endl;
+    }
+  // either way
   TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
 
+  std::string tpc_tzero_calib_dir = CDBInterface::instance()->getUrl("TPC_TZERO_OFFSET");
+  if (tpc_tzero_calib_dir.empty())
+    {
+      std::cout << "No calibrated TPC time zero for Run " << RunNumber << ". Use default value " << G4TPC::tpc_tzero_reco << " ns" << std::endl;
+    }
+  else
+    {
+      CDBTTree *cdbttree = new CDBTTree(tpc_tzero_calib_dir);
+      cdbttree->LoadCalibrations();
+      G4TPC::tpc_tzero_reco = cdbttree->GetSingleFloatValue("tpc_tzero");
+      std::cout << "Use calibrated TPC time offset for Run " << RunNumber << ": " << G4TPC::tpc_tzero_reco << " ns" << std::endl;
+    }
 }
 
 


### PR DESCRIPTION
Accompanies coresoftware PR #3438, should not be merged until after that.

Enables the application of the TPC time zero offset using alignment transforms.