### PR TITLE
handle ppg02 sims

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -154,6 +154,20 @@ namespace Input
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
+
+    case ppg02:
+      Input::beam_crossing = 1.;  // +1 mRad for late 2024 with triggered readout for mvtx
+      localbcross = Input::beam_crossing / 2. * 1e-3;
+      //  Xing angle is split among both beams, means set to 0.5 mRad
+      HepMCGen->set_beam_direction_theta_phi(localbcross, 0, M_PI - localbcross, 0);  // 1.5mrad x-ing of sPHENIX
+      HepMCGen->set_vertex_distribution_mean(-0.022,0.223, -4.03, 0.);
+      HepMCGen->set_vertex_distribution_width(
+          120e-4,         // approximation from past PHENIX data
+          120e-4,         // approximation from past PHENIX data
+          9.358,             // measured by intt
+          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+      break;
+      
     default:
       std::cout << "ApplysPHENIXBeamParameter: invalid beam_config = " << beam_config << std::endl;
 
@@ -242,6 +256,7 @@ namespace INPUTHEPMC
   bool FERMIMOTION = false;
   bool HIJINGFLIP = false;
   bool REACTIONPLANERAND = false;
+  float HEPMC_STRANGENESS_FRACTION = -1.;
 
 }  // namespace INPUTHEPMC
 
@@ -557,6 +572,10 @@ void InputRegister()
     }
     // copy HepMC records into G4
     HepMCNodeReader *hr = new HepMCNodeReader();
+    if (INPUTHEPMC::HEPMC_STRANGENESS_FRACTION >= 0)
+    {
+      hr->AddStrangeness(INPUTHEPMC::HEPMC_STRANGENESS_FRACTION);
+    }
     se->registerSubsystem(hr);
   }
 }

--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -1,0 +1,46 @@
+#ifndef MACRO_G4RUNSETTINGS
+#define MACRO_G4RUNSETTINGS
+
+#include <GlobalVariables.C>
+
+#include <G4_Input.C>
+
+void RunSettings(int runnumber, const std::string type = "")
+{
+  switch (runnumber)
+  {
+  case 21: // zero beam xing angle, mvtx rotated
+    Input::BEAM_CONFIGURATION = Input::pp_ZEROANGLE;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    break;
+  case 22: // zero beam xing angle, mvtx rotated
+    Input::BEAM_CONFIGURATION = Input::pp_COLLISION;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    break;    
+  case 24: // single particle sims
+    break;
+  case 25:     // run 25 AuAu: field off
+    G4MAGNET::magfield = "0";
+    break;
+  case 26:     // run 26 ppg02 sims: field off, ppg02 beam settings
+    Input::BEAM_CONFIGURATION = Input::ppg02;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    G4MAGNET::magfield = "0";
+    std::cout << "use ppg02 settings" << std::endl;
+    break;
+  case 27:     // run 27 ppg02 sims: field off, ppg02 beam settings 40% strangeness fraction
+    Input::BEAM_CONFIGURATION = Input::ppg02;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    G4MAGNET::magfield = "0";
+    INPUTHEPMC::HEPMC_STRANGENESS_FRACTION = 40.;
+    std::cout << "use ppg02 settings" << std::endl;
+    break;
+  default:
+    cout << "runnnumber " << runnumber << " not implemented" << endl;
+    gSystem->Exit(1);
+    break;
+  }
+  return;
+}
+
+#endif

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -26,7 +26,8 @@ namespace Input
     AA_COLLISION = 0,
     pA_COLLISION = 1,
     pp_COLLISION = 2,
-    pp_ZEROANGLE = 3
+    pp_ZEROANGLE = 3,
+    ppg02 = 4
   };
 
   BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;


### PR DESCRIPTION
This PR adds hooks to run the ppg02 simulations. (Simulation-) Run dependent settings go into G4_RunSettings.C which can be called from any Fun4All macro in the sim chain, so we keep the settings in one place