### PR TITLE
latest Fun4All_Year2_Fitting.C macro

### DIFF
--- a/CaloProduction/Fun4All_Year2_Fitting.C
+++ b/CaloProduction/Fun4All_Year2_Fitting.C
@@ -8,6 +8,10 @@
 
 #include <calovalid/CaloFittingQA.h>
 
+#include <calopacketskimmer/CaloPacketSkimmer.h>
+
+#include <mbd/MbdReco.h>
+
 #include <ffamodules/CDBInterface.h>
 #include <ffamodules/FlagHandler.h>
 #include <ffamodules/HeadReco.h>
@@ -25,30 +29,32 @@
 
 #include <TSystem.h>
 
+#include <fstream>
+
 R__LOAD_LIBRARY(libfun4allraw.so)
 R__LOAD_LIBRARY(libcalovalid.so)
 R__LOAD_LIBRARY(libcalotrigger.so)
+R__LOAD_LIBRARY(libCaloPacketSkimmer.so)
 
 // this pass containis the reco process that's stable wrt time stamps(raw tower building)
 void Fun4All_Year2_Fitting(int nEvents = 100,
-                           const std::string &fname = "DST_TRIGGERED_EVENT_run2pp_ana451_2024p009-00047748-00000.root",
-                           const std::string &outfile = "DST_CALOFITTING_run2pp_ana451_2024p009-00047748-00000.root",
-                           const std::string &outfile_hist = "HIST_CALOFITTINGQA_run2pp_ana451_2024p009-00047748-00000.root",
-                           const std::string &dbtag = "ProdA_2024")
+                           const std::string &inlist = "files.list",
+                           const std::string &outfile1 = "DST_CALOFITTING_run3oo_pro1_newcdbtag_v008-00082703-00000.root",
+                           const std::string &outfile2 = "DST_ZDC_RAW_run3oo_pro1_newcdbtag_v008-00082703-00000.root",
+                           const std::string &outfile_hist = "HIST_CALOFITTINGQA_run3auau_new_newcdbtag_v008-00082703-00000.root",
+                           const std::string &dbtag = "newcdbtag")
 {
   gSystem->Load("libg4dst.so");
 
   Fun4AllServer *se = Fun4AllServer::instance();
   se->Verbosity(1);
+  se->VerbosityDownscale(10000);
 
   recoConsts *rc = recoConsts::instance();
 
-  std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(fname);
-  int runnumber = runseg.first;
-
   // conditions DB flags and timestamp
   rc->set_StringFlag("CDB_GLOBALTAG", dbtag);
-  rc->set_uint64Flag("TIMESTAMP", runnumber);
+
   CDBInterface::instance()->Verbosity(1);
 
   FlagHandler *flag = new FlagHandler();
@@ -58,6 +64,9 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
   TriggerRunInfoReco *triggerinfo = new TriggerRunInfoReco();
   se->registerSubsystem(triggerinfo);
 
+  CaloPacketSkimmer *calopacket = new CaloPacketSkimmer();
+  se->registerSubsystem(calopacket);
+
   Process_Calo_Fitting();
 
   ///////////////////////////////////
@@ -65,17 +74,61 @@ void Fun4All_Year2_Fitting(int nEvents = 100,
   CaloFittingQA *ca = new CaloFittingQA("CaloFittingQA");
   se->registerSubsystem(ca);
 
-  Fun4AllInputManager *In = new Fun4AllDstInputManager("in");
-  In->AddFile(fname);
-  se->registerInputManager(In);
+  // Fun4AllInputManager *In = new Fun4AllDstInputManager("in");
+  // In->AddFile(fname);
+  // se->registerInputManager(In);
+  Fun4AllInputManager *In = nullptr;
+  std::ifstream infile;
+  infile.open(inlist);
+  int iman = 0;
+  std::string line;
+  if (infile.is_open())
+  {
+    bool first{true};
+    while (std::getline(infile, line))
+    {
+      if (line[0] == '#')
+      {
+        std::cout << "found commented out line " << line << std::endl;
+        continue;
+      }
+      if (first)
+      {
+        std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(line);
+        int runnumber = runseg.first;
+        rc->set_uint64Flag("TIMESTAMP", runnumber);
+        first = false;
+      }
 
-  Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfile);
-  out->StripNode("CEMCPackets");
-  out->StripNode("HCALPackets");
-  out->StripNode("ZDCPackets");
-  out->StripNode("SEPDPackets");
+      std::cout << line << std::endl;
+      std::string magname = "DSTin_" + std::to_string(iman);
+      In = new Fun4AllDstInputManager(magname);
+      In->Verbosity(1);
+      In->AddFile(line);
+      se->registerInputManager(In);
+      iman++;
+    }
+    infile.close();
+  }
+  if (iman == 0)
+  {
+    std::cout << "No files in filelist" << std::endl;
+    gSystem->Exit(1);
+  }
+  Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", outfile1);
+  out->StripCompositeNode("Packets");
+  out->StripNode("12001");
   se->registerOutputManager(out);
-
+  out = new Fun4AllDstOutputManager("DSTOUTzdc", outfile2);
+  out->AddNode("EventHeader");
+  out->AddNode("Sync");
+  out->AddNode("12001");
+  se->registerOutputManager(out);
+  // se->Print();
+  if (nEvents < 0)
+  {
+    return;
+  }
   se->run(nEvents);
   se->End();
 


### PR DESCRIPTION
This is a copy from prodmacros - which we are using for the current calo production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

This PR updates the `Fun4All_Year2_Fitting.C` macro with the latest version from the prodmacros repository, which is actively used for calorimeter production. The update modernizes the macro to handle batch processing workflows and improved data management.

## Key Changes

- **Input handling**: Switched from single file (`fname`) to batch list processing via `inlist` parameter. The macro now reads a text file containing paths to multiple DST inputs, skipping comment lines (starting with `#`).
- **Multiple input managers**: Creates a separate `Fun4AllDstInputManager` for each input file in the list, allowing parallel processing of multiple run segments.
- **Timestamp extraction**: Automatically extracts run/segment information from the first file in the list using `Fun4AllUtils::GetRunSegment()` and sets the `TIMESTAMP` in `recoConsts` accordingly.
- **CaloPacketSkimmer integration**: Adds new `CaloPacketSkimmer` subsystem and loads `libCaloPacketSkimmer.so` for packet-level data filtering.
- **Output refactoring**: Replaces single output with two specialized outputs:
  - **outfile1**: Main DST output with composite "Packets" node stripped and node "12001" removed
  - **outfile2**: Minimal output containing only "EventHeader", "Sync", and node "12001" (likely for ZDC data)
- **Logging optimization**: Adds `VerbosityDownscale(10000)` to reduce log verbosity for production runs.
- **Error handling**: Adds hard-fail behavior if no input files are found in the list (calls `gSystem->Exit(1)`).
- **Early exit**: Added early return when `nEvents < 0` for validation-only runs.

## Potential Risk Areas

- **IO format changes**: The dual-output strategy fundamentally changes the output structure. Downstream analysis code expecting single DST may break if not updated to handle the separate outfile2.
- **Data loss**: Node "12001" is stripped from the main output but preserved in outfile2. Ensure this split doesn't discard needed information for standard analysis workflows.
- **File list dependency**: The macro now hard-fails if the input list file is empty or missing. Production workflows must ensure proper list generation.
- **Timestamp override**: Using only the first file's run segment for the global timestamp may cause issues if processing files from disparate runs. Verify this aligns with production batch composition requirements.
- **Thread safety**: Multiple input managers may affect concurrent processing behavior differently than the original single-file approach.

## Possible Future Improvements

- Add validation that all files in the list belong to the same run segment before processing.
- Consider making the timestamp extraction configurable rather than always using the first file.
- Add logging of which input files are being processed for production auditing.
- Document the expected format and contents of the `inlist` file.

---
*Note: AI-generated analysis has been used; please verify against the actual use case and production requirements, particularly regarding the dual-output structure and node stripping strategy.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->