### PR TITLE
Adding PPG14 run 36 to G4_RunSettings

### DIFF
--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -72,6 +72,14 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     Input::BEAM_CONFIGURATION = Input::mRad_075;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
+  case 36:  // run 36- ppg14, AuAu 1mRad xing angle, mvtx rotated, flow flucuations enabled, scale factor sqrt(1.3)
+    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    INPUTHEPMC::FLOW_FLUCTUATIONS = true;
+    INPUTHEPMC::FLOW_SCALING = 1.14;
+    std::cout << "use ppg14 run33 settings" << std::endl;
+    break;
+  
   default:
     if (runnumber < 100)
     {

--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -77,7 +77,7 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     Enable::MVTX_APPLYMISALIGNMENT = true;
     INPUTHEPMC::FLOW_FLUCTUATIONS = true;
     INPUTHEPMC::FLOW_SCALING = 1.14;
-    std::cout << "use ppg14 run33 settings" << std::endl;
+    std::cout << "use ppg14 run36 settings" << std::endl;
     break;
   
   default:


### PR DESCRIPTION
This is a small sample configuration for a modified HIJING afterburner with the following settings:
- Event-by-event flow fluctuations enabled
- Vn coefficient scaling = sqrt(1.3)  = 1.14

Intended to run for HIJING MB (type 4) and jet 10,20,30 embedded samples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation

Add configuration support for PPG14 run 36 simulations to the sPHENIX macros so users can produce HIJING minimum-bias and jet-embedded samples (jet energies 10, 20, 30 GeV) with a modified afterburner that includes event-by-event flow fluctuations and an increased Vn scale.

## Key changes

- Added new run configuration case (36) in common/G4_RunSettings.C
- Sets BEAM_CONFIGURATION = AA_COLLISION (Au+Au)
- Enables MVTX_APPLYMISALIGNMENT
- Enables INPUTHEPMC::FLOW_FLUCTUATIONS (event-by-event flow)
- Sets INPUTHEPMC::FLOW_SCALING = 1.14 (√1.3) to scale Vn coefficients
- Updates run settings console message to reference run36

## Potential risk areas

- Event generation / physics modeling: Enabling flow fluctuations and scaling Vn changes underlying event anisotropy and background properties; analyses sensitive to flow (background subtraction, v_n-related observables, efficiency/acceptance studies) should validate with the new settings.
- Reconstruction / analysis impact: Modified background characteristics could affect object reconstruction, embedding studies, and systematic estimates; reprocessing validation is recommended.
- IO / config compatibility: No changes to file formats or public interfaces were introduced; risk is limited to simulation output physics content rather than I/O schema.
- Thread-safety / performance: No concurrent-control or heavy computation changes expected; no performance or thread-safety issues anticipated from this small settings-only change.

## Possible future improvements

- Add automated validation tests or example macros that reproduce key distributions (v_n, multiplicity, jet-related observables) for run36 to assist downstream users.
- Document recommended use cases and known differences vs. previous runs (e.g., run33/run35) in README or release notes.
- Consider parameterizing the FLOW_SCALING factor via config so users can sweep values without editing the source.

Note: This summary was produced with AI assistance—please verify the implemented flags and the console message text (ensure it references run36) as AI outputs can be mistaken.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->