### PR TITLE
Add TPC tilt angles to macros, default is zero for all

### DIFF
--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -316,6 +316,13 @@ void TPC_Endcaps(PHG4Reco* g4Reco)
 
   //  tpc_endcap->set_int_param("construction_verbosity", 2);
 
+  // set the TPC tilt in sPHENIX
+  tpc_endcap->set_double_param("rot_x", G4TPC::rot_x);
+  tpc_endcap->set_double_param("rot_y", G4TPC::rot_y);
+  tpc_endcap->set_double_param("rot_z", G4TPC::rot_z);
+  std::cout << "G4_TrkrSimulation: Setting TPC endcap tilt angles to rot_x = " << G4TPC::rot_x
+	    << " roty = " << G4TPC::rot_y << " rot_z = " << G4TPC::rot_z << std::endl;
+  
   g4Reco->registerSubsystem(tpc_endcap);
 
   return;
@@ -353,6 +360,12 @@ double TPC(PHG4Reco* g4Reco,
   tpc->set_double_param("tpc_length", G4TPC::maxDriftLength * 2 + G4TPC::CM_halfwidth * 2);
   tpc->set_double_param("maxdriftlength", G4TPC::maxDriftLength);
   tpc->set_double_param("CM_halfwidth", G4TPC::CM_halfwidth);
+  // set the TPC tilt in sPHENIX
+  tpc->set_double_param("rot_x", G4TPC::rot_x);
+  tpc->set_double_param("rot_y", G4TPC::rot_y);
+  tpc->set_double_param("rot_z", G4TPC::rot_z);
+  std::cout << "G4_TrkrSimulation: Setting TPC tilt angles to rot_x = " << G4TPC::rot_x
+	    << " roty = " << G4TPC::rot_y << " rot_z = " << G4TPC::rot_z << std::endl;
   tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
   tpc->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -212,6 +212,9 @@ namespace G4TPC
 
   double maxDriftLength = 102.325;  // new value, CM face to top of GEM stack
   double CM_halfwidth = 0.28;  // cm
+   double rot_x = 0.0;  // tpc default tilt angles (for tpc envelope and endcap)
+  double rot_y = 0.0;
+  double rot_z = 0.0;
   double sampa_tzero_bias = -65.0; // ns, set for simulations/reco matching with new sampa response
   bool apply_tpc_tzero_correction = false;  // true to apply small correction to TPC time zero in alignment transforms
 

--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -358,6 +358,12 @@ int Fun4All_G4_sPHENIX(
   // TRACKING::pp_mode = true;
   // TRACKING::pp_extended_readout_time = 20000;
 
+  // Place to set TPC tilt angles for envelope and endcaps, if desired
+  G4TPC::rot_x = 0.0;
+  G4TPC::rot_y = 0.0;
+  G4TPC::rot_z = 0.0;
+  std::cout << "Fun4All macro: Setting TPC tilt angles to rot_x = " << G4TPC::rot_x << " roty = " << G4TPC::rot_y << " rot_z = " << G4TPC::rot_z << std::endl;
+  
   // set flags to simulate and correct TPC distortions, specify distortion and correction files
   //G4TPC::ENABLE_STATIC_DISTORTIONS = true;
   //G4TPC::static_distortion_filename = std::string("/sphenix/user/rcorliss/distortion_maps/2023.02/Summary_hist_mdc2_UseFieldMaps_AA_event_0_bX180961051_0.distortion_map.hist.root");


### PR DESCRIPTION
This adds the rotation angles for the TPC gas envelope and TPC endcap tilt angle to G4_TrkrVariables and G4_TrkrSimulations, so they can be set from the macro using the G4TPC::rot_x, G4TPC::rot_y and G4TPC_rot_z variables. A placeholder is added to Fun4All_G4_sPHENIX.C where they can be set conveniently. It defaults to zero values.

This macros PR complements coresoftware PR#4308.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change exposes TPC tilt-angle configuration in the macro path so the gas envelope and endcap geometry can be rotated without code edits. It complements the corresponding geometry-side support by wiring the new angles through the simulation setup and adding a convenient default configuration entry.

- Added `G4TPC::rot_x`, `G4TPC::rot_y`, and `G4TPC::rot_z` to `G4_TrkrVariables`, defaulting to `0.0`.
- Updated `G4_TrkrSimulation` so both the TPC body and endcaps read and apply these rotation angles during setup.
- Added a placeholder/configuration block in `Fun4All_G4_sPHENIX.C` to set and report the TPC rotation values at runtime.
- Kept defaults unchanged for existing workflows unless the new macro settings are used.

Potential risk areas:
- Geometry/IO behavior may change if non-zero rotations are enabled, affecting downstream reconstruction inputs and comparisons.
- Small risk of inconsistencies if macro values are set differently across jobs or forgotten in production configs.
- Logging to stdout may slightly affect output formatting in some workflows.

Possible future improvements:
- Add validation/range checks for rotation inputs.
- Document the new macro knobs more prominently in example configs.
- Extend similar configuration handling to other detector geometry parameters where useful.

AI can make mistakes; please use best judgment when reviewing the exact implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->