### PR TITLE
feat: add cdb verbosity by default

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -60,7 +60,8 @@ int Fun4All_G4_sPHENIX(
 
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
   PHRandomSeed::Verbosity(1);
-
+  CDBInterface::instance()->Verbosity(1);
+  
   // just if we set some flags somewhere in this macro
   recoConsts *rc = recoConsts::instance();
   // By default every random number generator uses
@@ -736,7 +737,7 @@ int Fun4All_G4_sPHENIX(
   // Exit
   //-----
 
-//  CDBInterface::instance()->Print(); // print used DB files
+  CDBInterface::instance()->Print(); // print used DB files
   se->End();
   std::cout << "All done" << std::endl;
   delete se;


### PR DESCRIPTION
This adds CDB verbosity and file printing by default to our default simulation macro. This should propagate automatically to the QA macros on future PRs