### PR TITLE
fix: ppmode flag to vertexer

### DIFF
--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -75,7 +75,7 @@ void Tracking_Reco_Vertex_run2pp(const std::string& clusterMapName="TRKR_CLUSTER
   finder->setTrackQualityCut(300);
   finder->setNmvtxRequired(3);
   finder->setOutlierPairCut(0.10);
-
+  finder->set_pp_mode(TRACKING::pp_mode);
   se->registerSubsystem(finder);
 
   if (!G4TRACKING::convert_seeds_to_svtxtracks)
@@ -689,6 +689,7 @@ void vertexing()
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
   auto *vtxfinder = new PHSimpleVertexFinder;
+  vtxfinder->set_pp_mode(TRACKING::pp_mode);
   vtxfinder->Verbosity(verbosity);
   se->registerSubsystem(vtxfinder);
 }


### PR DESCRIPTION
Neither the data nor simulation vertexer call was properly setting the flag to run streaming readout mode - that is a big problem and would explain why the vertexing output was puzzling in the simulations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

In streaming readout mode (pp mode), the sPHENIX tracking vertexer components require proper configuration of a `pp_mode` flag to function correctly. This flag had been omitted from the `PHSimpleVertexFinder` instantiations in two critical reconstruction functions, potentially causing unexpected behavior in vertex finding output during both data and simulation processing. The flag was already being properly propagated to other tracking components (track fitters, seeders, matching algorithms), but the vertexer had not received this treatment.

## Key Changes

- **`Tracking_Reco_Vertex_run2pp()` function**: Added `set_pp_mode(TRACKING::pp_mode)` call to the `PHSimpleVertexFinder` instance
- **`vertexing()` function**: Added `set_pp_mode(TRACKING::pp_mode)` call to the `PHSimpleVertexFinder` instance  

This ensures the vertexer respects the streaming readout mode configuration in both the Run 2 pp-specific reconstruction path and the generic vertexing path.

## Potential Risk Areas

- **Reconstruction behavior changes**: The vertex finding algorithm may now produce different results when `pp_mode` is enabled, particularly in terms of vertex selection criteria or track-vertex association. This could affect downstream physics analyses using vertices from affected reconstruction chains.
- **Simulation vs. data consistency**: Without this fix, simulation vertexing behavior was inconsistent with intended pp-mode parameters, potentially explaining discrepancies between simulated and real vertex distributions.

## Future Improvements

Consider auditing other reconstruction functions in the macro to verify complete and consistent propagation of the `pp_mode` flag across all sensitive components. Additionally, validation studies comparing vertex distributions before and after this fix would be beneficial to document the impact.

---
**Note**: AI tools can make mistakes in code interpretation. Please verify that `TRACKING::pp_mode` is the correct flag and that the vertexer modifications align with the intended physics behavior for streaming readout mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->