### PR TITLE
fix: converter cluster map name

### DIFF
--- a/TrackingProduction/Fun4All_TrackFitting.C
+++ b/TrackingProduction/Fun4All_TrackFitting.C
@@ -136,6 +136,7 @@ void Fun4All_TrackFitting(
     // SiliconTrackSeedContainer or TpcTrackSeedContainer
     converter->setTrackSeedName("SvtxTrackSeedContainer");
     converter->setFieldMap(G4MAGNET::magfield_tracking);
+    converter->setClusterMapName("TRKR_CLUSTER_SEED");
     converter->Verbosity(0);
     se->registerSubsystem(converter);
   }


### PR DESCRIPTION
Fixes the cluster map name for the converter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation
The `Fun4All_TrackFitting.C` workflow was inconsistent in its use of cluster map names. Multiple downstream functions in the track fitting pipeline were configured to use `"TRKR_CLUSTER_SEED"` as the cluster container name, but the `TrackSeedTrackMapConverter` module was not explicitly setting its output cluster map, potentially causing data structure mismatches in the reconstruction pipeline.

## Key Changes
- Added `converter->setClusterMapName("TRKR_CLUSTER_SEED")` to the `TrackSeedTrackMapConverter` initialization in `Fun4All_TrackFitting.C`
- This ensures the seed-to-track converter outputs to the same cluster map that downstream track matching, fitting, and vertexing functions expect to read from

## Potential Risk Areas
- **Reconstruction behavior**: This fix ensures consistent data flow between converter output and downstream track fitting/vertexing modules. Any existing workflows relying on the previous (unspecified) cluster map behavior could see differences in reconstruction results.
- **IO format**: The cluster map name is a structural element in the DST output; workflows analyzing output from the converter should be aware of this naming change.

## Notes
- This is a consistency fix aligning the converter configuration with the rest of the workflow that was already expecting `"TRKR_CLUSTER_SEED"`
- The fix appears to be part of a broader effort to generalize cluster map naming in the reconstruction pipeline (related commits show work on "add cluster map name option to track matching")
- AI analysis may have missed subtleties in how the converter handles data when the cluster map name is not explicitly set; review the converter implementation for complete understanding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->