### PR TITLE
Add flags to run HCALOUT or HCALIN analysis

### DIFF
--- a/calibrations/calo/hcal_calib_year2/genTSCalib/get_tsFiles_flat.sh
+++ b/calibrations/calo/hcal_calib_year2/genTSCalib/get_tsFiles_flat.sh
@@ -5,9 +5,14 @@ currDir=$PWD
 cosmicsFile=$1 #cosmics runs
 tsFile=$2      #file to write merged TS root files to
 mergeNum=$3    #how many TS files to merge after given cosmics run #
+run_ohcal=$4   # true/false: run HCALOUT
+run_ihcal=$5   # true/false: run HCALIN
+
 
 dummyFile="dummy.txt"  #file to hold first 'x' files after cosmics run # - sort of a staging file to ensure we got right files
-tag="cosmics"          #when searching for merged ts files, make sure to look for "merged_XXXXX.root" and not the merged root files with "cosmics" in name - given we use comsics in the name for this scripts output
+tag="cosmics"          #when searching for merged ts files, make sure to look for "merged_XXXXX.root" and not the merged root files with "cosmics" in name - given we use cosmics in the name for this scripts output
+
+mkdir -p merged
 
 while IFS= read -r line
 do
@@ -16,9 +21,10 @@ do
     echo "${IFS}" 
     x=0  #counter
     incr=$line
-    
+
     #path to LCE output files
-    cd /sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cos_only_tsc_spec_output2/ 
+   # cd /sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cos_only_tsc_spec_output2/
+   cd /sphenix/user/anjsmenon/work/macros/calibrations/calo/hcal_calib_year2/condor_histmaker/out_run/ 
 
     touch $dummyFile
 
@@ -27,8 +33,8 @@ do
 	
 	incr=$(($incr+1))
 
-        if [ $incr -gt 60000 ]; then
-            echo "Incr has exceeded 6000, exiting loop."
+        if [ $incr -gt 70000 ]; then
+            echo "Incr has exceeded 60000, exiting loop."
             break
         fi
 
@@ -42,17 +48,22 @@ do
 	fi
 
     done
+    # Before running hadd, check if dummy.txt is empty
+	if [ ! -s $dummyFile ]; then
+   	     echo "No valid files found for run $line, skipping..."
+              continue
+	fi
 
     echo "Merging these files..."
     cat $dummyFile  
 
     #merge files in dummyFile and send to new text file
-    string="merged/mergedTS_cosmics_$line.root"
+    string="$currDir/merged/mergedTS_cosmics_$line.root"
 
     rm $string 
     bash -c "hadd -f $string @$dummyFile"
 
-    echo "$PWD/$string" >> $tsFile
+    echo "$string" >> $tsFile
 
     rm $dummyFile
 
@@ -62,7 +73,11 @@ mv $tsFile $currDir
 
 #execute fitting macro
 cd $currDir
