### PR TITLE
Separate streaming luminosity calculation

### DIFF
--- a/BcoLumiProduction/Fun4All_StreamingBco.C
+++ b/BcoLumiProduction/Fun4All_StreamingBco.C
@@ -1,0 +1,76 @@
+
+#include <bcolumicount/StreamingBcoReco.h>
+
+#include <ffamodules/SyncReco.h>
+
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+
+#include <fun4allraw/Fun4AllPrdfInputManager.h>
+
+
+#include <phool/recoConsts.h>
+
+#include <Rtypes.h> // defines R__LOAD_LIBRARY macro for clang-tidy
+#include <TSystem.h>
+#include <fstream>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libbcolumicount.so)
+R__LOAD_LIBRARY(libffamodules.so)
+
+void Fun4All_StreamingBco(const int nEvents = 0,
+		      const std::string &inlist = "gl1daq.list")
+{
+
+  std::string bcodst = "DST_BCOINFO-";
+  std::string outfile = "DST_STREAMING_BCOINFO-";
+  std::string histfile = "bco_histos-";
+  std::ifstream file("gl1daq.list");  // open the file
+  if (!file.is_open()) {
+    std::cerr << "Failed to open file\n";
+  }
+
+  // There is probably a better way to do this... revisit!
+  std::string infilename;
+  if (std::getline(file, infilename)) {
+      std::string run_segments = infilename.substr(infilename.size() - 17, 8);
+      outfile += run_segments;
+      outfile += ".root";
+      bcodst += run_segments;
+      bcodst += ".root";
+      histfile += run_segments;
+      histfile += ".root";
+  } else {
+      std::cout << "File is empty or read failed\n";
+  }
+  gSystem->Load("libg4dst.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+  //se->Verbosity(1);
+
+  StreamingBcoReco *streaming_bco = new StreamingBcoReco();
+  //streaming_bco->Verbosity(2);
+
+  se->registerSubsystem(streaming_bco);
+  Fun4AllPrdfInputManager *in_prdf = new Fun4AllPrdfInputManager("PRDFin");
+  //in->Verbosity(10);
+  in_prdf->AddListFile(inlist);
+  se->registerInputManager(in_prdf);
+
+  Fun4AllInputManager *in_dst = new Fun4AllDstInputManager("DSTin");
+  in_dst->AddFile(bcodst);
+  se->registerInputManager(in_dst);
+
+  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out",outfile);
+  se->registerOutputManager(out);
+
+  se->run(nEvents);
+
+  se->dumpHistos(histfile);
+  se->End();
+  delete se;
+  gSystem->Exit(0);
+}

--- a/BcoLumiProduction/Fun4All_StreamingLumi.C
+++ b/BcoLumiProduction/Fun4All_StreamingLumi.C
@@ -1,5 +1,5 @@
 
-#include <bcolumicount/StreamingBcoLumiReco.h>
+#include <bcolumicount/StreamingLumiReco.h>
 
 #include <ffamodules/SyncReco.h>
 
@@ -22,13 +22,12 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libbcolumicount.so)
 R__LOAD_LIBRARY(libffamodules.so)
 
