### PR TITLE
Revert Use of isSim for the CaloTowerStatus

### DIFF
--- a/common/Calo_Calib.C
+++ b/common/Calo_Calib.C
@@ -63,7 +63,6 @@ void Process_Calo_Calib()
 
     std::string calibdir = CDBInterface::instance()->getUrl(calibName_hotMap);
     statusEMC->set_directURL_hotMap(calibdir);
-    statusEMC->set_isSim(true);
   }
   se->registerSubsystem(statusEMC);
 

--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -349,7 +349,6 @@ void CEMC_Towers()
     CaloTowerStatus *statusEMC = new CaloTowerStatus("CEMCSTATUS");
     statusEMC->set_detector_type(CaloTowerDefs::CEMC);
     statusEMC->set_time_cut(1);
-    statusEMC->set_isSim(true);
     se->registerSubsystem(statusEMC);
 
     CaloTowerCalib *calibEMC = new CaloTowerCalib("CEMCCALIB");


### PR DESCRIPTION
This reverts commit ab182f9cea2a1c1b7907b51788f7cfcb2a86f54c and f9c6353dd8a3eb3098b09161f71194d4ef7912dc.