### PR TITLE
Update Fun4All_FieldOnAllTrackersCalos.C

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackersCalos.C
@@ -74,9 +74,7 @@ void Fun4All_FieldOnAllTrackersCalos(
     const bool convertSeeds = false)
 {
   gSystem->Load("libg4dst.so");
-
-  int verbosity = 0;
-
+    
   std::cout << "Including " << myInputLists.size() << " files." << std::endl;
   std::string firstfile = GetFirstLine(myInputLists[0]);
   if (*firstfile.c_str() == '\0') return;
@@ -84,6 +82,15 @@ void Fun4All_FieldOnAllTrackersCalos(
   int runnumber = runseg.first;
   int segment = runseg.second;
 
+  auto rc = recoConsts::instance();
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+
+  int verbosity = 0;
+  
   Enable::DSTOUT = false;
   string outputRecoDir = "./inReconstruction/" + to_string(runnumber) + "/";
   string makeDirectory = "mkdir -p " + outputRecoDir;
@@ -113,13 +120,7 @@ void Fun4All_FieldOnAllTrackersCalos(
     se->registerInputManager(infile);
   }
 
-  auto rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", runnumber);
-
-  Enable::CDB = true;
-  rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");
-  rc->set_uint64Flag("TIMESTAMP", runnumber);
-
+  
   std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
 
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");


### PR DESCRIPTION
move "rc->set_StringFlag("CDB_GLOBALTAG", "ProdA_2024");" up in the macro to prevent no CDB tag set error:

( /home/phnxbld/sPHENIX/alma9.2-gcc-14.2.0/ana/source/coresoftware/offline/framework/ffamodules/CDBInterface.cc:125: CDB_GLOBALTAG flag needs to be set via
rc->set_StringFlag("CDB_GLOBALTAG",<global tag>))