### PR TITLE
Added scripts to extract pedestal and ZS thresholds from TPOT clock raw data

### DIFF
--- a/calibrations/tpot/ConvertCalibrationToJSon.C
+++ b/calibrations/tpot/ConvertCalibrationToJSon.C
@@ -1,0 +1,92 @@
+R__LOAD_LIBRARY(libmicromegas.so)
+
+#include <micromegas/MicromegasCalibrationData.h>
+
+#include <micromegas/MicromegasCalibrationData.h>
+#include <micromegas/MicromegasMapping.h>
+
+#include <nlohmann/json.hpp>
+
+void ConvertCalibrationToJSon( int runnumber = 74871 )
+{
+
+  const auto inputfile = Form("TPOT_Pedestal-%08i-0000.root", runnumber );
+  const auto outputfile = Form("TPOT_Pedestal-%08i-0000.json", runnumber );
+
+  std::cout << "EvaluateCalibration - inputfile: " << inputfile << std::endl;
+  std::cout << "EvaluateCalibration - outputfile: " << outputfile << std::endl;
+
+  MicromegasCalibrationData m_calibration_data;
+  m_calibration_data.read(inputfile);
+
+  const MicromegasMapping m_mapping;
+
+  static const int nsigma = 5;
+  static const bool use_maximum = true;
+
+  nlohmann::json calib_list;
+  // loop over available fees
+  /// get list of fee ids
+  for( const auto& fee_id:m_mapping.get_fee_id_list() )
+  {
+    double mean_pedestal = 0;
+    double mean_rms = 0;
+
+    double max_pedestal = 0;
+    double max_rms = 0;
+
+    int entries = 0;
+
+    for( int ich = 0; ich < MicromegasDefs::m_nchannels_fee; ++ich )
+    {
+      const auto pedestal = m_calibration_data.get_pedestal( fee_id, ich );
+      const auto rms = m_calibration_data.get_rms( fee_id, ich );
+
+      if(!pedestal || pedestal<20) continue;
+      if(!rms) continue;
+
+      // need to comment out SCOZ - FEE = 8
+      if( fee_id == 8 && ich > 128 ) continue;
+
+      max_pedestal = std::max<double>(max_pedestal,pedestal);
+      max_rms = std::max<double>(max_rms,rms);
+
+      mean_pedestal += pedestal;
+      mean_rms += rms;
+      ++entries;
+    }
+
+    mean_pedestal/=entries;
+    mean_rms/=entries;
+
+    const double mean_threshold = mean_pedestal+nsigma*mean_rms;
+    std::cout
+      << "feid: " << fee_id
+      << " pedestal: " << mean_pedestal
+      << " rms: " << mean_rms
+      << " threshold: " << mean_threshold
+      << " value: " << int( 4.*mean_threshold )
+      << std::endl;
+
+    const double max_threshold = max_pedestal+nsigma*max_rms;
+    std::cout
+      << "feid: " << fee_id
+      << " pedestal: " << max_pedestal
+      << " rms: " << max_rms
+      << " threshold: " << max_threshold
+      << " value: " << int( 4.*max_threshold )
+      << std::endl;
+
+    // cable swap. This is a pain. I do not know how to address this
+    const int fee_id_new = (fee_id == 11) ? 21:fee_id;
+    nlohmann::json calibration = {
+      {"fee_id", fee_id_new },
+      {"threshold", int(4*std::round( use_maximum ? max_threshold:mean_threshold ))}
+    };
+
+    calib_list.emplace_back(calibration);
+  }
+
+  std::ofstream out( outputfile );
+  out << std::setw(2) << calib_list << std::endl;
+}

--- a/calibrations/tpot/ConvertTpotCalibrationToJSon.C
+++ b/calibrations/tpot/ConvertTpotCalibrationToJSon.C
@@ -7,7 +7,7 @@ R__LOAD_LIBRARY(libmicromegas.so)
 
 #include <nlohmann/json.hpp>
 
