### PR TITLE
If PHActsTrkFitter is run,  then PHActsVertexPropagator must be run

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
@@ -198,6 +198,12 @@ void Fun4All_FieldOnAllTrackers_KFP(
   finder->setOutlierPairCut(0.1);
   se->registerSubsystem(finder);
 
+  // Propagate track positions to the vertex position
+  auto vtxProp = new PHActsVertexPropagator;
+  vtxProp->Verbosity(0);
+  vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+  se->registerSubsystem(vtxProp);
+  
   //KFParticle setup
   KFParticle_sPHENIX *kfparticle = new KFParticle_sPHENIX("myKShortReco");
   kfparticle->Verbosity(1);

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -397,6 +397,12 @@ void Fun4All_FullReconstruction(
   finder->setOutlierPairCut(0.1);
   se->registerSubsystem(finder);
 
+  // Propagate track positions to the vertex position
+  auto vtxProp = new PHActsVertexPropagator;
+  vtxProp->Verbosity(0);
+  vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+  se->registerSubsystem(vtxProp);
+
   TString residoutfile = theOutfile + "_resid.root";
   std::string residstring(residoutfile.Data());
 

--- a/TrackingProduction/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/Fun4All_PRDFReconstruction.C
@@ -529,6 +529,12 @@ void Fun4All_PRDFReconstruction(
   finder->setNmvtxRequired(3);
   finder->setOutlierPairCut(0.1);
   se->registerSubsystem(finder);
+
+  // Propagate track positions to the vertex position
+  auto vtxProp = new PHActsVertexPropagator;
+  vtxProp->Verbosity(0);
+  vtxProp->fieldMap(G4MAGNET::magfield_tracking);
+  se->registerSubsystem(vtxProp);
   
   TString residoutfile = outfilename + "_resid.root";
   std::string residstring(residoutfile.Data());


### PR DESCRIPTION
If PHActsTrkFitter is run,  then PHActsVertexPropagator must be run also, to get the track DCA values right.