### PR TITLE
fix: check for geometry building from scratch

### DIFF
--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -20,6 +20,17 @@
 R__LOAD_LIBRARY(libtrack_reco.so)
 R__LOAD_LIBRARY(libtpccalib.so)
 
+void LoadTrackingCDBGeometry()
+{
+
+  auto *se = Fun4AllServer::instance();
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+  
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+  
+}
 void TrackingInit()
 {
    // server
@@ -40,11 +51,7 @@ void TrackingInit()
   // G4Setup() was not run
   if(CDB::is_data_reco)
     {
-      std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
-      
-      Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-      ingeo->AddFile(geofile);
-      se->registerInputManager(ingeo);
+      LoadTrackingCDBGeometry();
     }
  
   TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -38,7 +38,7 @@ void TrackingInit()
 
   // check that we are not building the geometry from scratch, i.e. that
   // G4Setup() was not run
-  if(Input::READHITS || CDB::is_data_reco)
+  if(CDB::is_data_reco)
     {
       std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
       

--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -24,13 +24,7 @@ void TrackingInit()
 {
    // server
   auto *se = Fun4AllServer::instance();
-
-  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
-
-  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-  ingeo->AddFile(geofile);
-  se->registerInputManager(ingeo);
-
+ 
   auto *rc = recoConsts::instance();
   if(rc->get_StringFlag("CDB_GLOBALTAG").find("MDC") != std::string::npos)
     {
@@ -42,6 +36,17 @@ void TrackingInit()
       CDB::is_data_reco = true;
     }
 
+  // check that we are not building the geometry from scratch, i.e. that
+  // G4Setup() was not run
+  if(Input::READHITS || CDB::is_data_reco)
+    {
+      std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+      
+      Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+      ingeo->AddFile(geofile);
+      se->registerInputManager(ingeo);
+    }
+ 
   TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;
 
   ACTSGEOM::ActsGeomInit();

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -486,6 +486,10 @@ int Fun4All_G4_sPHENIX(
   {
     G4Setup();
   }
+  else
+  {
+    LoadTrackingCDBGeometry();
+  }
 
   //------------------
   // Detector Division


### PR DESCRIPTION
Tony identified a bug in the default macro where, if you wanted to test local geometry changes, they were overwritten by loading the CDB geometry in. This fixes that by only loading the CDB geometry if real data reco is being processed or if g4setup is not called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / Context
Developers testing local geometry modifications were seeing those changes overwritten when the tracking CDB geometry (`Tracking_Geometry`) was loaded. This made iteration difficult, especially when using workflows that build or modify geometry locally (e.g., via `G4Setup`-driven setups).

## Key Changes
- **Made `Tracking_Geometry` input registration conditional** in `common/Trkr_RecoInit.C` (the `GeoIn` `Fun4AllRunNodeInputManager` is no longer registered unconditionally).
- **Load CDB tracking geometry only when `CDB::is_data_reco` is true**, guarded by:
  - `CDB::is_data_reco = false` when `recoConsts::get_StringFlag("CDB_GLOBALTAG")` contains `"MDC"`
  - otherwise `CDB::is_data_reco = true`
- **Geometry override prevention**: when the condition is not met, local geometry changes are preserved because the CDB `Tracking_Geometry` file is not injected via `GeoIn`.

## Potential Risk Areas
- **Global-tag substring logic**: behavior depends on detecting `"MDC"` in `CDB_GLOBALTAG`; tags with unexpected naming could cause the wrong reconstruction mode and either skip or load CDB geometry incorrectly.
- **Reconstruction behavior changes**: workflows that previously relied on always loading `Tracking_Geometry` may now behave differently when `CDB::is_data_reco` is false.
- **Global mutable state**: `CDB::is_data_reco` is set at init time; if multiple processes/configurations are run in the same job context, verify it cannot lead to cross-talk (thread-safety/process-safety assumptions).

## Possible Future Improvements
- Add **explicit logging** indicating whether CDB `Tracking_Geometry` was loaded and why (including the evaluated `CDB_GLOBALTAG` and the resulting `CDB::is_data_reco`).
- Replace/augment the **string-based `"MDC"` heuristic** with a more explicit configuration or dedicated flag.
- Consider an explicit check for whether geometry was built by **`G4Setup` / geometry-from-scratch**, rather than inferring from CDB tag content.

*Note: AI-generated summaries can contain mistakes and may miss nuances—please use best judgment and validate against the actual runtime configuration and intent for your specific reconstruction workflow.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->