### PR TITLE
add macro to show how to write the cdb dump and read it back

### DIFF
--- a/CDBTest/TestCDBFileDump.C
+++ b/CDBTest/TestCDBFileDump.C
@@ -1,0 +1,45 @@
+#ifndef TESTCDBFILEDUMP_C
+#define TESTCDBFILEDUMP_C
+
+#include <ffamodules/CDBInterface.h>
+
+#include <phool/recoConsts.h>
+
+#include <TSystem.h>
+
+#include <iostream>
+
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+
+
+// if you want to use calibration outside of scdf, you need to source the sphenix_setup script
+// from the opensciencegrid cvmfs area
+// source /cvmfs/sphenix.opensciencegrid.org/alma9.2-gcc-14.2.0/opt/sphenix/core/bin/sphenix_setup.csh -n
+
+// during reading there is no check on the global tag or timestamp (runnumber). All this is set
+// during the writing of the calibration list file.
+
+void WriteFile(uint64_t timestamp = 82476)
+{
+  recoConsts *rc = recoConsts::instance();
+  // we need to set the cdb tag and timestamp to select the calibrations to write
+  rc->set_StringFlag("CDB_GLOBALTAG","newcdbtag"); 
+  rc->set_uint64Flag("TIMESTAMP",timestamp);
+  CDBInterface *cdb = CDBInterface::instance();
+  cdb->DumpCalibrations("calibs.list");
+
+  return;
+}
+
+void ReadFile()
+{
+  // there is no timestamp or global tag when reading - this is set when you create the dump
+  CDBInterface *cdb = CDBInterface::instance();
+  cdb->ReadCalibrationsFromFile("calibs.list");
+  // print a random calibration to see if it works
+  std::cout << cdb->getUrl("ohcal_abscalib_mip_bldg912") << std::endl;
+  return;
+}
+
+#endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This PR introduces a tutorial macro demonstrating how to use the sPHENIX Calibration Database (CDB) interface to export and import calibration data to/from local files. This extends the existing CDBTest suite of example macros and addresses the common workflow of dumping calibrations for external use or archival purposes.

## Key Changes

- **New macro `CDBTest/TestCDBFileDump.C`**: Adds two complementary functions:
  - `WriteFile(timestamp)`: Dumps all calibrations from CDB to `calibs.list` with specified global tag and timestamp
  - `ReadFile()`: Reads calibrations from `calibs.list` file and verifies successful loading by retrieving a sample calibration URL
- Includes documentation comments on setup requirements (sphenix_setup script from CVMFS) and behavior notes (timestamp and global tag are preserved during file dump but not checked during read)

## Potential Risk Areas

- **File Format**: The `calibs.list` format is CDBInterface-specific and not explicitly documented in this macro. Care should be taken when sharing or archiving these files across different framework versions.
- **No Error Handling**: Both functions lack error checking for file I/O operations or invalid CDB states, which could silently fail in production workflows.
- **Hard-coded Verification**: The read-back verification uses a single hard-coded calibration key (`"ohcal_abscalib_mip_bldg912"`) rather than comprehensive validation.

## Possible Future Improvements

- Add error handling and validation for file I/O operations
- Implement more comprehensive read-back verification across multiple subsystems
- Document the `calibs.list` file format specification
- Add optional logging or statistics output (e.g., number of calibrations dumped/loaded)
- Consider adding timestamp compatibility checks or migration utilities

**Note**: AI-generated summaries may contain inaccuracies; please verify key implementation details when reviewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->