### PR TITLE
adjustments for new calowaveformsim

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -339,11 +339,10 @@ void CEMC_Towers()
   }
   else
   {
-    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim();
+    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim("CEMCCaloWaveformSim");
     caloWaveformSim->set_detector_type(CaloTowerDefs::CEMC);
     caloWaveformSim->set_detector("CEMC");
     caloWaveformSim->set_nsamples(12);
-    caloWaveformSim->set_pedestalsamples(12);
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
     caloWaveformSim->get_light_collection_model().load_data_file(
@@ -361,9 +360,17 @@ void CEMC_Towers()
     }
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+
+    // calibration overrides:
+    // caloWaveformSim->set_calibName("CEMC_calib_ADC_to_ETower");
+    // caloWaveformSim->set_fieldname("CEMC_calib_ADC_to_ETower");
+    // caloWaveformSim->set_directURL_calib("CEMC_MC_calib_default.root");
+    // caloWaveformSim->set_MC_calibName("CEMC_MC_RECALIB");
+    // caloWaveformSim->set_MC_fieldname("CEMC_calib_ADC_to_ETower");
+    // caloWaveformSim->set_directURL_MCcalib("CEMC_MC_calib_default_v3.root");
     se->registerSubsystem(caloWaveformSim);
 
-    CaloTowerBuilder *ca2 = new CaloTowerBuilder();
+    CaloTowerBuilder *ca2 = new CaloTowerBuilder("CEMCCaloTowerBuilder");
     ca2->set_detector_type(CaloTowerDefs::CEMC);
     ca2->set_nsamples(12);
     ca2->set_dataflag(false);

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -344,18 +344,18 @@ void HCALInner_Towers()
   }
   else
   {
-    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim();
+    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim("HCALINCaloWaveformSim");
     caloWaveformSim->set_detector_type(CaloTowerDefs::HCALIN);
     caloWaveformSim->set_detector("HCALIN");
     caloWaveformSim->set_nsamples(12);
-    caloWaveformSim->set_pedestalsamples(12);
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+    //caloWaveformSim->set_calibName("HCALIN_calib_ADC_to_ETower");
     se->registerSubsystem(caloWaveformSim);
 
-    CaloTowerBuilder *ca2 = new CaloTowerBuilder();
+    CaloTowerBuilder *ca2 = new CaloTowerBuilder("HCALINCaloTowerBuilder");
     ca2->set_detector_type(CaloTowerDefs::HCALIN);
     ca2->set_nsamples(12);
     ca2->set_dataflag(false);

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -380,18 +380,18 @@ void HCALOuter_Towers()
   // where I use waveformsim
   else
   {
-    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim();
+    CaloWaveformSim *caloWaveformSim = new CaloWaveformSim("HCALOUTCaloWaveformSim");
     caloWaveformSim->set_detector_type(CaloTowerDefs::HCALOUT);
     caloWaveformSim->set_detector("HCALOUT");
     caloWaveformSim->set_nsamples(12);
-    caloWaveformSim->set_pedestalsamples(12);
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
+    caloWaveformSim->set_calibName("HCALOUT_calib_ADC_to_ETower");
     se->registerSubsystem(caloWaveformSim);
 
-    CaloTowerBuilder *ca2 = new CaloTowerBuilder();
+    CaloTowerBuilder *ca2 = new CaloTowerBuilder("HCALOUTCaloTowerBuilder");
     ca2->set_detector_type(CaloTowerDefs::HCALOUT);
     ca2->set_nsamples(12);
     ca2->set_dataflag(false);


### PR DESCRIPTION
This PR removes the not needed setting of the number of samples in the pedestal (which in the worst case scenario really messes things up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Motivation / context:  
Adjust the calorimeter waveform simulation setup for the new `CaloWaveformSim` behavior by removing pedestal sample configuration that is no longer needed and may cause incorrect behavior in edge cases. Please note that AI-assisted summaries can make mistakes; use best judgment when reviewing the changes.

Key changes:
- Removed `set_pedestalsamples(12)` from waveform-based tower building in:
  - `common/G4_CEmc_Spacal.C`
  - `common/G4_HcalIn_ref.C`
  - `common/G4_HcalOut_ref.C`
- Switched `CaloWaveformSim` and `CaloTowerBuilder` construction to named instances in the updated branches.
- Added a calibration mapping for HCAL outer waveform simulation:
  - `HCALOUT_calib_ADC_to_ETower`
- Left existing waveform/tower-building logic otherwise unchanged.

Potential risk areas:
- Reconstruction behavior changes due to altered waveform/pedestal handling.
- IO/format expectations if downstream code assumes the previous pedestal sample setting.
- Performance impact should be minimal, but named-instance configuration may affect debugging/logging behavior.
- Thread-safety concerns are not evident from the diff, but should be validated in standard multi-threaded workflows.

Possible future improvements:
- Add regression checks comparing tower response before/after the waveform-sim update.
- Document the expected `CaloWaveformSim` configuration for each calorimeter subsystem.
- Verify calibration and reconstruction outputs on representative datasets to confirm no unintended physics changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->