### PR TITLE
Bugfix: remove JetQADefs::GL1::Random

### DIFF
--- a/common/Jet_QA.C
+++ b/common/Jet_QA.C
@@ -86,7 +86,6 @@ namespace JetQA
     {JetQADefs::GL1::ZDCS, "zdcs"},
     {JetQADefs::GL1::ZDCN, "zdcn"},
     {JetQADefs::GL1::ZDCNS, "zdcns"},
-    {JetQADefs::GL1::Random, "random"},
     {JetQADefs::GL1::HCalSingle, "hcalsingle"},
     {JetQADefs::GL1::MBDS, "mbds"},
     {JetQADefs::GL1::MBDN, "mbdn"},


### PR DESCRIPTION
This PR removes `JetQADefs::GL1::Random` (which I forgot to do after earlier upstream changes).