### PR TITLE
Fixed a bug in loading distortions in MC.

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -519,7 +519,7 @@ void TPC_Cells()
     distortionMap->set_read_phi_as_radians(G4TPC::DISTORTIONS_USE_PHI_AS_RADIANS);
 
     distortionMap->set_do_static_distortions(G4TPC::ENABLE_STATIC_DISTORTIONS);
-    distortionMap->set_static_distortion_filename(CDBInterface::instance()->getUrl(G4TPC::static_distortion_filename));
+    distortionMap->set_static_distortion_filename(G4TPC::static_distortion_filename);
 
     distortionMap->set_do_time_ordered_distortions(G4TPC::ENABLE_TIME_ORDERED_DISTORTIONS);
     distortionMap->set_time_ordered_distortion_filename(G4TPC::time_ordered_distortion_filename);


### PR DESCRIPTION
Said bug was introduced by me in https://github.com/sPHENIX-Collaboration/macros/pull/1320 and would prevent from loading non-default, local distortion maps in the simulation chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

PR #1320 introduced a regression in the TPC distortion map loading mechanism that prevented users from loading non-default, locally-specified distortion maps during simulation. This PR restores the ability to use custom distortion maps while preserving backward compatibility with the Conditions Database (CDB) fallback for default distortion maps.

## Key Changes

- **Fixed distortion filename resolution in `TPC_Cells()` function**: Changed `distortionMap->set_static_distortion_filename()` to directly use the user-configurable `G4TPC::static_distortion_filename` variable instead of attempting to resolve it through `CDBInterface::instance()->getUrl()` at the point of setting
- The fix maintains the existing logic where:
  - If `G4TPC::static_distortion_filename` is empty, the code falls back to fetching the default from CDB (line 507)
  - If a user has explicitly set `G4TPC::static_distortion_filename` to a local file path, that custom file is now properly used
- All surrounding distortion configuration logic remains unchanged (time-ordered distortions, initialization, etc.)

## Potential Risk Areas

**Reconstruction behavior**: Users who have custom distortion maps configured will now be able to use them instead of being forced to use CDB defaults. This restores intended functionality but represents a behavior change from the buggy state. Any simulations run with PR #1320 that unexpectedly used default distortion maps will now use the user-specified maps.

**No identified concerns for**: IO format changes, thread-safety issues, or performance impact.

## Notes

*AI may make mistakes in code analysis. Please use best judgment when reviewing the specific implementation, particularly regarding any undocumented side effects of CDBInterface behavior or the timing of when distortion files are loaded versus when the filename variable is set.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/macros/pull/1326)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->