-void Fun4All_StreamingBcoLumi(const int nEvents = 0,
+void Fun4All_StreamingLumi(const int nEvents = 0,
 		      const std::string &inlist = "gl1daq.list")
 {
 
   std::string bcodst = "DST_BCOINFO-";
-  std::string outfile = "DST_STREAMINGLUMI_BCOINFO-";
-  std::string histfile = "bco_histos-";
+  std::string outfile = "DST_STREAMING_LUMIINFO-";
   std::ifstream file("gl1daq.list");  // open the file
   if (!file.is_open()) {
     std::cerr << "Failed to open file\n";
@@ -42,8 +41,6 @@ void Fun4All_StreamingBcoLumi(const int nEvents = 0,
       outfile += ".root";
       bcodst += run_segments;
       bcodst += ".root";
-      histfile += run_segments;
-      histfile += ".root";
   } else {
       std::cout << "File is empty or read failed\n";
   }
@@ -51,10 +48,10 @@ void Fun4All_StreamingBcoLumi(const int nEvents = 0,
   Fun4AllServer *se = Fun4AllServer::instance();
   //se->Verbosity(1);
 
-  StreamingBcoLumiReco *lumi = new StreamingBcoLumiReco();
-  //lumi->Verbosity(2);
+  StreamingLumiReco *streaming_lumi = new StreamingLumiReco();
+  //streaming_lumi->Verbosity(2);
 
-  se->registerSubsystem(lumi);
+  se->registerSubsystem(streaming_lumi);
   Fun4AllPrdfInputManager *in_prdf = new Fun4AllPrdfInputManager("PRDFin");
   //in->Verbosity(10);
   in_prdf->AddListFile(inlist);
@@ -69,7 +66,6 @@ void Fun4All_StreamingBcoLumi(const int nEvents = 0,
 
   se->run(nEvents);
 
-  se->dumpHistos(histfile);
   se->End();
   delete se;
   gSystem->Exit(0);

--- a/BcoLumiProduction/Fun4All_StreamingLumi.C
+++ b/BcoLumiProduction/Fun4All_StreamingLumi.C
@@ -26,7 +26,7 @@ void Fun4All_StreamingLumi(const int nEvents = 0,
 		      const std::string &inlist = "gl1daq.list")
 {
 
-  std::string bcodst = "DST_BCOINFO-";
+  std::string streaming_bcodst = "DST_STREAMING_BCOINFO-";
   std::string outfile = "DST_STREAMING_LUMIINFO-";
   std::ifstream file("gl1daq.list");  // open the file
   if (!file.is_open()) {
@@ -39,8 +39,8 @@ void Fun4All_StreamingLumi(const int nEvents = 0,
       std::string run_segments = infilename.substr(infilename.size() - 17, 8);
       outfile += run_segments;
       outfile += ".root";
-      bcodst += run_segments;
-      bcodst += ".root";
+      streaming_bcodst += run_segments;
+      streaming_bcodst += ".root";
   } else {
       std::cout << "File is empty or read failed\n";
   }
@@ -58,7 +58,7 @@ void Fun4All_StreamingLumi(const int nEvents = 0,
   se->registerInputManager(in_prdf);
 
   Fun4AllInputManager *in_dst = new Fun4AllDstInputManager("DSTin");
-  in_dst->AddFile(bcodst);
+  in_dst->AddFile(streaming_bcodst);
   se->registerInputManager(in_dst);
 
   Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out",outfile);

--- a/BcoLumiProduction/Fun4All_Test_StreamingBco.C
+++ b/BcoLumiProduction/Fun4All_Test_StreamingBco.C
@@ -1,5 +1,5 @@
 
-#include <bcolumicount/StreamingBcoLumiCheck.h>
+#include <bcolumicount/StreamingBcoCheck.h>
 
 #include <ffamodules/SyncReco.h>
 
@@ -21,16 +21,16 @@ R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libbcolumicount.so)
 R__LOAD_LIBRARY(libffamodules.so)
 
-void Fun4All_Test_StreamingBcoLumi(const int nEvents = 0,
-          const std::string &bcodst = "DST_STREAMINGLUMI_BCOINFO-00052050.root")
+void Fun4All_Test_StreamingBco(const int nEvents = 0,
+          const std::string &bcodst = "DST_STREAMING_BCOINFO-00052050.root")
 {
   gSystem->Load("libg4dst.so");
   Fun4AllServer *se = Fun4AllServer::instance();
   //se->Verbosity(1);
 
-  StreamingBcoLumiCheck *lumi_streaming = new StreamingBcoLumiCheck();
-  //lumi_streaming->Verbosity(10);
-  se->registerSubsystem(lumi_streaming);
+  StreamingBcoCheck *streaming_bco_check = new StreamingBcoCheck();
+  //streaming_bco_check->Verbosity(10);
+  se->registerSubsystem(streaming_bco_check);
 
 
   Fun4AllInputManager *in_dst = new Fun4AllDstInputManager("in");

--- a/BcoLumiProduction/Fun4All_Test_StreamingLumi.C
+++ b/BcoLumiProduction/Fun4All_Test_StreamingLumi.C
@@ -1,0 +1,46 @@
+
+#include <bcolumicount/StreamingLumiCheck.h>
+
+#include <ffamodules/SyncReco.h>
+
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+
+#include <fun4allraw/Fun4AllPrdfInputManager.h>
+
+
+#include <phool/recoConsts.h>
+
+#include <Rtypes.h> // defines R__LOAD_LIBRARY macro for clang-tidy
+#include <TSystem.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libbcolumicount.so)
+R__LOAD_LIBRARY(libffamodules.so)
+
+void Fun4All_Test_StreamingLumi(const int nEvents = 0,
+          const std::string &bcodst = "DST_STREAMING_LUMIINFO-00052050.root")
+{
+  gSystem->Load("libg4dst.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+  //se->Verbosity(1);
+
+  StreamingLumiCheck *streaming_lumi_check = new StreamingLumiCheck();
+  //streaming_lumi_check->Verbosity(10);
+  se->registerSubsystem(streaming_lumi_check);
+
+
+  Fun4AllInputManager *in_dst = new Fun4AllDstInputManager("in");
+  in_dst->AddFile(bcodst);
+  se->registerInputManager(in_dst);
+
+
+  se->run(nEvents);
+
+  se->End();
+  delete se;
+  gSystem->Exit(0);
+}


### PR DESCRIPTION
Separate streaming luminosity calculation into its own Subsysreco module (StreamingLumiReco). Modify corresponding macros accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR decouples the streaming luminosity reconstruction from the BCO-only workflow by introducing a dedicated `StreamingLumiReco` subsystem and updating the Fun4All entry-point macros and tests to match.

**Motivation / context**
- Separate the streaming luminosity reconstruction path from the BCO production chain for clearer maintenance and more explicit dataflow.
- Align production and validation macros with the new modular reconstruction structure.

**Key changes**
- Added `BcoLumiProduction/Fun4All_StreamingLumi.C` as the new job entrypoint:
  - loads required libraries
  - derives a run-segment suffix from `gl1daq.list`
  - runs `StreamingLumiReco`
  - reads `DST_STREAMING_BCOINFO-<segment>.root`
  - writes `DST_STREAMING_LUMIINFO-<segment>.root`
- Updated `BcoLumiProduction/Fun4All_StreamingBco.C`:
  - switches to `StreamingBcoReco` (instead of `StreamingBcoLumiReco`)
  - renames the exported macro entry to `Fun4All_StreamingBco`
  - changes output DST prefix to `DST_STREAMING_BCOINFO-...`
- Added/updated validation macros:
  - `BcoLumiProduction/Fun4All_Test_StreamingBco.C` uses `StreamingBcoCheck` and defaults to `DST_STREAMING_BCOINFO-00052050.root`
  - `BcoLumiProduction/Fun4All_Test_StreamingLumi.C` uses `StreamingLumiCheck` and defaults to `DST_STREAMING_LUMIINFO-00052050.root`

**Potential risk areas**
- **IO format / filename conventions:** DST chaining now depends on `DST_STREAMING_BCOINFO-*` → `DST_STREAMING_LUMIINFO-*`; downstream workflows expecting older names may break.
- **Reconstruction behavior changes:** splitting luminosity into its own `StreamingLumiReco` stage could lead to differences vs the previous combined/alternative module path.
- **Assumptions around `gl1daq.list` parsing:** behavior when the run-segment extraction fails may propagate incorrect filenames.

**Possible future improvements**
- Add regression/validation to compare old vs new outputs for the same segments.
- Tighten validation around `gl1daq.list` parsing and segment extraction (fail fast or explicitly warn/abort when malformed).

AI can make mistakes—please use best judgment when reading this summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->