### PR TITLE
refactor: call standard functions

### DIFF
--- a/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
@@ -174,6 +174,7 @@ void Fun4All_raw_hit_KFP(
 
   Enable::QA = false;
   Enable::CDB = true;
+  //rc->set_StringFlag("CDB_GLOBALTAG", "2025p012");
   rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
   rc->set_uint64Flag("TIMESTAMP", runnumber);
 
@@ -307,77 +308,15 @@ void Fun4All_raw_hit_KFP(
    */
   if (G4TRACKING::convert_seeds_to_svtxtracks)
   {
-    auto *converter = new TrackSeedTrackMapConverter;
-    // Default set to full SvtxTrackSeeds. Can be set to
-    // SiliconTrackSeedContainer or TpcTrackSeedContainer
-    converter->setTrackSeedName("SvtxTrackSeedContainer");
-    converter->setFieldMap(G4MAGNET::magfield_tracking);
-    converter->Verbosity(0);
-    se->registerSubsystem(converter);
+    G4TRACKING::convertSeedsContainerName = "SvtxTrackSeedContainer";
+    convert_seeds();
   }
   else
   {
-    auto *deltazcorr = new PHTpcDeltaZCorrection;
-    deltazcorr->Verbosity(0);
-    se->registerSubsystem(deltazcorr);
-
-    // perform final track fit with ACTS
-    auto *actsFit = new PHActsTrkFitter;
-    actsFit->Verbosity(0);
-    actsFit->commissioning(G4TRACKING::use_alignment);
-    // in calibration mode, fit only Silicons and Micromegas hits
-    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
-    actsFit->set_use_clustermover(true);  // default is true for now
-    actsFit->useActsEvaluator(false);
-    actsFit->useOutlierFinder(false);
-    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
-    se->registerSubsystem(actsFit);
-
-    auto *cleaner = new PHTrackCleaner();
-    cleaner->Verbosity(0);
-    cleaner->set_pp_mode(TRACKING::pp_mode);
-    se->registerSubsystem(cleaner);
-
-    if (G4TRACKING::SC_CALIBMODE)
-    {
-      /*
-       * in calibration mode, calculate residuals between TPC and fitted tracks,
-       * store in dedicated structure for distortion correction
-       */
-      auto *residuals = new PHTpcResiduals;
-      const TString tpc_residoutfile = theOutfile + "_PhTpcResiduals.root";
-      residuals->setOutputfile(tpc_residoutfile.Data());
-      residuals->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-
-      // matches Tony's analysis
-      residuals->setMinPt(0.2);
-
-      // reconstructed distortion grid size (phi, r, z)
-      residuals->setGridDimensions(36, 48, 80);
-      se->registerSubsystem(residuals);
-    }
+    Tracking_Reco_TrackFit_run2pp();
   }
 
-  auto *finder = new PHSimpleVertexFinder;
-  finder->Verbosity(0);
-  finder->setDcaCut(0.5);
-  finder->setTrackPtCut(0.3);
-  finder->setBeamLineCut(1);
-  finder->setTrackQualityCut(1000);
-  finder->setNmvtxRequired(3);
-  finder->setOutlierPairCut(0.1);
-  se->registerSubsystem(finder);
-
-  if (!G4TRACKING::convert_seeds_to_svtxtracks)
-  {
-    // Propagate track positions to the vertex position
-    auto *vtxProp = new PHActsVertexPropagator;
-    vtxProp->Verbosity(0);
-    vtxProp->fieldMap(G4MAGNET::magfield_tracking);
-    se->registerSubsystem(vtxProp);
-  }
+  Tracking_Reco_Vertex_run2pp();
 
   TString residoutfile = theOutfile + "_resid.root";
   std::string residstring(residoutfile.Data());
@@ -399,7 +338,7 @@ void Fun4All_raw_hit_KFP(
   resid->convertSeeds(G4TRACKING::convert_seeds_to_svtxtracks);
 
   //   resid->Verbosity(0);
-  // se->registerSubsystem(resid);
+  se->registerSubsystem(resid);
 
   // auto ntuplizer = new TrkrNtuplizer("TrkrNtuplizer");
   // se->registerSubsystem(ntuplizer);


### PR DESCRIPTION
This refactors the run3pp macro to call the standard functions instead of home cooked ones, so that everything is consistent.