### PR TITLE
Write dst with diffuse laser events only

### DIFF
--- a/TrackingProduction/Fun4All_DiffuseLaser.C
+++ b/TrackingProduction/Fun4All_DiffuseLaser.C
@@ -1,0 +1,146 @@
+/*
+ * This macro shows a minimum working example of running the tracking
+ * hit unpackers with some basic seeding algorithms to try to put together
+ * tracks. There are some analysis modules run at the end which package
+ * hits, clusters, and clusters on tracks into trees for analysis.
+ */
+
+#include <GlobalVariables.C>
+#include <fun4all/Fun4AllUtils.h>
+#include <G4_ActsGeom.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_LaserClustering.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+#include <ffamodules/CDBInterface.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+
+#include <phool/recoConsts.h>
+
+#include <tpc/LaserEventIdentifier.h>
+
+#include <tpc/DiffuseLaserEventSelector.h>
+
+
+#include <stdio.h>
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libtpccalib.so)
+
+
+
+void Fun4All_DiffuseLaser(
+    const int nEvents = 100,
+    const std::string filelist = "filelist.list",
+    const std::string outdir = "./",
+    const std::string outfilename = "diffuse_laser")
+{
+
+  gSystem->Load("libg4dst.so");
+  
+  auto se = Fun4AllServer::instance();
+  se->Verbosity(0);
+  auto rc = recoConsts::instance();
+  CDBInterface::instance()->Verbosity(1);
+  
+  rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
+
+
+
+  std::ifstream ifs(filelist);
+  std::string filepath;
+
+  int i = 0;
+  int runnumber = std::numeric_limits<int>::quiet_NaN();
+  int segment = std::numeric_limits<int>::quiet_NaN();
+  
+   while (std::getline(ifs, filepath))
+  {
+    std::cout << "Adding DST with filepath: " << filepath << std::endl;
+    if (i == 0)
+    {
+      std::pair<int, int>
+          runseg = Fun4AllUtils::GetRunSegment(filepath);
+      runnumber = runseg.first;
+      segment = runseg.second;
+      rc->set_IntFlag("RUNNUMBER", runnumber);
+      rc->set_uint64Flag("TIMESTAMP", runnumber);
+    }
+  
+    std::string inputname = "InputManager" + std::to_string(i);
+    auto *hitsin = new Fun4AllDstInputManager(inputname);
+    hitsin->fileopen(filepath);
+    se->registerInputManager(hitsin);
+    i++;
+  }
+
+  TpcReadoutInit(runnumber);
+
+  
+  TRACKING::tpc_zero_supp = true;
+  Enable::MVTX_APPLYMISALIGNMENT = true;
+  ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
+  
+
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = false;
+  //G4TPC::ENABLE_STATIC_CORRECTIONS = false;
+  //G4TPC::USE_PHI_AS_RAD_STATIC_CORRECTIONS=false;
+
+
+  G4TPC::ENABLE_AVERAGE_CORRECTIONS = false;
+
+  TRACKING::pp_mode = true;
+  
+  TrackingInit();
+
+  std::ostringstream ebdcname;
+  for (int ebdc = 0; ebdc < 24; ebdc++)
+  {
+    for (int endpoint = 0; endpoint < 2; endpoint++)
+    {
+        ebdcname.str("");
+        if (ebdc < 10)
+        {
+          ebdcname << "0";
+        }
+        ebdcname << ebdc << "_" << endpoint;
+        Tpc_HitUnpacking(ebdcname.str());
+    }
+  }
+
+  Tpc_LaserEventIdentifying();
+
+  se->registerSubsystem( new DiffuseLaserEventSelector());
+
+
+  std::cout<< "Output DST "<<Form("%s/%s_%d_%d.root",outdir.c_str(), outfilename.c_str(), runnumber, segment)  << std::endl;
+  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", Form("%s/%s_%d_%d.root",outdir.c_str(), outfilename.c_str(), runnumber, segment));
+  out->AddEventSelector("DiffuseLaserEventSelector");
+  out->AddNode("Sync");
+  out->AddNode("EventHeader");
+  out->AddNode("TRKR_HITSET");
+  se->registerOutputManager(out);
+
+  se->run(nEvents);
+  se->End();
+
+  CDBInterface::instance()->Print();
+  se->PrintTimer();
+
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+}

--- a/TrackingProduction/Fun4All_DiffuseLaser.C
+++ b/TrackingProduction/Fun4All_DiffuseLaser.C
@@ -29,7 +29,7 @@
 #include <tpc/DiffuseLaserEventSelector.h>
 
 
