### PR TITLE
Add Calo/Track-Specific Jet Production Macros

### DIFF
--- a/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_CaloJetProductionYear3.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear3.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_CALOJETPRODUCTIONYEAR3_C
 #define FUN4ALL_CALOJETPRODUCTIONYEAR3_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_JETPRODUCTIONYEAR2_C
 #define FUN4ALL_JETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_JetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_JetProductionYear2_AuAu.C
@@ -1,15 +1,19 @@
 #ifndef FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_JETPRODUCTIONYEAR2_AUAU_C
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <GlobalVariables.C>
 
-// coresoftware headers
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -26,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_JetProductionYear3.C
+++ b/JetProduction/Fun4All_JetProductionYear3.C
@@ -1,15 +1,19 @@
 #ifndef FUN4ALL_JETPRODUCTIONYEAR3_C
 #define FUN4ALL_JETPRODUCTIONYEAR3_C
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <GlobalVariables.C>
 
-// coresoftware headers
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -26,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -1,16 +1,20 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>  // n.b. needed for rho calculation
+#include <NoBkgdSubJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,19 +31,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>  // n.b. needed for rho calculation
-#include <NoBkgdSubJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR2_AUAU_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)

--- a/JetProduction/Fun4All_TrackJetProductionYear3.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear3.C
@@ -1,16 +1,19 @@
 #ifndef FUN4ALL_TRACKJETPRODUCTIONYEAR3_C
 #define FUN4ALL_TRACKJETPRODUCTIONYEAR3_C
 
+#include <GlobalVariables.C>
 
-// c++ utilities
-#include <fstream>
-#include <iostream>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
+#include <G4_ActsGeom.C>
+#include <G4_Centrality.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <HIJetReco.C>
+#include <Jet_QA.C>
+#include <QA.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
 
-// coresoftware headers
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <fun4all/Fun4AllDstInputManager.h>
@@ -27,18 +30,12 @@
 #include <qautils/QAHistManagerDef.h>
 #include <zdcinfo/ZdcReco.h>
 
-// f4a macros
-#include <G4_ActsGeom.C>
-#include <G4_Centrality.C>
-#include <G4_Global.C>
-#include <G4_Magnet.C>
-#include <GlobalVariables.C>
-#include <HIJetReco.C>
-#include <Jet_QA.C>
-#include <QA.C>
-#include <Trkr_Reco.C>
-#include <Trkr_RecoInit.C>
-#include <Trkr_TpcReadoutInit.C>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 // load libraries
 R__LOAD_LIBRARY(libcentrality.so)


### PR DESCRIPTION
This PR back-propagates the calo/track-specific jet production macros introduced in [ProdFlow#115](https://github.com/sPHENIX-Collaboration/ProdFlow/pull/115).