### PR TITLE
chore: pp mode to streaming mode

### DIFF
--- a/JetProduction/Fun4All_CaloJetProductionYear2.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear2.C
@@ -107,7 +107,7 @@ void Fun4All_CaloJetProductionYear2(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = NSJETS::is_pp;
+  TRACKING::streaming_mode                     = NSJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear2_AuAu.C
@@ -108,7 +108,7 @@ void Fun4All_CaloJetProductionYear2_AuAu(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_CaloJetProductionYear3.C
+++ b/JetProduction/Fun4All_CaloJetProductionYear3.C
@@ -108,7 +108,7 @@ void Fun4All_CaloJetProductionYear3(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_JetProductionYear2.C
+++ b/JetProduction/Fun4All_JetProductionYear2.C
@@ -127,7 +127,7 @@ void Fun4All_JetProductionYear2(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = NSJETS::is_pp;
+  TRACKING::streaming_mode                     = NSJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_JetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_JetProductionYear2_AuAu.C
@@ -119,7 +119,7 @@ void Fun4All_JetProductionYear2_AuAu(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_JetProductionYear3.C
+++ b/JetProduction/Fun4All_JetProductionYear3.C
@@ -120,7 +120,7 @@ void Fun4All_JetProductionYear3(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_TrackJetProductionYear2.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear2.C
@@ -117,7 +117,7 @@ void Fun4All_TrackJetProductionYear2(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = NSJETS::is_pp;
+  TRACKING::streaming_mode                     = NSJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear2_AuAu.C
@@ -110,7 +110,7 @@ void Fun4All_TrackJetProductionYear2_AuAu(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/JetProduction/Fun4All_TrackJetProductionYear3.C
+++ b/JetProduction/Fun4All_TrackJetProductionYear3.C
@@ -110,7 +110,7 @@ void Fun4All_TrackJetProductionYear3(
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
   Enable::MVTX_APPLYMISALIGNMENT        = true;
   ACTSGEOM::mvtx_applymisalignment      = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode                     = HIJETS::is_pp;
+  TRACKING::streaming_mode                     = HIJETS::is_pp;
 
   // initialize interfaces, register inputs -----------------------------------
 

--- a/TrackingProduction/Fun4All_DiffuseLaser.C
+++ b/TrackingProduction/Fun4All_DiffuseLaser.C
@@ -104,7 +104,7 @@ void Fun4All_DiffuseLaser(
 
   G4TPC::ENABLE_AVERAGE_CORRECTIONS = false;
 
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
   
   TrackingInit();
 

--- a/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
@@ -177,7 +177,7 @@ void Fun4All_FieldOnAllTrackers_KFP(
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);

--- a/TrackingProduction/Fun4All_FullReconstruction.C
+++ b/TrackingProduction/Fun4All_FullReconstruction.C
@@ -99,7 +99,7 @@ void Fun4All_FullReconstruction(
             << " vdrift: " << G4TPC::tpc_drift_velocity_reco
             << std::endl;
 
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
@@ -264,7 +264,7 @@ void Fun4All_FullReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
   if (G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {
     // for general tracking
@@ -300,7 +300,7 @@ void Fun4All_FullReconstruction(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto *mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
-  mm_match->set_pp_mode(TRACKING::pp_mode);
+  mm_match->set_pp_mode(TRACKING::streaming_mode);
   mm_match->set_rphi_search_window_lyr1(3.);
   mm_match->set_rphi_search_window_lyr2(15.0);
   mm_match->set_z_search_window_lyr1(30.0);
@@ -341,7 +341,7 @@ void Fun4All_FullReconstruction(
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);
@@ -350,7 +350,7 @@ void Fun4All_FullReconstruction(
 
     auto *cleaner = new PHTrackCleaner();
     cleaner->Verbosity(0);
-    cleaner->set_pp_mode(TRACKING::pp_mode);
+    cleaner->set_pp_mode(TRACKING::streaming_mode);
     se->registerSubsystem(cleaner);
 
     if (G4TRACKING::SC_CALIBMODE)

--- a/TrackingProduction/Fun4All_KShortReco.C
+++ b/TrackingProduction/Fun4All_KShortReco.C
@@ -117,7 +117,7 @@ void Fun4All_KShortReco(
   G4TRACKING::SC_CALIBMODE = false;
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   auto *se = Fun4AllServer::instance();
   se->Verbosity(1);

--- a/TrackingProduction/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/Fun4All_PRDFReconstruction.C
@@ -215,7 +215,7 @@ void Fun4All_PRDFReconstruction(
   //! flags to set
   Enable::QA = true;
   TRACKING::tpc_zero_supp = true;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
   G4TRACKING::convert_seeds_to_svtxtracks = false;
   G4TPC::REJECT_LASER_EVENTS = true;
 
@@ -426,7 +426,7 @@ void Fun4All_PRDFReconstruction(
     finder->setTrackQualityCut(1000000000);
     finder->setNmvtxRequired(3);
     finder->setOutlierPairCut(0.1);
-    finder->set_pp_mode(TRACKING::pp_mode);
+    finder->set_pp_mode(TRACKING::streaming_mode);
     finder->setTrackMapName("SiliconSvtxTrackMap");
     finder->setVertexMapName("SiliconSvtxVertexMap");
     se->registerSubsystem(finder);

--- a/TrackingProduction/Fun4All_TrackAnalyzer.C
+++ b/TrackingProduction/Fun4All_TrackAnalyzer.C
@@ -71,7 +71,7 @@ void Fun4All_TrackAnalyzer(
   G4TRACKING::SC_CALIBMODE = false;
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   std::string theOutfile = outfilename + "_" + std::to_string(runnumber) + "-" + std::to_string(segment) + ".root";
 

--- a/TrackingProduction/Fun4All_TrackCaloAnalysis.C
+++ b/TrackingProduction/Fun4All_TrackCaloAnalysis.C
@@ -66,7 +66,7 @@ void Fun4All_TrackCaloAnalysis(
 
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   auto *se = Fun4AllServer::instance();
   se->Verbosity(1);

--- a/TrackingProduction/Fun4All_TrackFitting.C
+++ b/TrackingProduction/Fun4All_TrackFitting.C
@@ -74,7 +74,7 @@ void Fun4All_TrackFitting(
   G4TRACKING::SC_CALIBMODE = false;
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
   
   TString outfile = outfilename + "_" + runnumber + "-" + segment + ".root";
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -105,7 +105,7 @@ void Fun4All_TrackSeeding(
    * TPC clusters not participating to the ACTS track fit
    */
   G4TRACKING::SC_CALIBMODE = false;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -76,7 +76,7 @@ void Fun4All_ZFAllTrackers(
   G4TRACKING::SC_CALIBMODE = false;
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   auto *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
@@ -145,13 +145,13 @@ void Fun4All_ZFAllTrackers(
   silicon_match->window_deta.set_QoverpT_maxabs({0.06,0,0});
   silicon_match->window_dphi.set_QoverpT_maxabs({0.11,0,0});
   silicon_match->set_test_windows_printout(false);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
   silicon_match->zeroField(true);
   se->registerSubsystem(silicon_match);
 
   auto *mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
-  mm_match->set_pp_mode(TRACKING::pp_mode);
+  mm_match->set_pp_mode(TRACKING::streaming_mode);
 
   mm_match->set_rphi_search_window_lyr1(3.);
   mm_match->set_rphi_search_window_lyr2(15.0);
@@ -188,7 +188,7 @@ void Fun4All_ZFAllTrackers(
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);

--- a/TrackingProduction/run3auau/Fun4All_PRDFReconstruction.C
+++ b/TrackingProduction/run3auau/Fun4All_PRDFReconstruction.C
@@ -485,7 +485,7 @@ void Fun4All_PRDFReconstruction(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
   if (G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {
     // for general tracking
@@ -561,7 +561,7 @@ void Fun4All_PRDFReconstruction(
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);
@@ -570,7 +570,7 @@ void Fun4All_PRDFReconstruction(
 
     auto *cleaner = new PHTrackCleaner();
     cleaner->Verbosity(0);
-    cleaner->set_pp_mode(TRACKING::pp_mode);
+    cleaner->set_pp_mode(TRACKING::streaming_mode);
     // se->registerSubsystem(cleaner);
   }
 

--- a/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
@@ -219,7 +219,7 @@ void Fun4All_raw_hit_KFP(
             << " vdrift: " << G4TPC::tpc_drift_velocity_reco
             << std::endl;
 
-  TRACKING::pp_mode = false;
+  TRACKING::streaming_mode = false;
 
   // distortion calibration mode
   /*
@@ -393,7 +393,7 @@ void Fun4All_raw_hit_KFP(
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(0);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
   if (G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {
     // for general tracking
@@ -469,7 +469,7 @@ void Fun4All_raw_hit_KFP(
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);
@@ -478,7 +478,7 @@ void Fun4All_raw_hit_KFP(
 
     auto *cleaner = new PHTrackCleaner();
     cleaner->Verbosity(0);
-    cleaner->set_pp_mode(TRACKING::pp_mode);
+    cleaner->set_pp_mode(TRACKING::streaming_mode);
     se->registerSubsystem(cleaner);
 
     if (G4TRACKING::SC_CALIBMODE)

--- a/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
@@ -213,7 +213,7 @@ void Fun4All_raw_hit_KFP(
             << " vdrift: " << G4TPC::tpc_drift_velocity_reco
             << std::endl;
 
-  TRACKING::pp_mode = true;
+  TRACKING::streaming_mode = true;
 
   // distortion calibration mode
   /*

--- a/calibrations/tpc/TpcDVCalib/Fun4All_FieldOnAllTrackersCalos.C
+++ b/calibrations/tpc/TpcDVCalib/Fun4All_FieldOnAllTrackersCalos.C
@@ -135,7 +135,7 @@ void Fun4All_FieldOnAllTrackersCalos(
   G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
   std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
 
-  TRACKING::pp_mode = false;
+  TRACKING::streaming_mode = false;
 
   TrackingInit();
   if(doTpcOnlyTracking)
@@ -206,7 +206,7 @@ void Fun4All_FieldOnAllTrackersCalos(
   seeder->SetMinHitsPerCluster(0);
   seeder->SetMinClustersPerTrack(3);
   seeder->useFixedClusterError(true);
-  seeder->set_pp_mode(TRACKING::pp_mode);
+  seeder->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(seeder);
 
   // expand stubs in the TPC using simple kalman filter
@@ -225,7 +225,7 @@ void Fun4All_FieldOnAllTrackersCalos(
   cprop->useFixedClusterError(true);
   cprop->set_max_window(5.);
   cprop->Verbosity(verbosity);
-  cprop->set_pp_mode(TRACKING::pp_mode);
+  cprop->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(cprop);
 
   /*
@@ -247,7 +247,7 @@ void Fun4All_FieldOnAllTrackersCalos(
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto *mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(verbosity);
-  mm_match->set_pp_mode(TRACKING::pp_mode);
+  mm_match->set_pp_mode(TRACKING::streaming_mode);
   mm_match->set_rphi_search_window_lyr1(3.);
   mm_match->set_rphi_search_window_lyr2(15.0);
   mm_match->set_z_search_window_lyr1(30.0);
@@ -298,7 +298,7 @@ void Fun4All_FieldOnAllTrackersCalos(
       actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
       actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     }
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);

--- a/calibrations/tpc/TpcDVCalib/Fun4All_TrackAnalysis.C
+++ b/calibrations/tpc/TpcDVCalib/Fun4All_TrackAnalysis.C
@@ -170,7 +170,7 @@ void Fun4All_TrackAnalysis(
       actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
       actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
     }
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -792,7 +792,7 @@ void InputManagers()
     double extended_readout_time = 0.0;
     if (TRACKING::streaming_mode)
     {
-      extended_readout_time = TRACKING::pp_extended_readout_time;
+      extended_readout_time = TRACKING::extended_readout_time;
     }
     INPUTMANAGER::HepMCPileupInputManager->set_time_window(-time_window, time_window + extended_readout_time);
     std::cout << "Pileup window is from " << -time_window << " to " << time_window + extended_readout_time << std::endl;

--- a/common/G4_Input.C
+++ b/common/G4_Input.C
@@ -790,7 +790,7 @@ void InputManagers()
     INPUTMANAGER::HepMCPileupInputManager->set_collision_rate(Input::PILEUPRATE);
     double time_window = G4TPC::maxDriftLength / PILEUP::TpcDriftVelocity;
     double extended_readout_time = 0.0;
-    if (TRACKING::pp_mode)
+    if (TRACKING::streaming_mode)
     {
       extended_readout_time = TRACKING::pp_extended_readout_time;
     }

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -112,7 +112,7 @@ void Mvtx_Cells()
 
   double maps_readout_window = 9900.0;  // ns
   double extended_readout_time = 0.0;
-  if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   // override the default timing window - default is +/- 5000 ns
   maps_hits->set_double_param("mvtx_tmin", -maps_readout_window);
   maps_hits->set_double_param("mvtx_tmax", maps_readout_window + extended_readout_time);
@@ -218,7 +218,7 @@ void Intt_Cells()
 
   // The timing window defaults are set in the INTT ladder model, they can be overridden here
   double extended_readout_time = 0.0;
-  if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
   reco->set_double_param("tmax", 80.0 + extended_readout_time);
   reco->set_double_param("tmin", -20.0);
   std::cout << "INTT readout window is set to -20 to " << 80.0 + extended_readout_time << std::endl;
@@ -363,7 +363,7 @@ double TPC(PHG4Reco* g4Reco,
   }
 
   double extended_readout_time = 0.0;
-  if (TRACKING::pp_mode)
+  if (TRACKING::streaming_mode)
   {
     extended_readout_time = TRACKING::pp_extended_readout_time;
   }
@@ -654,7 +654,7 @@ void Micromegas_Cells()
   auto* reco = new PHG4MicromegasHitReco;
   reco->Verbosity(verbosity);
   double extended_readout_time = 0.0;
-  if (TRACKING::pp_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
 
   reco->set_double_param("micromegas_tmax", 800.0 + extended_readout_time);
   se->registerSubsystem(reco);

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -112,7 +112,7 @@ void Mvtx_Cells()
 
   double maps_readout_window = 9900.0;  // ns
   double extended_readout_time = 0.0;
-  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::extended_readout_time;
   // override the default timing window - default is +/- 5000 ns
   maps_hits->set_double_param("mvtx_tmin", -maps_readout_window);
   maps_hits->set_double_param("mvtx_tmax", maps_readout_window + extended_readout_time);
@@ -218,7 +218,7 @@ void Intt_Cells()
 
   // The timing window defaults are set in the INTT ladder model, they can be overridden here
   double extended_readout_time = 0.0;
-  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::extended_readout_time;
   reco->set_double_param("tmax", 80.0 + extended_readout_time);
   reco->set_double_param("tmin", -20.0);
   std::cout << "INTT readout window is set to -20 to " << 80.0 + extended_readout_time << std::endl;
@@ -365,7 +365,7 @@ double TPC(PHG4Reco* g4Reco,
   double extended_readout_time = 0.0;
   if (TRACKING::streaming_mode)
   {
-    extended_readout_time = TRACKING::pp_extended_readout_time;
+    extended_readout_time = TRACKING::extended_readout_time;
   }
 
   tpc->set_double_param("extended_readout_time", extended_readout_time);
@@ -414,7 +414,7 @@ double TPC(PHG4Reco* g4Reco,
   std::cout << "    drift_velocity_sim " << drift_vel << std::endl;
   std::cout << "    max_driftlength " << G4TPC::maxDriftLength << std::endl;
   std::cout << "    CM_halfwidth " << G4TPC::CM_halfwidth << std::endl;
-  std::cout << "    pp_extended_readout_time " << TRACKING::pp_extended_readout_time << std::endl;
+  std::cout << "    extended_readout_time " << TRACKING::extended_readout_time << std::endl;
 
   g4Reco->registerSubsystem(tpc);
 
@@ -654,7 +654,7 @@ void Micromegas_Cells()
   auto* reco = new PHG4MicromegasHitReco;
   reco->Verbosity(verbosity);
   double extended_readout_time = 0.0;
-  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::pp_extended_readout_time;
+  if (TRACKING::streaming_mode) extended_readout_time = TRACKING::extended_readout_time;
 
   reco->set_double_param("micromegas_tmax", 800.0 + extended_readout_time);
   se->registerSubsystem(reco);

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -82,7 +82,7 @@ namespace G4P6DECAYER
 namespace TRACKING
 {
   std::string TrackNodeName = "SvtxTrackMap";
-  bool pp_mode = false;
+  bool streaming_mode = false;
   double pp_extended_readout_time = 24900.0;  // ns
   bool reco_tpc_is_configured = false;
   int reco_tpc_maxtime_sample = 425;

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -83,7 +83,7 @@ namespace TRACKING
 {
   std::string TrackNodeName = "SvtxTrackMap";
   bool streaming_mode = false;
-  double pp_extended_readout_time = 24900.0;  // ns
+  double extended_readout_time = 24900.0;  // ns
   bool reco_tpc_is_configured = false;
   int reco_tpc_maxtime_sample = 425;
   int reco_tpc_time_presample = 40;  // 120 - 80

--- a/common/Trkr_Eval.C
+++ b/common/Trkr_Eval.C
@@ -44,10 +44,10 @@ void Tracking_Eval(const std::string& outputfile)
   eval->do_track_match(true);
   eval->set_use_initial_vertex(G4TRACKING::g4eval_use_initial_vertex);
   bool embed_scan = true;
-  if (TRACKING::pp_mode) embed_scan = false;
+  if (TRACKING::streaming_mode) embed_scan = false;
   eval->scan_for_embedded(embed_scan);   // take all tracks if false - take only embedded tracks if true
   eval->scan_for_primaries(embed_scan);  // defaults to only thrown particles for ntp_gtrack
-  std::cout << "SvtxEvaluator: pp_mode set to " << TRACKING::pp_mode << " and scan_for_embedded set to " << embed_scan << std::endl;
+  std::cout << "SvtxEvaluator: streaming_mode set to " << TRACKING::streaming_mode << " and scan_for_embedded set to " << embed_scan << std::endl;
   eval->Verbosity(verbosity);
 
   se->registerSubsystem(eval);

--- a/common/Trkr_LaserClustering.C
+++ b/common/Trkr_LaserClustering.C
@@ -78,7 +78,7 @@ void TPC_LaminationFitting()
     laminations->Verbosity(verbosity);
     laminations->set_phiHistInRad(G4TPC::USE_PHI_AS_RAD_AVERAGE_CORRECTIONS);
     laminations->set_nLayerCut(1);
-    laminations->set_ppMode(TRACKING::pp_mode);
+    laminations->set_ppMode(TRACKING::streaming_mode);
     laminations->set_fieldOff(G4TPC::BFieldOff);
     laminations->setOutputfile(G4TPC::LaminationOutputName);
     laminations->set_stripePatternFile(G4TPC::CMStripePattern);

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -75,7 +75,7 @@ void Tracking_Reco_Vertex_run2pp(const std::string& clusterMapName="TRKR_CLUSTER
   finder->setTrackQualityCut(300);
   finder->setNmvtxRequired(3);
   finder->setOutlierPairCut(0.10);
-  finder->set_pp_mode(TRACKING::pp_mode);
+  finder->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(finder);
 
   if (!G4TRACKING::convert_seeds_to_svtxtracks)
@@ -105,7 +105,7 @@ void Tracking_Reco_TrackFit_run2pp(const std::string &outfile = "run2pptrackfit.
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
   actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-  actsFit->set_pp_mode(TRACKING::pp_mode);
+  actsFit->set_pp_mode(TRACKING::streaming_mode);
   actsFit->set_use_clustermover(true);  // default is true for now
   actsFit->useActsEvaluator(false);
   actsFit->useOutlierFinder(false);
@@ -114,7 +114,7 @@ void Tracking_Reco_TrackFit_run2pp(const std::string &outfile = "run2pptrackfit.
 
   auto *cleaner = new PHTrackCleaner();
   cleaner->Verbosity(0);
-  cleaner->set_pp_mode(TRACKING::pp_mode);
+  cleaner->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(cleaner);
 
   if (G4TRACKING::SC_CALIBMODE)
@@ -270,7 +270,7 @@ void Tracking_Reco_SiTpcTrackMatching_run2pp(const std::string& clusterMapName =
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(verbosity);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
   silicon_match->set_cluster_map_name(clusterMapName);
   if (G4TPC::ENABLE_AVERAGE_CORRECTIONS)
   {
@@ -313,7 +313,7 @@ void Tracking_Reco_TpcTpotTrackMatching_run2pp(const std::string& clustermapname
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers
   auto *mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(verbosity);
-  mm_match->set_pp_mode(TRACKING::pp_mode);
+  mm_match->set_pp_mode(TRACKING::streaming_mode);
   mm_match->set_rphi_search_window_lyr1(3.);
   mm_match->set_rphi_search_window_lyr2(15.0);
   mm_match->set_z_search_window_lyr1(30.0);
@@ -534,7 +534,7 @@ void Tracking_Reco_TrackSeed()
   {
   }
 
-  seeder->set_pp_mode(TRACKING::pp_mode);
+  seeder->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(seeder);
 
   // expand stubs in the TPC using simple kalman filter
@@ -590,15 +590,15 @@ void Tracking_Reco_TrackSeed()
   {
   }
 
-  cprop->set_pp_mode(TRACKING::pp_mode);
+  cprop->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(cprop);
 
-  if (TRACKING::pp_mode)
+  if (TRACKING::streaming_mode)
   {
     // for pp mode, apply preliminary distortion corrections to TPC clusters before crossing is known
     // and refit the trackseeds. Replace KFProp fits with the new fit parameters in the TPC seeds.
     auto *prelim_distcorr = new PrelimDistortionCorrection;
-    prelim_distcorr->set_pp_mode(TRACKING::pp_mode);
+    prelim_distcorr->set_pp_mode(TRACKING::streaming_mode);
     prelim_distcorr->Verbosity(verbosity);
 
     if (G4TPC::TPC_GAS_MIXTURE == "NeCF4")
@@ -645,8 +645,8 @@ void Tracking_Reco_TrackSeed()
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(verbosity);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
-  std::cout << "PHSiliconTpcTrackMatching pp_mode set to " << TRACKING::pp_mode << std::endl;
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
+  std::cout << "PHSiliconTpcTrackMatching streaming_mode set to " << TRACKING::streaming_mode << std::endl;
   if (G4TRACKING::SC_CALIBMODE)
   {
     // search windows for initial matching with distortions
@@ -671,7 +671,7 @@ void Tracking_Reco_TrackSeed()
     // Match TPC track stubs from CA seeder to clusters in the micromegas layers
     auto *mm_match = new PHMicromegasTpcTrackMatching;
     mm_match->Verbosity(verbosity);
-    mm_match->set_pp_mode(TRACKING::pp_mode);
+    mm_match->set_pp_mode(TRACKING::streaming_mode);
     mm_match->set_rphi_search_window_lyr1(0.2);
     mm_match->set_rphi_search_window_lyr2(13.0);
     mm_match->set_z_search_window_lyr1(26.0);
@@ -689,7 +689,7 @@ void vertexing()
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
 
   auto *vtxfinder = new PHSimpleVertexFinder;
-  vtxfinder->set_pp_mode(TRACKING::pp_mode);
+  vtxfinder->set_pp_mode(TRACKING::streaming_mode);
   vtxfinder->Verbosity(verbosity);
   se->registerSubsystem(vtxfinder);
 }
@@ -739,7 +739,7 @@ void Tracking_Reco_TrackFit()
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);  // default is true for now
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);
@@ -876,7 +876,7 @@ void Tracking_Reco_CommissioningTrackSeed()
   {
   }
 
-  seeder->set_pp_mode(TRACKING::pp_mode);
+  seeder->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(seeder);
 
   // expand stubs in the TPC using simple kalman filter
@@ -928,15 +928,15 @@ void Tracking_Reco_CommissioningTrackSeed()
   {
   }
 
-  cprop->set_pp_mode(TRACKING::pp_mode);
+  cprop->set_pp_mode(TRACKING::streaming_mode);
   se->registerSubsystem(cprop);
 
-  if (TRACKING::pp_mode)
+  if (TRACKING::streaming_mode)
   {
     // for pp mode, apply preliminary distortion corrections to TPC clusters before crossing is known
     // and refit the trackseeds. Replace KFProp fits with the new fit parameters in the TPC seeds.
     auto *prelim_distcorr = new PrelimDistortionCorrection;
-    prelim_distcorr->set_pp_mode(TRACKING::pp_mode);
+    prelim_distcorr->set_pp_mode(TRACKING::streaming_mode);
     prelim_distcorr->Verbosity(verbosity);
 
     if (G4TPC::TPC_GAS_MIXTURE == "NeCF4")
@@ -984,7 +984,7 @@ void Tracking_Reco_CommissioningTrackSeed()
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(verbosity);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
 
   silicon_match->set_phi_search_window(0.2);
   silicon_match->set_eta_search_window(0.015);

--- a/common/Trkr_TruthReco.C
+++ b/common/Trkr_TruthReco.C
@@ -227,8 +227,8 @@ void Tracking_Reco_TrackSeed()
       // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
       auto *silicon_match = new PHSiliconTpcTrackMatching;
       silicon_match->Verbosity(verbosity);
-      silicon_match->set_pp_mode(TRACKING::pp_mode);
-      std::cout << "PHSiliconTpcTrackMatching pp_mode set to " << TRACKING::pp_mode << std::endl;
+      silicon_match->set_pp_mode(TRACKING::streaming_mode);
+      std::cout << "PHSiliconTpcTrackMatching streaming_mode set to " << TRACKING::streaming_mode << std::endl;
       if (G4TRACKING::SC_CALIBMODE)
       {
         // search windows for initial matching with distortions
@@ -354,7 +354,7 @@ void Tracking_Reco_TrackFit()
     // in calibration mode, fit only Silicons and Micromegas hits
     actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
     actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
+    actsFit->set_pp_mode(TRACKING::streaming_mode);
     actsFit->set_use_clustermover(true);
     actsFit->useActsEvaluator(false);
     actsFit->useOutlierFinder(false);
@@ -547,7 +547,7 @@ void Tracking_Reco_CommissioningTrackSeed()
   // Match the TPC track stubs from the CA seeder to silicon track stubs from PHSiliconTruthTrackSeeding
   auto *silicon_match = new PHSiliconTpcTrackMatching;
   silicon_match->Verbosity(verbosity);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
+  silicon_match->set_pp_mode(TRACKING::streaming_mode);
 
   silicon_match->set_phi_search_window(0.2);
   silicon_match->set_eta_search_window(0.015);


### PR DESCRIPTION
The names `pp_extended_readout_time` and `pp_mode` had caused confusion about whether or not they apply to the OO data. The streaming readout reconstruction is the same, so this PR refactors the variables to a more general name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Motivation / context**

This PR refactors tracking configuration flag names to use more general *streaming_mode* terminology, avoiding ambiguity about whether the settings apply only to pp data. The intent is to keep reconstruction behavior consistent while improving clarity.

**Key changes**
- Replaced `TRACKING::pp_mode` with `TRACKING::streaming_mode` across jet production, tracking production, calibration, and common reconstruction macros.
- Renamed `TRACKING::pp_extended_readout_time` to `TRACKING::extended_readout_time`, and updated pileup/readout timing logic and diagnostics to use the new names.
- Updated downstream configuration plumbing to pass `streaming_mode` through relevant `set_pp_mode(...)` APIs and conditionals (including `embed_scan` gating and key tracking steps like vertexing/matching/fitting/cleaning).
- Updated `common/GlobalVariables.C` to remove the old `pp_*` globals and introduce `streaming_mode` / `extended_readout_time`.
- Residual references to the old `pp_mode` / `pp_extended_readout_time` identifiers appear to be limited to commented-out lines (no active logic found in the quick scan).

**Potential risk areas**
- Reconstruction behavior changes if any component interprets `streaming_mode` differently than the prior `pp_mode` semantics.
- Compatibility risk for external workflows/macros that may still reference the old global names (even if this repo is updated).
- Timing/pileup effects if `extended_readout_time` is consumed differently than `pp_extended_readout_time`.
- Thread-safety concerns are unlikely to increase from a rename alone, but should be re-validated where these globals are read during initialization.

**Possible future improvements**
- Remove/clean remaining commented references to the old `pp_*` terminology and update any documentation/examples.
- Add/confirm regression checks (e.g., tracking QA and timing/pileup validation) to verify behavior is unchanged end-to-end.
- If external users need time to migrate, consider a deprecation/compatibility layer for the old names.

AI can make mistakes, so please use best judgment when reviewing the renamed configuration paths and their downstream effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->