### PR TITLE
save git tag given by cmd line

### DIFF
--- a/common/SaveGitTags.C
+++ b/common/SaveGitTags.C
@@ -7,7 +7,15 @@
 
 R__LOAD_LIBRARY(libphool.so)
 
+void SaveGitTags();
 void SetGitTagsFromFile(const std::string &filename);
+
+void SaveGitTags(const std::string &commitid)
+{
+  recoConsts *rc = recoConsts::instance();
+  rc->set_StringFlag("MDC2_GITTAG", commitid);
+  SaveGitTags();
+}
 
 // build the filename from rebuild.info under $OFFLINE_MAIN
 void SaveGitTags()


### PR DESCRIPTION
For the sims we want to save the tag/commit id from the mdc2 macros as well. The SaveGitTags() now takes an optional string argument which is saved under MDC2_GITTAG