### PR TITLE
Static correction fix

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -128,7 +128,7 @@ namespace G4TPC
 
   // static distortion corrections
   bool ENABLE_STATIC_CORRECTIONS = false;
-  std::string static_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/static_only_inverted_10-new.root";
+  std::string static_correction_filename;
   bool USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   // average distortion corrections
@@ -140,7 +140,6 @@ namespace G4TPC
   bool SaveAllLaminationHists = false;
   bool BFieldOff = false;
 
-  
   // enable central membrane g4hits generation
   bool ENABLE_CENTRAL_MEMBRANE_HITS = false;
 

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -24,7 +24,7 @@ void TrackingInit()
 {
    // server
   auto *se = Fun4AllServer::instance();
-  
+
   std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
 
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
@@ -41,11 +41,18 @@ void TrackingInit()
       std::cout << "Setting reconstruction for data with CDB tag " << rc->get_StringFlag("CDB_GLOBALTAG") << std::endl;
       CDB::is_data_reco = true;
     }
-  
+
   TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
 
   ACTSGEOM::ActsGeomInit();
-  G4TPC::module_edge_correction_filename = CDBInterface::instance()->getUrl("TPC_Module_Edge");
+
+  // initialize module edge correction
+  if( G4TPC::module_edge_correction_filename.empty() )
+  { G4TPC::module_edge_correction_filename = CDBInterface::instance()->getUrl("TPC_Module_Edge"); }
+
+  // initialize static distortion correction
+  if( G4TPC::static_correction_filename.empty() )
+  { G4TPC::module_edge_correction_filename = CDBInterface::instance()->getUrl("TPC_STATIC_CORRECTION_MODEL"); }
 
   // space charge correction
   if (G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS || G4TPC::ENABLE_STATIC_CORRECTIONS || G4TPC::ENABLE_AVERAGE_CORRECTIONS)

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -52,7 +52,7 @@ void TrackingInit()
 
   // initialize static distortion correction
   if( G4TPC::static_correction_filename.empty() )
-  { G4TPC::module_edge_correction_filename = CDBInterface::instance()->getUrl("TPC_STATIC_CORRECTION_MODEL"); }
+  { G4TPC::static_correction_filename = CDBInterface::instance()->getUrl("TPC_STATIC_CORRECTION_MODEL"); }
 
   // space charge correction
   if (G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS || G4TPC::ENABLE_STATIC_CORRECTIONS || G4TPC::ENABLE_AVERAGE_CORRECTIONS)


### PR DESCRIPTION
This PR fetches the static distortion correction file from CDB rather than $CALIBRATION_ROOT directory.
One can still set the file manually in the calling macro, overriding loading the CDB file.
Also slightly modified the logic for the MODULE_EDGE_CORRECTION, also alowing user to specify the file in the calling macro.
Change should be transparent to users.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Static Correction File Loading Refactored to Use CDB

### Motivation / Context
Previously, the TPC static distortion correction file defaulted to a hardcoded path based on the `CALIBRATIONROOT` environment variable. This PR moves the default file loading to the Calibration Database (CDB), allowing the collaboration to manage correction files centrally while maintaining backward compatibility. Users can still override the default by specifying the file path directly in their calling macros.

### Key Changes
- **G4_TrkrVariables.C**: Removed the hardcoded initialization of `G4TPC::static_correction_filename`, now left empty by default
- **Trkr_RecoInit.C**: Added conditional loading logic that populates both `module_edge_correction_filename` and `static_correction_filename` from CDB URLs only if the variables are empty
  - Module edge correction loads from `TPC_Module_Edge` CDB entry if not already set
  - Static correction loads from `TPC_STATIC_CORRECTION_MODEL` CDB entry if not already set
- Minor whitespace formatting corrections

### Risk Areas
- **Reconstruction Behavior**: The correction files are now loaded from CDB instead of local calibration root. Ensure CDB entries for `TPC_STATIC_CORRECTION_MODEL` and `TPC_Module_Edge` are properly populated and current
- **Configuration Flexibility**: Users who relied on the environment variable override path will need to be aware that the new default is CDB; they can still override by setting the variables in their macros before calling `TrackingInit()`
- **Database Dependency**: Reconstruction now explicitly depends on CDB availability for default correction files

### Potential Future Improvements
- Document the migration path for users who may have custom configuration scripts
- Consider providing utilities to validate CDB correction file availability before reconstruction begins
- Monitor for any performance impact from CDB lookups during initialization

**Note**: AI-generated summaries may contain inaccuracies. Please review the actual code changes for complete accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->