### PR TITLE
Calo-CDB: Refactor Selection Logic

### DIFF
--- a/calibrations/calo/calo_cdb/README.org
+++ b/calibrations/calo/calo_cdb/README.org
@@ -9,7 +9,7 @@ This package automates the generation of the CDB maps for the calorimeters. Spec
 
 ** Steps
 
-1) The ~FileCatalog~ is queried for all runnumber, tag, file paths, and time given a run type and minimum event threshold. By default the run type is set to ~run3auau~ and minimum event threshold is 500k events.
+1) The ~FileCatalog~ is queried for all runnumber, tag, file paths, and time given a run type. By default the run type is set to ~run3auau~.
 2) The result is reduced as follows: Only the tag corresponding to the latest time among duplicate instaces of run numbers is kept. For example, if there are two instances (run, tag, time) of (A,B,C) and (A,D,E) where E > C then (A,B,C) is dropped and only (A,D,E) is kept.
 3) Using the ~filter-datasets~ binary, the CDB (Calibrations Database) is pinged given the run number and specific calibration name. If no result is returned by the CDB or if the tag in the calibration name does not match the latest tag, then the pair of run number and tag is kept to produce the calibration files. Otherwise the pair is removed since the latest calibration already exists in the CDB. A list of all such runs is written to ~{runtype}-process.csv~.
 4) Using the ~{runtype}-process.csv~ file, a unique file is created for each run number which consists of all of the ~HIST_CALOQA~ for that run number.
@@ -26,7 +26,6 @@ This package automates the generation of the CDB maps for the calorimeters. Spec
 To get a quick list of all options allowed, run the script using the ~-h~ flag as follows: ~runProd.py -h~.
 Some key flags:
 - ~--run-type~: By default is set to ~run3auau~ but can also work with ~run2auau~ or ~run2pp~.
-- ~--min-events~: By default is set to ~500k~. Only runs with at least this many events are considered.
 - ~--output~: By default is set to ~test~. This directory is where all relevant log files and condor files are stored.
 - ~--condor-log-dir~: By default is set to ~/tmp/<USER>/dump~. This directory is where the condor log files are stored. As long as the location is under ~/tmp~ it should be fine.
 - ~--do-condor-submit~: By default this is disabled. Enabling this option submits the condor jobs as needed. Useful for embedding the script in a cron job. Note: Jobs are only submitted if there exists a run with outdated or missing calibrations.
@@ -34,10 +33,10 @@ Some key flags:
 
 Example:
 #+begin_src bash
-runProd.py --run-type run3auau --min-events 500000 --output run3auau --verbose
+runProd.py --run-type run3auau --output run3auau --verbose
 #+end_src
 
 Example Cron Job (Once a day at midnight):
 #+begin_src
-0 0 * * * runProd.py --run-type run3auau --min-events 500000 --output run3auau --verbose --do-condor-submit
+0 0 * * * runProd.py --run-type run3auau --output run3auau --verbose --do-condor-submit
 #+end_src


### PR DESCRIPTION
- The `runProd.py` script was refactored to move the complex logic for selecting the highest-priority production tag for each runnumber.
- This logic was offloaded from an inefficient, in-memory pandas operation into a more performant, server-side SQL query using a Common Table Expression (CTE) and a window function.
- The change simplifies the Python code in the `process_df` function, reduces the amount of data transferred from the database, and significantly improves the script's overall performance.