### PR TITLE
Fix TPC unpacking skipping segment *39

### DIFF
--- a/TrackingProduction/Fun4All_Cosmics.C
+++ b/TrackingProduction/Fun4All_Cosmics.C
@@ -93,7 +93,7 @@ void Fun4All_Cosmics(
      
       if(filepath.find("ebdc") != std::string::npos)
 	{
-	  if(filepath.find("39") == std::string::npos)
+	  if(filepath.find("ebdc39") == std::string::npos)
 	    {
 	      nTpcFiles++;
 	    }

--- a/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
@@ -159,7 +159,7 @@ void Fun4All_raw_hit_KFP(
 	  }
      if(filepath.find("ebdc") != std::string::npos)
        {
-	 if(filepath.find("39") == std::string::npos)
+	 if(filepath.find("ebdc39") == std::string::npos)
 	   {
 	     nTpcFiles++;
 	   }


### PR DESCRIPTION
Fixed issue that was skipping segment *39 due to issue with identifying TPOT ebdc. Instead of identifying TPC files as ones that contain "ebdc" but not ones that contain "39", still identify as containing "ebdc" but don't include ones that contain "ebdc39"