### PR TITLE
Nominal O+O simulation setup

### DIFF
--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -108,6 +108,7 @@ namespace Input
     double localbcross = Input::beam_crossing / 2. * 1e-3;
     switch (beam_config)
     {
+    case AuAu_COLLISION:
     case AA_COLLISION:
     case mRad_10:
       // heavy ion mode
@@ -202,7 +203,7 @@ namespace Input
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
-    case OOdNdEta:
+    case OOdNdEta: // special for Cheng-Wei's intt based dNdEta analysis
       Input::beam_crossing = 0.75;
       //0.75 mRad is split among both beams, means set to 0.375 mRad
       localbcross = Input::beam_crossing / 2. * 1e-3;
@@ -216,7 +217,7 @@ namespace Input
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
-    case OO_COLLISION_NOMINAL:
+    case OO_COLLISION:
       Input::beam_crossing = 0.75;
       //0.75 mRad is split among both beams, means set to 0.375 mRad
       localbcross = Input::beam_crossing / 2. * 1e-3;

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -216,6 +216,20 @@ namespace Input
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
+    case OO_COLLISION:
+      Input::beam_crossing = 0.75;
+      //0.75 mRad is split among both beams, means set to 0.375 mRad
+      localbcross = Input::beam_crossing / 2. * 1e-3;
+
+      HepMCGen->set_beam_direction_theta_phi(localbcross, 0, M_PI - localbcross, 0);
+      HepMCGen->set_vertex_distribution_mean(-0.0365, 0.137, 0.0, 0.);
+      HepMCGen->set_vertex_distribution_width(
+          92.4e-4,         // measured from silicon vertices in OO data
+          74.1e-4,         // measured from silicon vertices in OO data
+          7.15,          // measured from MBD vertex distribution in OO data, with all trigger included
+          20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
+
+      break;
     default:
       std::cout << "ApplysPHENIXBeamParameter: invalid beam_config = " << beam_config << std::endl;
 

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -109,7 +109,6 @@ namespace Input
     switch (beam_config)
     {
     case AuAu_COLLISION:
-    case AA_COLLISION:
     case mRad_10:
       // heavy ion mode
       Input::beam_crossing = 1.;  // +1 mRad for late 2024 with triggered readout for mvtx

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -216,7 +216,7 @@ namespace Input
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;
-    case OO_COLLISION:
+    case OO_COLLISION_NOMINAL:
       Input::beam_crossing = 0.75;
       //0.75 mRad is split among both beams, means set to 0.375 mRad
       localbcross = Input::beam_crossing / 2. * 1e-3;
@@ -226,7 +226,7 @@ namespace Input
       HepMCGen->set_vertex_distribution_width(
           92.4e-4,         // measured from silicon vertices in OO data
           74.1e-4,         // measured from silicon vertices in OO data
-          7.15,          // measured from MBD vertex distribution in OO data, with all trigger included
+          12.1,          // measured from MBD vertex distribution in OO data, with trigger bit 14 (MBD S&N > 1 && |vtx| < 150 cm, least biased)
           20 / 29.9792);  // 20cm collision length / speed of light in cm/ns
 
       break;

--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -84,7 +84,7 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
   case 38:  // Nominal sPHENIX OO collision settings, 0.75mRad xing angle, mvtx rotated
-    Input::BEAM_CONFIGURATION = Input::OO_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::OO_COLLISION_NOMINAL;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
   

--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -21,7 +21,7 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     break;
   case 23:  // AuAu 1mRad xing angle, mvtx rotated
   case 30:  // AuAu 1mRad xing angle, mvtx rotated
-    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::AuAu_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
   case 24:  // single particle sims
@@ -43,21 +43,21 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     std::cout << "use ppg02 settings" << std::endl;
     break;
   case 31:  // run 31 ppg08, AuAu 1mRad xing angle, mvtx rotated, flow flucuations enabled
-    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::AuAu_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     INPUTHEPMC::FLOW_FLUCTUATIONS = true;
     INPUTHEPMC::FLOW_SCALING = 1.0;
     std::cout << "use ppg08 run31 settings" << std::endl;
     break;
   case 32:  // run 32 ppg08, AuAu 1mRad xing angle, mvtx rotated, flow fluctuations disabled, scale 2
-    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::AuAu_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     INPUTHEPMC::FLOW_FLUCTUATIONS = false;
     INPUTHEPMC::FLOW_SCALING = 2.0;
     std::cout << "use ppg08 run32 settings" << std::endl;
     break;
   case 33:  // run 33 ppg08, AuAu 1mRad xing angle, mvtx rotated, flow afterburner disabled
-    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::AuAu_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     INPUTHEPMC::FLOW_FLUCTUATIONS = false;
     INPUTHEPMC::FLOW = false;
@@ -68,12 +68,12 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     Input::BEAM_CONFIGURATION = Input::mRad_05;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
-  case 35:  // 0.75mRad xing angle, mvtx rotated
-    Input::BEAM_CONFIGURATION = Input::mRad_075;
+  case 35:  // OO: 0.75mRad xing angle, mvtx rotated, measured vertex mean and width
+    Input::BEAM_CONFIGURATION = Input::OO_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
   case 36:  // run 36- ppg14, AuAu 1mRad xing angle, mvtx rotated, flow flucuations enabled, scale factor sqrt(1.3)
-    Input::BEAM_CONFIGURATION = Input::AA_COLLISION;
+    Input::BEAM_CONFIGURATION = Input::AuAu_COLLISION;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     INPUTHEPMC::FLOW_FLUCTUATIONS = true;
     INPUTHEPMC::FLOW_SCALING = 1.14;
@@ -81,10 +81,6 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     break;
   case 37:  // 0.75mRad xing angle, mvtx rotated, OO vertex from intt for dNdEta
     Input::BEAM_CONFIGURATION = Input::OOdNdEta;
-    Enable::MVTX_APPLYMISALIGNMENT = true;
-    break;
-  case 38:  // Nominal sPHENIX OO collision settings, 0.75mRad xing angle, mvtx rotated
-    Input::BEAM_CONFIGURATION = Input::OO_COLLISION_NOMINAL;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
   
@@ -96,6 +92,7 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     }
     break;
   }
+// tests use runnumber >= 100, just that we can run them without having to change this macro
   if (runnumber >= 100)
   {
     Input::BEAM_CONFIGURATION = Input::mRad_00;

--- a/common/G4_RunSettings.C
+++ b/common/G4_RunSettings.C
@@ -83,6 +83,10 @@ void RunSettings(int runnumber, const std::string & /*type*/ = "")
     Input::BEAM_CONFIGURATION = Input::OOdNdEta;
     Enable::MVTX_APPLYMISALIGNMENT = true;
     break;
+  case 38:  // Nominal sPHENIX OO collision settings, 0.75mRad xing angle, mvtx rotated
+    Input::BEAM_CONFIGURATION = Input::OO_COLLISION;
+    Enable::MVTX_APPLYMISALIGNMENT = true;
+    break;
   
   default:
     if (runnumber < 100)

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -26,6 +26,7 @@ namespace Input
   enum BeamConfiguration
   {
     AA_COLLISION = 0,
+    AuAu_COLLISION = 0,
     pA_COLLISION = 1,
     pp_COLLISION = 2,
     pp_ZEROANGLE = 3,
@@ -36,7 +37,7 @@ namespace Input
     mRad_15 = 8,
     mRad_075 = 9,
     OOdNdEta = 10,
-    OO_COLLISION_NOMINAL = 11
+    OO_COLLISION = 11
   };
 
   BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -35,7 +35,8 @@ namespace Input
     mRad_10 = 7,
     mRad_15 = 8,
     mRad_075 = 9,
-    OOdNdEta = 10
+    OOdNdEta = 10,
+    OO_COLLISION = 11
   };
 
   BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -25,8 +25,8 @@ namespace Input
   //! nominal beam parameter configuration choices for BEAM_CONFIGURATION
   enum BeamConfiguration
   {
-    AA_COLLISION = 0,
     AuAu_COLLISION = 0,
+    AA_COLLISION = AuAu_COLLISION,
     pA_COLLISION = 1,
     pp_COLLISION = 2,
     pp_ZEROANGLE = 3,

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -36,7 +36,7 @@ namespace Input
     mRad_15 = 8,
     mRad_075 = 9,
     OOdNdEta = 10,
-    OO_COLLISION = 11
+    OO_COLLISION_NOMINAL = 11
   };
 
   BeamConfiguration BEAM_CONFIGURATION = AA_COLLISION;


### PR DESCRIPTION
This PR adds instances in both `G4_Input.C` and `G4_RunSettings.C` for the nominal O+O simulation parameters with pileup.

~~(I am marking this as a draft PR for now to start the discussion. I will give a presentation at the upcoming software & simulation meeting to discuss the proposal)~~
Link to the presentation in the software and simulation meeting on May 26th, 2026: https://indico.bnl.gov/event/33016/#16-oo-tracking-simulation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Nominal O+O Simulation Setup with Pileup — concise summary

Motivation / context
- Add a nominal O+O (Oxygen-Oxygen) simulation configuration with pileup to the sPHENIX macros to support OO-simulation studies and reproduce measured OO beam/vertex conditions presented at the software & simulation meeting (May 26, 2026).

Key changes
- common/GlobalVariables.C
  - Added enum value: Input::BeamConfiguration::OO_COLLISION_NOMINAL = 11.
- common/G4_Input.C
  - Added an OO-specific branch in ApplysPHENIXBeamParameter that sets:
    - Input::beam_crossing = 0.75 mRad (split 0.375 mRad per beam)
    - HepMC beam direction via set_beam_direction_theta_phi(...)
    - Vertex mean: (-0.0365, 0.137, 0.0, 0.0) cm
    - Vertex widths: 92.4e-4 (x), 74.1e-4 (y), 12.1 cm (z) with collision length term
    - Commented provenance: silicon vertex measurements and MBD vertex distribution using trigger bit 14 (MBD S&N > 1 && |vtx| < 150 cm)
  - OOdNdEta case now has an explicit break and clarified comment.
  - AuAu_COLLISION handled as an alias of AA_COLLISION in heavy-ion branch.
- common/G4_RunSettings.C
  - Case 35 repurposed to OO settings: Input::BEAM_CONFIGURATION set to Input::OO_COLLISION and Enable::MVTX_APPLYMISALIGNMENT enabled.
  - Several AuAu-related run cases standardized to Input::AuAu_COLLISION.
  - Case 37 remains mapped to Input::OOdNdEta (the Cheng‑Wei intt-based dNdEta variant).
- Commit/PR metadata
  - Author renamed OO_COLLISION → OO_COLLISION_NOMINAL in some places (intent to distinguish nominal parameters from OOdNdEta).

Potential risk areas
- Enum / case-name inconsistency: GlobalVariables defines OO_COLLISION_NOMINAL but RunSettings and G4_Input use OO_COLLISION — this could be a source of misconfiguration or build/logic errors if names diverge; verify the identifier mapping is consistent across compilation and usage.
- Reconstruction / analysis impact: Changing vertex mean/width and beam crossing will alter simulated vertex distributions and therefore tracking/reconstruction performance and physics observables. Validate reconstruction and analysis chains against real OO data.
- Detector alignment & conditions: MVTX misalignment is enabled for OO runs; confirm this matches the detector state for the data-taking period targeted by the simulation.
- Trigger/selection bias: The OO z-width uses MBD-based vertex selection (trigger bit 14). That introduces selection bias — analyses must account for it or use an alternative, well-documented selection.
- Backwards compatibility: No public API signatures changed, but simulation behavior and run-number mappings changed; downstream workflows depending on the previous defaults should be re-tested.

Possible future improvements
- Resolve naming consistency: unify the enum and case identifiers (OO_COLLISION vs OO_COLLISION_NOMINAL) to avoid confusion and accidental mis-selection.
- Document provenance: add a brief note or reference linking the measured vertex/beam parameter sources (plots, analysis notes) into the code comments or a README so future maintainers can verify or update parameters.
- Add validation tests: include small simulation+reco validation jobs (or unit-style checks) that compare simulated vertex distributions to the measured OO distributions to guard against regressions.
- Clarify retention of OOdNdEta: explicitly document whether OOdNdEta (Cheng‑Wei’s dNdEta parameters) should be kept for legacy studies or retired.

Caveat
- This summary was produced with AI assistance; AI can make mistakes. Please verify critical parameter names and numeric values against the code and original measurement sources before merging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/macros/pull/1328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->