### PR TITLE
fix: acts geom mvtx misalignment setting

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -42,7 +42,7 @@ namespace ACTSGEOM
     {
       G4MICROMEGAS::n_micromegas_layer = 0;
     }
-
+    ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
     MagnetFieldInit();
 
     // Build the Acts geometry


### PR DESCRIPTION
This fixes a bug that happens in some macros where a flag is set but doesn't get propagated down properly