-void ConvertCalibrationToJSon( int runnumber = 74871 )
+void ConvertTpotCalibrationToJSon( int runnumber = 74871 )
 {
 
   const auto inputfile = Form("TPOT_Pedestal-%08i-0000.root", runnumber );

--- a/calibrations/tpot/Fun4All_TpotCalibration.C
+++ b/calibrations/tpot/Fun4All_TpotCalibration.C
@@ -1,0 +1,85 @@
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <fun4allraw/Fun4AllStreamingInputManager.h>
+#include <fun4allraw/SingleMicromegasPoolInput.h>
+
+#include <phool/recoConsts.h>
+
+#include <micromegas/MicromegasCombinedDataCalibration.h>
+#include <micromegas/MicromegasClusterizer.h>
+
+#include <GlobalVariables.C>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libfun4allraw.so)
+
+//____________________________________________________________________
+int Fun4All_TpotCalibration(
+  const int nEvents = 1000,
+  const char* inputFile = "/sphenix/lustre01/sphnxpro/physics/TPOT/calib/TPOT_ebdc39_calib-00074871-0000.evt",
+  const char* calibrationFile = "TPOT_Pedestal-00074871-0000.root",
+  const char* evaluationFile = "MicromegasCombinedDataCalibration-00074871-0000.root"
+  )
+{
+  // print inputs
+  std::cout << "Fun4All_TpotCalibration - nEvents: " << nEvents << std::endl;
+  std::cout << "Fun4All_TpotCalibration - inputFile: " << inputFile << std::endl;
+  std::cout << "Fun4All_TpotCalibration - calibrationFile: " << calibrationFile << std::endl;
+  std::cout << "Fun4All_TpotCalibration - evaluationFile: " << evaluationFile << std::endl;
+
+  // server
+  auto se = Fun4AllServer::instance();
+  se->Verbosity(1);
+
+  // reco const
+  auto rc = recoConsts::instance();
+
+  // condition database
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG",CDB::global_tag);
+  rc->set_uint64Flag("TIMESTAMP",CDB::timestamp);
+
+  //input
+  auto in = new Fun4AllStreamingInputManager;
+  se->registerInputManager(in);
+  if( true )
+  {
+    // Micromegas single input
+    auto single = new SingleMicromegasPoolInput;
+    single->AddFile(inputFile);
+    in->registerStreamingInput(single, InputManagerType::MICROMEGAS);
+  }
+
+  {
+    // micromegas raw data calibration
+    auto micromegasCombinedDataCalibration = new MicromegasCombinedDataCalibration;
+    micromegasCombinedDataCalibration->set_sample_min(0);
+    micromegasCombinedDataCalibration->set_sample_max(20);
+
+    // calibration output
+    micromegasCombinedDataCalibration->set_calibration_file(calibrationFile);
+
+    // evaluation outpue
+    micromegasCombinedDataCalibration->set_do_evaluation(true);
+    micromegasCombinedDataCalibration->set_evaluation_file(evaluationFile);
+
+    se->registerSubsystem( micromegasCombinedDataCalibration );
+  }
+
+  // process events
+  se->run(nEvents);
+
+  // terminate
+  se->End();
+  se->PrintTimer();
+
+  std::cout << "All done" << std::endl;
+  delete se;
+  gSystem->Exit(0);
+  return 0;
+}
+
+// This function is only used to test if we can load this as root6 macro
+// without running into unresolved libraries and include files
+void RunFFALoadTest() {}


### PR DESCRIPTION
Two macros are added: 
- One macro to run over TPOT raw (non-zero suppressed, baseline-corrected) data, extract per channel mean and RMS suitable for per-channel threshold determination and store them in the right CDBTree object
- One macro to load a TPOT calibration CDBTree object and convert it to a per FEE threshold suitable for FEE configuration online.