### PR TITLE
added MvtxClusterPruner, as a replacement to the removed MvtxHitPruner.

### DIFF
--- a/common/Trkr_Clustering.C
+++ b/common/Trkr_Clustering.C
@@ -15,7 +15,7 @@
 
 #include <intt/InttClusterizer.h>
 #include <mvtx/MvtxClusterizer.h>
-#include <mvtx/MvtxHitPruner.h>
+#include <mvtx/MvtxClusterPruner.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wundefined-internal"
@@ -55,17 +55,23 @@ void Mvtx_HitUnpacking(const std::string& felix="")
     }
   se->registerSubsystem(mvtxunpacker);
 }
+
 void Mvtx_Clustering()
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::MVTX_VERBOSITY);
   auto se = Fun4AllServer::instance();
 
-  // For the Mvtx layers
-  //================
-  auto mvtxclusterizer = new MvtxClusterizer("MvtxClusterizer");
+  // clusterizer
+  auto mvtxclusterizer = new MvtxClusterizer;
   mvtxclusterizer->Verbosity(verbosity);
   se->registerSubsystem(mvtxclusterizer);
+
+  // cluster pruner
+  auto mvtxClusterPruner = new MvtxClusterPruner;
+  mvtxClusterPruner->set_use_strict_matching(true);
+  se->registerSubsystem(mvtxClusterPruner);
 }
+
 void Intt_HitUnpacking(const std::string& server="")
 {
   int verbosity = std::max(Enable::VERBOSITY, Enable::INTT_VERBOSITY);


### PR DESCRIPTION
This macro adds the MvtxClusterPruner in the Mvtx clustering part of the macro, as a replacement for the now removed MvtxHitPruner. 

I'll check the impact on the tracking QA when available, before merging.