### PR TITLE
Update Calo_Calib.C - Propagate isSim flag to CaloTowerStatus

### DIFF
--- a/common/Calo_Calib.C
+++ b/common/Calo_Calib.C
@@ -63,6 +63,7 @@ void Process_Calo_Calib()
 
     std::string calibdir = CDBInterface::instance()->getUrl(calibName_hotMap);
     statusEMC->set_directURL_hotMap(calibdir);
+    statusEMC->set_isSim(true);
   }
   se->registerSubsystem(statusEMC);
 


### PR DESCRIPTION
# Description
Invoke the isSim flag for the EMCal CaloTowerStatus when the run is simulation.

# Links to other PRs in macros and calibration repositories (if applicable)
Related PR in coresoftware: https://github.com/sPHENIX-Collaboration/coresoftware/pull/3741