### PR TITLE
Remove calls to set_use_legacy_windowing in silicon-tpc matcher. 

### DIFF
--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -277,7 +277,6 @@ void Fun4All_FullReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {

--- a/TrackingProduction/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/Fun4All_PRDFReconstruction.C
@@ -428,7 +428,6 @@ void Fun4All_PRDFReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {

--- a/TrackingProduction/Fun4All_TrackFitting.C
+++ b/TrackingProduction/Fun4All_TrackFitting.C
@@ -134,7 +134,6 @@ void Fun4All_TrackFitting(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -226,7 +226,6 @@ void Fun4All_TrackSeeding(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -132,7 +132,6 @@ void Fun4All_ZFAllTrackers(
 
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   // set search windows matching Silicon to TPC seeds
   // Selected for tracks with ntpc>34,|z_Si-z_TPC|<30,crossing==0
   // see https://indico.bnl.gov/event/26202/attachments/59703/102575/2025_01_31_ZeroField.pdf

--- a/TrackingProduction/run3auau/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/run3auau/Fun4All_PRDFReconstruction.C
@@ -475,7 +475,6 @@ void Fun4All_PRDFReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {

--- a/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
@@ -400,7 +400,6 @@ void Fun4All_raw_hit_KFP(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_use_legacy_windowing(false);
   silicon_match->set_pp_mode(TRACKING::pp_mode);
   if(G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {


### PR DESCRIPTION
The set_use_legacy_windowing method in the silicon-tpc matcher has been removed in coresoftware PR 3669. This macro change does not change any behavior.