-root.exe -b -q run_cosmicsTS.C\(\"$cosmicsFile\",\"$tsFile\"\) 
+
+mkdir -p "$currDir/fitResults"
+
+
+root.exe -b -q run_cosmicsTS.C\(\"$cosmicsFile\",\"$tsFile\",$run_ohcal,$run_ihcal\) 
 
 echo "Finished running get_ts_files.sh."
 echo "All done!"

--- a/calibrations/calo/hcal_calib_year2/genTSCalib/run.sh
+++ b/calibrations/calo/hcal_calib_year2/genTSCalib/run.sh
@@ -1,3 +1,8 @@
 # This performs the hadd-ing, fitting, and combining with a cosmics of
 # a set TSC spectra files.  See get_tsFiles_flat.sh for meaning of args
-sh get_tsFiles_flat.sh cos_runs.txt tsc_merge_list.txt 10
+
+
+run_ohcal=$1  # first argument: true/false for HCALOUT
+run_ihcal=$2  # second argument: true/false for HCALIN
+
+sh get_tsFiles_flat.sh cos_runs.txt tsc_merge_list.txt 2 $run_ohcal $run_ihcal

--- a/calibrations/calo/hcal_calib_year2/genTSCalib/run_cosmicsTS.C
+++ b/calibrations/calo/hcal_calib_year2/genTSCalib/run_cosmicsTS.C
@@ -4,8 +4,11 @@
 
 R__LOAD_LIBRARY(libLiteCaloEvalTowSlope.so)
 
+gSystem->mkdir("fitResults", true);
+gSystem->mkdir("cdbFiles", true); 
+
 //make sure TS_list has relative or full paths to actual root files
-void run_cosmicsTS(const char *runs = "runList.txt", const char *TS_list= "lce_output_files.txt")
+void run_cosmicsTS(const char *runs = "runList.txt", const char *TS_list= "lce_output_files.txt", bool run_ohcal=false, bool run_ihcal=false)
 {
   ifstream runlist(runs);
   std::string line;
@@ -16,11 +19,20 @@ void run_cosmicsTS(const char *runs = "runList.txt", const char *TS_list= "lce_o
   //read from run txt file and txt file w/ lce histos at the same time
   while(getline(runlist,line) && getline(tsList,line2))
   {
-    
-    std::string oh_out = "fitResults/oh_cosmicsMerged_fitted_" + line + ".root";
-    std::string ih_out = "fitResults/ih_cosmicsMerged_fitted_" + line + ".root";
+
+    cout << "=============================================" << endl;
+    cout << "Processing run number: " << line << endl;
+
+    if (line.empty() || line2.empty()) continue;  // Skip blank lines
 
     cout << "analysing file " << line2 << endl;
+
+
+    if (run_ohcal){
+
+    std::cout << "Running analysis for **HCALOUT**..." << std::endl;
+
+    std::string oh_out = "fitResults/oh_cosmicsMerged_fitted_" + line + ".root";
   
     LiteCaloEval hout;
     hout.CaloType(LiteCaloEval::HCALOUT);
@@ -29,8 +41,21 @@ void run_cosmicsTS(const char *runs = "runList.txt", const char *TS_list= "lce_o
     hout.setFitMin(0.4);//GeV
     hout.setFitMax(2.5);
     hout.FitRelativeShifts(&hout,110);
-    //hout.draw_spectra(oh_out.c_str());
-    //hout.fit_info(oh_out.c_str(), stoi(line));
+    hout.draw_spectra(oh_out.c_str());
+    hout.fit_info(oh_out.c_str(), stoi(line));
+    
+    string cosmic_CDB_file_oh = Form("/sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cosmicCalibFiles/ohcal_cosmic_calibration_%s.root",line.c_str());
+    
+    //modify the cosmics calibration file based on tsc fit output
+    tsc_cos_merge(oh_out,cosmic_CDB_file_oh,Form("cdbFiles/ohcal_cdb_tsc_cos_calib_%s.root",line.c_str()),0);
+    
+    }
+
+    if (run_ihcal){
+
+    cout << "Running analysis for **HCALIN**..." << std::endl;
+
+    string ih_out = "fitResults/ih_cosmicsMerged_fitted_" + line + ".root";
     
     LiteCaloEval hin;
     hin.CaloType(LiteCaloEval::HCALIN);
@@ -39,20 +64,19 @@ void run_cosmicsTS(const char *runs = "runList.txt", const char *TS_list= "lce_o
     hin.setFitMin(0.20);
     hin.setFitMax(1.5);
     hin.set_doQA(true);
-    //hin.FitRelativeShifts(&hin,110);
-    //hin.draw_spectra(ih_out.c_str());
+    hin.FitRelativeShifts(&hin,110);
+    hin.draw_spectra(ih_out.c_str());
     //hin.fit_info(ih_out.c_str(), stoi(line));
     
 
-    string cosmic_CDB_file_oh = Form("/sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cosmicCalibFiles/ohcal_cosmic_calibration_%s.root",line.c_str());
-    //string cosmic_CDB_file_ih = Form("/sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cosmicCalibFiles/ihcal_cosmic_calibration_%s.root",line.c_str());
-
-    // modify the cosmics calibration file based on tsc fit output
-    tsc_cos_merge(oh_out,cosmic_CDB_file_oh,Form("cdbFiles/ohcal_cdb_tsc_cos_calib_%s.root",line.c_str()),0);
-    //tsc_cos_merge(ih_out,cosmic_CDB_file_ih,Form("ihcal_cdb_tsc_cos_calib_%s.root",line.c_str()),1);
+    string cosmic_CDB_file_ih = Form("/sphenix/u/bseidlitz/work/macros/calibrations/calo/hcal_towerSlope_y2/cosmicCalibFiles/ihcal_cosmic_calibration_%s.root",line.c_str());
+   
+    //modify the cosmics calibration file based on tsc fit output
+    tsc_cos_merge(ih_out,cosmic_CDB_file_ih,Form("cdbFiles/ihcal_cdb_tsc_cos_calib_%s.root",line.c_str()),1);
+    }
 
   }
 
- std:cout << "Macro is done executing." << std::endl;
+std:cout << "Macro is done executing." << std::endl;
   
 }//end macro


### PR DESCRIPTION
Add flags to toggle HCALIN and HCALOUT analysis in run_cosmicsTS workflow
Updated run_cosmicsTS.C, get_tsFiles_flat.sh, and run.sh to support these boolean flags for selectively running HCALIN, HCALOUT. 