-#include <stdio.h>
+#include <cstdio>
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffamodules.so)
 R__LOAD_LIBRARY(libtpc.so)
@@ -39,16 +39,16 @@ R__LOAD_LIBRARY(libtpccalib.so)
 
 void Fun4All_DiffuseLaser(
     const int nEvents = 100,
-    const std::string filelist = "filelist.list",
-    const std::string outdir = "./",
-    const std::string outfilename = "diffuse_laser")
+    const std::string& filelist = "filelist.list",
+    const std::string& outdir = "./",
+    const std::string& outfilename = "diffuse_laser")
 {
 
   gSystem->Load("libg4dst.so");
   
-  auto se = Fun4AllServer::instance();
+  auto *se = Fun4AllServer::instance();
   se->Verbosity(0);
-  auto rc = recoConsts::instance();
+  auto *rc = recoConsts::instance();
   CDBInterface::instance()->Verbosity(1);
   
   rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");


### PR DESCRIPTION
Write trkr_hitset for diffuse laser events only to dst
Uses DiffuseLaserEventSelector from the coresoftware PR (Select only diffuse laser events#4274)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
Provide an analysis macro to extract and write only diffuse TPC laser calibration events (used for alignment/distortion studies) from existing DST files. This enables streamlined calibration workflows by producing DSTs containing just the TRKR_HITSET information for selected diffuse-laser events.

## Key changes
- Added TrackingProduction/Fun4All_DiffuseLaser.C (146 lines):
  - New Fun4All macro Fun4All_DiffuseLaser(nEvents, filelist, outdir, outfilename).
  - Loads required libraries (libfun4all, libffamodules, libtpc, libtpccalib, libg4dst).
  - Reads input DST paths from a filelist and sets RUNNUMBER / TIMESTAMP from the first file.
  - Initializes TPC readout and tracking geometry (registers Tracking_Geometry URL via Fun4AllRunNodeInputManager).
  - Configures tracking flags (TPC zero-suppression, MVTX misalignment, pp_mode, disables some TPC corrections).
  - Runs Tpc_HitUnpacking over 24 endboards × 2 endpoints and Tpc_LaserEventIdentifying.
  - Registers DiffuseLaserEventSelector (from coresoftware PR `#4274`) as a subsystem and configures output:
    - Creates a Fun4AllDstOutputManager writing outdir/outfilename_run_segment.root.
    - Adds event selector "DiffuseLaserEventSelector".
    - Writes only Sync, EventHeader, and TRKR_HITSET nodes to the output DST.

## Potential risk areas
- External dependency: Behavior relies on DiffuseLaserEventSelector implementation (coresoftware PR `#4274`); interface/selection changes there will affect outputs.
- IO / DST format: Output DST intentionally restricts nodes to TRKR_HITSET (plus Sync/EventHeader). This may break downstream consumers expecting other nodes/collections.
- Reconstruction behavior: Changing which nodes are written (and applying selection before output) alters what is preserved for later reconstruction/analysis.
- Hard-coded CDB tag: CDB_GLOBALTAG is set to "newcdbtag" in the macro and may be inappropriate for some runs.
- File handling / robustness: filelist parsing has no error handling; missing/invalid paths may cause failures or silent misbehavior.
- Process control / cleanup: macro calls gSystem->Exit(0) and deletes the Fun4AllServer; abrupt exit semantics may complicate embedding or scripted usage.
- Performance / scalability: running 48 hit-unpacking chains and full tracking initialization may be CPU/memory intensive for large samples.
- Thread-safety: macro assumes single-threaded Fun4All execution; not validated for concurrent execution contexts.

## Possible future improvements
- Parameterize CDB_GLOBALTAG, output node list, and run/segment behavior via macro arguments or config file.
- Add robust input validation, file existence checks, and clearer error/logging for filelist and CDB access.
- Emit selection diagnostics (counts: scanned events, selected events, per-file breakdown) to aid validation.
- Optionally include additional nodes or an option to preserve a configurable minimal set of collections for downstream tools.
- Avoid abrupt process exit to support embedding in larger workflows; ensure proper resource cleanup.
- Add unit/integration tests to verify output DST contents and selector behavior across datasets.

---

Note: AI summaries can be incorrect — please verify the macro code and cross-check with coresoftware PR `#4274` for selector details and expected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sPHENIX-Collaboration/macros/pull/1329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->