### PR TITLE
Distortion setup fix

### DIFF
--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -131,12 +131,10 @@ void Fun4All_FullReconstruction(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   // to turn on the average corrections, enable the three lines below
   // note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();

--- a/TrackingProduction/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/Fun4All_PRDFReconstruction.C
@@ -218,18 +218,14 @@ void Fun4All_PRDFReconstruction(
   TRACKING::pp_mode = true;
   G4TRACKING::convert_seeds_to_svtxtracks = false;
   G4TPC::REJECT_LASER_EVENTS = true;
-  
+
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   //to turn on the average corrections, enable the three lines below
   //note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_AVERAGE_CORRECTIONS = true;
-   // to use a custom file instead of the database file:
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
-  
+
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
   TpcReadoutInit(runnumber);
@@ -421,7 +417,7 @@ void Fun4All_PRDFReconstruction(
     converter->setFieldMap(G4MAGNET::magfield_tracking);
     converter->Verbosity(0);
     se->registerSubsystem(converter);
-    
+
     auto *finder = new PHSimpleVertexFinder("SiliconVertexFinder");
     finder->Verbosity(0);
     finder->setDcaCut(0.1);
@@ -434,7 +430,7 @@ void Fun4All_PRDFReconstruction(
     finder->setTrackMapName("SiliconSvtxTrackMap");
     finder->setVertexMapName("SiliconSvtxVertexMap");
     se->registerSubsystem(finder);
-    
+
     auto *siliconqa = new SiliconSeedsQA;
     siliconqa->setTrackMapName("SiliconSvtxTrackMap");
     siliconqa->setVertexMapName("SiliconSvtxVertexMap");
@@ -448,7 +444,7 @@ void Fun4All_PRDFReconstruction(
     convertertpc->setFieldMap(G4MAGNET::magfield_tracking);
     convertertpc->Verbosity(0);
     se->registerSubsystem(convertertpc);
-    
+
     auto *findertpc = new PHSimpleVertexFinder("TpcSimpleVertexFinder");
     findertpc->Verbosity(0);
     findertpc->setDcaCut(1);
@@ -469,7 +465,7 @@ void Fun4All_PRDFReconstruction(
     tpcqa->setSegment(rc->get_IntFlag("RUNSEGMENT"));
     se->registerSubsystem(tpcqa);
 
-    
+
     se->registerSubsystem(new TpcSiliconQA);
     se->registerSubsystem(new TrackFittingQA);
   }

--- a/TrackingProduction/Fun4All_TrackAnalyzer.C
+++ b/TrackingProduction/Fun4All_TrackAnalyzer.C
@@ -100,12 +100,11 @@ void Fun4All_TrackAnalyzer(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   // to turn on the average corrections, enable the three lines below
   // note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
+
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 

--- a/TrackingProduction/Fun4All_TrackCaloAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackCaloAnalysis.C
@@ -95,12 +95,10 @@ void Fun4All_TrackCaloAnalysis(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   //to turn on the average corrections, enable the three lines below
   //note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();

--- a/TrackingProduction/Fun4All_TrackFitting.C
+++ b/TrackingProduction/Fun4All_TrackFitting.C
@@ -105,12 +105,11 @@ void Fun4All_TrackFitting(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   //to turn on the average corrections, enable the three lines below
   //note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
+
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -124,12 +124,10 @@ void Fun4All_TrackSeeding(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   //to turn on the average corrections, enable the three lines below
   //note: these are designed to be used only if static corrections are also applied
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
 
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();

--- a/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
@@ -251,12 +251,10 @@ void Fun4All_raw_hit_KFP(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   // to turn on the average corrections derived from simulation, enable the three lines below
   // note: these are designed to be used only if static corrections are also applied
   // G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  // G4TPC::average_correction_filename = std::string(getenv("CALIBRATIONROOT")) + "/distortion_maps/average_minus_static_distortion_inverted_10-new.root";
 
   G4MAGNET::magfield_rescale = 1;
 

--- a/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
@@ -244,12 +244,10 @@ void Fun4All_raw_hit_KFP(
 
   // to turn on the default static corrections, enable the two lines below
   G4TPC::ENABLE_STATIC_CORRECTIONS = true;
-  G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS = false;
 
   // to turn on the average corrections derived from simulation, enable the three lines below
   // note: these are designed to be used only if static corrections are also applied
   // G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
-  // G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION");
 
   G4MAGNET::magfield_rescale = 1;
 

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -501,6 +501,17 @@ void TPC_Cells()
   auto* edrift = new PHG4TpcElectronDrift;
   edrift->Detector("TPC");
   edrift->Verbosity(verbosity);
+
+  if( G4TPC::ENABLE_STATIC_DISTORTIONS && G4TPC::static_distortion_filename.empty() )
+  {
+    G4TPC::static_distortion_filename = CDBInterface::instance()->getUrl("TPC_STATIC_DISTORTION");
+  }
+
+  if( G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS && G4TPC::time_ordered_distortion_filename.empty() )
+  {
+    G4TPC::time_ordered_distortion_filename = CDBInterface::instance()->getUrl("TPC_TIMEORDERED_DISTORTION");
+  }
+
   if (G4TPC::ENABLE_STATIC_DISTORTIONS || G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS)
   {
     auto* distortionMap = new PHG4TpcDistortion;
@@ -508,22 +519,11 @@ void TPC_Cells()
     distortionMap->set_read_phi_as_radians(G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS);
 
     distortionMap->set_do_static_distortions(G4TPC::ENABLE_STATIC_DISTORTIONS);
-    if (isRootFile(G4TPC::static_distortion_filename))
-    {
-      distortionMap->set_static_distortion_filename(G4TPC::static_distortion_filename);
-    }
-    else
-    {
-      distortionMap->set_static_distortion_filename(CDBInterface::instance()->getUrl(G4TPC::static_distortion_filename));
-    }
-    if (isRootFile(G4TPC::time_ordered_distortion_filename))
-    {
-      distortionMap->set_time_ordered_distortion_filename(G4TPC::time_ordered_distortion_filename);
-    }
-    else
-    {
-      distortionMap->set_time_ordered_distortion_filename(CDBInterface::instance()->getUrl(G4TPC::time_ordered_distortion_filename));
-    }
+    distortionMap->set_static_distortion_filename(CDBInterface::instance()->getUrl(G4TPC::static_distortion_filename));
+
+    distortionMap->set_do_time_ordered_distortions(G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS);
+    distortionMap->set_time_ordered_distortion_filename(G4TPC::time_ordered_distortion_filename);
+
     distortionMap->set_do_ReachesReadout(G4TPC::ENABLE_REACHES_READOUT);
     distortionMap->Init();
     edrift->setTpcDistortion(distortionMap);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -112,12 +112,11 @@ namespace G4TPC
 
   // apply static distortions in simulations
   bool ENABLE_STATIC_DISTORTIONS = false;
-
-  std::string static_distortion_filename = "TPC_STATIC_DISTORTION";
+  std::string static_distortion_filename;
 
   // apply time-ordered distortion fluctuations in simulation
   bool ENABLE_TIME_ORDERED_DISTORTIONS = false;
-  std::string time_ordered_distortion_filename = "TPC_TIMEORDERED_DISTORTION";
+  std::string time_ordered_distortion_filename;
 
   // allow distortions to remove electrons that
   bool ENABLE_REACHES_READOUT = true;
@@ -134,8 +133,9 @@ namespace G4TPC
   // average distortion corrections
   bool ENABLE_AVERAGE_CORRECTIONS = false;
   std::string average_correction_filename;
-  std::string CMStripePattern = "/sphenix/u/bkimelman/CMStripePattern_ideal.root";
   bool USE_PHI_AS_RAD_AVERAGE_CORRECTIONS = true;
+
+  std::string CMStripePattern = "/sphenix/u/bkimelman/CMStripePattern_ideal.root";
   bool average_correction_interpolate = true;
   bool SaveAllLaminationHists = false;
   bool BFieldOff = false;

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -47,12 +47,16 @@ void TrackingInit()
   ACTSGEOM::ActsGeomInit();
 
   // initialize module edge correction
-  if( G4TPC::module_edge_correction_filename.empty() )
+  if( G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS && G4TPC::module_edge_correction_filename.empty() )
   { G4TPC::module_edge_correction_filename = CDBInterface::instance()->getUrl("TPC_Module_Edge"); }
 
   // initialize static distortion correction
-  if( G4TPC::static_correction_filename.empty() )
+  if( G4TPC::ENABLE_STATIC_CORRECTIONS && G4TPC::static_correction_filename.empty() )
   { G4TPC::static_correction_filename = CDBInterface::instance()->getUrl("TPC_STATIC_CORRECTION_MODEL"); }
+
+  // initialize time average distortion correction
+  if( G4TPC::ENABLE_AVERAGE_CORRECTIONS && G4TPC::average_correction_filename.empty() )
+  { G4TPC::average_correction_filename = CDBInterface::instance()->getUrl("TPC_LAMINATION_FIT_CORRECTION"); }
 
   // space charge correction
   if (G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS || G4TPC::ENABLE_STATIC_CORRECTIONS || G4TPC::ENABLE_AVERAGE_CORRECTIONS)


### PR DESCRIPTION
This PR sanitize how distortion and distortion corrections are handled across our macros. 
Static, module edge and time averaged corrections are now handled the same way: if no file is specified, the default one is loaded from DB.
The same strategy is also applied for actual distortions in the simulations. 
Redundant and error-prone specifications of the time-averaged distortion files have been removed from production macro, so that default values are used consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Distortion Setup Standardization

## Motivation
This PR standardizes how distortions and distortion corrections are handled across the TPC tracking macros. Previously, different correction types (static, module-edge, and time-averaged) used inconsistent configuration approaches, and production macros contained redundant explicit specifications of CDB file paths. The changes establish a unified default-loading strategy: when a correction feature is enabled and no filename is specified, the appropriate default file is automatically retrieved from the CDB.

## Key Changes

**Variable Initialization (`common/G4_TrkrVariables.C`)**
- Removed hard-coded default values from `G4TPC::static_distortion_filename` and `G4TPC::time_ordered_distortion_filename`, leaving them uninitialized by default
- This allows the default-loading logic to take effect when needed

**Distortion Loading Logic (`common/Trkr_RecoInit.C`)**
- Implemented conditional CDB URL assignment for three correction types:
  - Module-edge corrections: loads from `"TPC_Module_Edge"` when enabled and filename is empty
  - Static corrections: loads from `"TPC_STATIC_CORRECTION_MODEL"` when enabled and filename is empty  
  - Average/time-averaged corrections: loads from `"TPC_LAMINATION_FIT_CORRECTION"` when enabled and filename is empty

**Simulation Setup (`common/G4_TrkrSimulation.C`)**
- Updated `TPC_Cells()` to populate default CDB URLs for static and time-ordered distortions automatically when enable flags are set and filenames are empty
- Removed file-type branching logic, using `CDBInterface::instance()->getUrl()` consistently

**Macro Cleanup (7 TrackingProduction macros)**
- Removed explicit settings of `USE_PHI_AS_RAD_STATIC_CORRECTIONS` and `USE_PHI_AS_RAD_AVERAGE_CORRECTIONS`, allowing defaults to apply
- Removed redundant assignments of `G4TPC::average_correction_filename` to CDB URLs
- Affected files: `Fun4All_FullReconstruction.C`, `Fun4All_PRDFReconstruction.C`, `Fun4All_TrackAnalyzer.C`, `Fun4All_TrackCaloAnalysis.C`, `Fun4All_TrackFitting.C`, `Fun4All_TrackSeeding.C`, and run3 variants

## Potential Risk Areas

**Reconstruction Behavior Changes**
- Default distortion corrections are now determined by CDB configuration rather than hard-coded values in macros
- If CDB is misconfigured or unavailable, corrections will not load; critical for data reconstruction quality
- Previous explicit phi-as-radians settings are removed; behavior now depends on global defaults

**CDB Dependency**
- Reconstruction now has stronger dependency on correct CDB configuration being available at runtime
- Inconsistencies between local macro configuration and CDB defaults could cause unexpected behavior

**Configuration Override Complexity**
- While values can still be overridden by calling macros, the default-loading pathway is less explicit
- Future maintainers must understand the three-step priority: (1) macro-set values, (2) CDB defaults, (3) code defaults

## Future Improvements
- Document the CDB keys and expected file formats for each correction type in a centralized location
- Consider adding validation checks in `TrackingInit()` to verify CDB files were successfully loaded
- Add diagnostic output showing which correction files were actually loaded (from CDB vs. macro override)

---
*Note: AI-assisted analysis was used in generating this summary. Review the actual code changes carefully, as subtle behavioral changes in distortion loading could affect track reconstruction quality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->