### PR TITLE
fix: zf macro running on run3pp

### DIFF
--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -197,7 +197,7 @@ void Fun4All_ZFAllTrackers(
   }
   else
   {
-    auto weightedFitter = new WeightedFitter;
+    auto *weightedFitter = new WeightedFitter;
     weightedFitter->set_track_map_node_name( "SvtxTrackMap" );
 
     if( !G4TRACKING::SC_USE_MICROMEGAS )

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -31,7 +31,7 @@
 #include <trackingdiagnostics/TrackResiduals.h>
 #include <trackingdiagnostics/TrkrNtuplizer.h>
 
-#include <trackreco/AzimuthalSeeder.h>
+#include <trackreco/WeightedFitter.h>
 
 #include <ffamodules/CDBInterface.h>
 
@@ -59,27 +59,53 @@ R__LOAD_LIBRARY(libtrackingqa.so)
 R__LOAD_LIBRARY(libEventDisplay.so)
 void Fun4All_ZFAllTrackers(
     const int nEvents = 0,
-    const std::string& tpcfilename = "DST_TRKR_CLUSTER_run2pp_ana466_2024p012_v001-00052077-00000.root",
-    const std::string& tpcdir = "/sphenix/lustre01/sphnxpro/production/run2pp/physics/ana466_2024p012_v001/DST_TRKR_CLUSTER/run_00052000_00052100/dst/",
+    const std::string& filelist = "filelist.list",
     const std::string& outfilename = "clusters_seeds",
     const bool convertSeeds = true)
 {
-  std::string inputtpcRawHitFile = tpcdir + tpcfilename;
-
   G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
   std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
-  std::pair<int, int>
-      runseg = Fun4AllUtils::GetRunSegment(tpcfilename);
-  int runnumber = runseg.first;
-  int segment = runseg.second;
+  
+  auto *rc = recoConsts::instance();
+  auto *se = Fun4AllServer::instance();
+  
+    // input manager for QM production raw hit DST file
+  std::ifstream ifs(filelist);
+  std::string filepath;
+
+  int i = 0;
+  int runnumber = std::numeric_limits<int>::quiet_NaN();
+  int segment = std::numeric_limits<int>::quiet_NaN();
+
+
+  while (std::getline(ifs, filepath))
+  {
+    std::cout << "Adding DST with filepath: " << filepath << std::endl;
+    if (i == 0)
+    {
+      std::pair<int, int>
+          runseg = Fun4AllUtils::GetRunSegment(filepath);
+      runnumber = runseg.first;
+      segment = runseg.second;
+      rc->set_IntFlag("RUNNUMBER", runnumber);
+      rc->set_uint64Flag("TIMESTAMP", runnumber);
+    }
+
+    std::string inputname = "InputManager" + std::to_string(i);
+    auto *hitsin = new Fun4AllDstInputManager(inputname);
+    hitsin->fileopen(filepath);
+    se->registerInputManager(hitsin);
+    i++;
+  }
+
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+  rc->set_IntFlag("RUNSEGMENT", segment);
 
   G4TRACKING::SC_CALIBMODE = false;
   Enable::MVTX_APPLYMISALIGNMENT = true;
   ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
   TRACKING::pp_mode = true;
 
-  auto *rc = recoConsts::instance();
-  rc->set_IntFlag("RUNNUMBER", runnumber);
   Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
   rc->set_uint64Flag("TIMESTAMP", runnumber);
@@ -94,7 +120,6 @@ void Fun4All_ZFAllTrackers(
 
 
   std::string theOutfile = outfilename + "_" + std::to_string(runnumber) + "-" + std::to_string(segment) + ".root";
-  auto *se = Fun4AllServer::instance();
   se->Verbosity(1);
 
   Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
@@ -106,48 +131,43 @@ void Fun4All_ZFAllTrackers(
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 
-  auto *hitsin = new Fun4AllDstInputManager("InputManager");
-  hitsin->fileopen(inputtpcRawHitFile);
-  // hitsin->AddFile(inputMbd);
-  se->registerInputManager(hitsin);
 
-  TRACKING::tpc_zero_supp = true;
-  /*
-  Mvtx_HitUnpacking();
-  Intt_HitUnpacking();
-  Tpc_HitUnpacking();
+  
+  for (int felix = 0; felix < 6; felix++)
+  {
+    Mvtx_HitUnpacking(std::to_string(felix));
+  }
+  for (int server = 0; server < 8; server++)
+  {
+    Intt_HitUnpacking(std::to_string(server));
+  }
+  std::ostringstream ebdcname;
+  for (int ebdc = 0; ebdc < 24; ebdc++)
+  {
+    for (int endpoint = 0; endpoint < 2; endpoint++)
+      {
+        ebdcname.str("");
+        if (ebdc < 10)
+	  {
+	    ebdcname << "0";
+	  }
+        ebdcname << ebdc << "_" << endpoint;
+        Tpc_HitUnpacking(ebdcname.str());
+      }
+  }
+
   Micromegas_HitUnpacking();
 
   Mvtx_Clustering();
   Intt_Clustering();
-
-  auto tpcclusterizer = new TpcClusterizer;
-  tpcclusterizer->Verbosity(0);
-  tpcclusterizer->set_do_hit_association(G4TPC::DO_HIT_ASSOCIATION);
-  tpcclusterizer->set_rawdata_reco();
-  se->registerSubsystem(tpcclusterizer);
-
+  TPC_Clustering_run2pp();
   Micromegas_Clustering();
-  */
+  
 
   // this now does Si and TPC seeding only
   Tracking_Reco_TrackSeed_ZeroField();
 
-  auto *silicon_match = new PHSiliconTpcTrackMatching;
-  silicon_match->Verbosity(0);
-  // set search windows matching Silicon to TPC seeds
-  // Selected for tracks with ntpc>34,|z_Si-z_TPC|<30,crossing==0
-  // see https://indico.bnl.gov/event/26202/attachments/59703/102575/2025_01_31_ZeroField.pdf
-  // Will probably be narrowed from improved alignment soon.
-  silicon_match->window_dx.set_QoverpT_maxabs({2.6,0,0});
-  silicon_match->window_dy.set_QoverpT_maxabs({2.3,0,0});
-  silicon_match->window_dz.set_QoverpT_range({-2.9,0,0},{4.2,0,0});
-  silicon_match->window_deta.set_QoverpT_maxabs({0.06,0,0});
-  silicon_match->window_dphi.set_QoverpT_maxabs({0.11,0,0});
-  silicon_match->set_test_windows_printout(false);
-  silicon_match->set_pp_mode(TRACKING::pp_mode);
-  silicon_match->zeroField(true);
-  se->registerSubsystem(silicon_match);
+  Tracking_Reco_SiTpcTrackMatching_run2pp();
 
   auto *mm_match = new PHMicromegasTpcTrackMatching;
   mm_match->Verbosity(0);
@@ -177,23 +197,17 @@ void Fun4All_ZFAllTrackers(
   }
   else
   {
-    auto *deltazcorr = new PHTpcDeltaZCorrection;
-    deltazcorr->Verbosity(0);
-    se->registerSubsystem(deltazcorr);
+    auto weightedFitter = new WeightedFitter;
+    weightedFitter->set_track_map_node_name( "SvtxTrackMap" );
 
-    // perform final track fit with ACTS
-    auto *actsFit = new PHActsTrkFitter;
-    actsFit->Verbosity(0);
-    actsFit->commissioning(G4TRACKING::use_alignment);
-    // in calibration mode, fit only Silicons and Micromegas hits
-    actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-    actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-    actsFit->set_pp_mode(TRACKING::pp_mode);
-    actsFit->set_use_clustermover(true);  // default is true for now
-    actsFit->useActsEvaluator(false);
-    actsFit->useOutlierFinder(false);
-    actsFit->setFieldMap(G4MAGNET::magfield_tracking);
-    se->registerSubsystem(actsFit);
+    if( !G4TRACKING::SC_USE_MICROMEGAS )
+    {
+      // exclude TPOT from fit
+      weightedFitter->exclude_layer_in_fit(55);
+      weightedFitter->exclude_layer_in_fit(56);
+    }
+
+    se->registerSubsystem(weightedFitter);
   }
 
 
@@ -215,7 +229,7 @@ void Fun4All_ZFAllTrackers(
   resid->outfileName(residstring);
   resid->alignment(false);
   resid->clusterTree();
-  resid->hitTree();
+  //resid->hitTree();
   resid->zeroField();
   resid->convertSeeds(G4TRACKING::convert_seeds_to_svtxtracks);
   resid->Verbosity(0);

--- a/TrackingProduction/Fun4All_ZFAllTrackers.C
+++ b/TrackingProduction/Fun4All_ZFAllTrackers.C
@@ -1,4 +1,4 @@
- /*
+/*
  * This macro shows a minimum working example of running the tracking
  * hit unpackers with some basic seeding algorithms to try to put together
  * tracks. There are some analysis modules run at the end which package
@@ -14,9 +14,9 @@
 #include <G4_Magnet.C>
 #include <G4_Mbd.C>
 #include <QA.C>
-#include <Trkr_RecoInit.C>
 #include <Trkr_Clustering.C>
 #include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
 #include <Trkr_TpcReadoutInit.C>
 
 #include <eventdisplay/TrackerEventDisplay.h>
@@ -45,7 +45,6 @@
 
 #include <phool/recoConsts.h>
 
-
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffamodules.so)
 R__LOAD_LIBRARY(libphool.so)
@@ -59,24 +58,23 @@ R__LOAD_LIBRARY(libtrackingqa.so)
 R__LOAD_LIBRARY(libEventDisplay.so)
 void Fun4All_ZFAllTrackers(
     const int nEvents = 0,
-    const std::string& filelist = "filelist.list",
-    const std::string& outfilename = "clusters_seeds",
+    const std::string &filelist = "filelist.list",
+    const std::string &outfilename = "clusters_seeds",
     const bool convertSeeds = true)
 {
   G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
   std::cout << "Converting to seeds : " << G4TRACKING::convert_seeds_to_svtxtracks << std::endl;
-  
+
   auto *rc = recoConsts::instance();
   auto *se = Fun4AllServer::instance();
-  
-    // input manager for QM production raw hit DST file
+
+  // input manager for QM production raw hit DST file
   std::ifstream ifs(filelist);
   std::string filepath;
 
   int i = 0;
   int runnumber = std::numeric_limits<int>::quiet_NaN();
   int segment = std::numeric_limits<int>::quiet_NaN();
-
 
   while (std::getline(ifs, filepath))
   {
@@ -111,13 +109,12 @@ void Fun4All_ZFAllTrackers(
   rc->set_uint64Flag("TIMESTAMP", runnumber);
   std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
 
-  TpcReadoutInit( runnumber );
-  std::cout<< " run: " << runnumber
-	   << " samples: " << TRACKING::reco_tpc_maxtime_sample
-	   << " pre: " << TRACKING::reco_tpc_time_presample
-	   << " vdrift: " << G4TPC::tpc_drift_velocity_reco
-	   << std::endl;
-
+  TpcReadoutInit(runnumber);
+  std::cout << " run: " << runnumber
+            << " samples: " << TRACKING::reco_tpc_maxtime_sample
+            << " pre: " << TRACKING::reco_tpc_time_presample
+            << " vdrift: " << G4TPC::tpc_drift_velocity_reco
+            << std::endl;
 
   std::string theOutfile = outfilename + "_" + std::to_string(runnumber) + "-" + std::to_string(segment) + ".root";
   se->Verbosity(1);
@@ -131,8 +128,6 @@ void Fun4All_ZFAllTrackers(
   G4MAGNET::magfield_rescale = 1;
   TrackingInit();
 
-
-  
   for (int felix = 0; felix < 6; felix++)
   {
     Mvtx_HitUnpacking(std::to_string(felix));
@@ -145,15 +140,15 @@ void Fun4All_ZFAllTrackers(
   for (int ebdc = 0; ebdc < 24; ebdc++)
   {
     for (int endpoint = 0; endpoint < 2; endpoint++)
+    {
+      ebdcname.str("");
+      if (ebdc < 10)
       {
-        ebdcname.str("");
-        if (ebdc < 10)
-	  {
-	    ebdcname << "0";
-	  }
-        ebdcname << ebdc << "_" << endpoint;
-        Tpc_HitUnpacking(ebdcname.str());
+        ebdcname << "0";
       }
+      ebdcname << ebdc << "_" << endpoint;
+      Tpc_HitUnpacking(ebdcname.str());
+    }
   }
 
   Micromegas_HitUnpacking();
@@ -162,7 +157,6 @@ void Fun4All_ZFAllTrackers(
   Intt_Clustering();
   TPC_Clustering_run2pp();
   Micromegas_Clustering();
-  
 
   // this now does Si and TPC seeding only
   Tracking_Reco_TrackSeed_ZeroField();
@@ -185,7 +179,6 @@ void Fun4All_ZFAllTrackers(
 
   if (G4TRACKING::convert_seeds_to_svtxtracks)
   {
-
     auto *converter = new TrackSeedTrackMapConverter;
     // Default set to full SvtxTrackSeeds. Can be set to
     // SiliconTrackSeedContainer or TpcTrackSeedContainer
@@ -198,9 +191,9 @@ void Fun4All_ZFAllTrackers(
   else
   {
     auto *weightedFitter = new WeightedFitter;
-    weightedFitter->set_track_map_node_name( "SvtxTrackMap" );
+    weightedFitter->set_track_map_node_name("SvtxTrackMap");
 
-    if( !G4TRACKING::SC_USE_MICROMEGAS )
+    if (!G4TRACKING::SC_USE_MICROMEGAS)
     {
       // exclude TPOT from fit
       weightedFitter->exclude_layer_in_fit(55);
@@ -209,8 +202,6 @@ void Fun4All_ZFAllTrackers(
 
     se->registerSubsystem(weightedFitter);
   }
-
-
 
   PHSimpleVertexFinder *finder = new PHSimpleVertexFinder;
   finder->zeroField(true);
@@ -229,7 +220,7 @@ void Fun4All_ZFAllTrackers(
   resid->outfileName(residstring);
   resid->alignment(false);
   resid->clusterTree();
-  //resid->hitTree();
+  // resid->hitTree();
   resid->zeroField();
   resid->convertSeeds(G4TRACKING::convert_seeds_to_svtxtracks);
   resid->Verbosity(0);

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -340,10 +340,8 @@ void Tracking_Reco_TrackSeed_ZeroField()
 
   auto *silicon_Seeding = new PHActsSiliconSeeding;
   silicon_Seeding->Verbosity(verbosity);
-  silicon_Seeding->setStrobeRange(-5, 5);
-  silicon_Seeding->isStreaming();
-  // these get us to about 83% INTT > 1
-  silicon_Seeding->setinttRPhiSearchWindow(0.2);
+  silicon_Seeding->setIter1();
+  silicon_Seeding->zeroField();
   se->registerSubsystem(silicon_Seeding);
 
   auto *merger = new PHSiliconSeedMerger;


### PR DESCRIPTION
This PR updates the zero field macro to work out of the box on the run3pp zero field run 81000. I see plenty of straight tracks with all three subsystems max number of clusters on them (3 MVTX, 2 INTT, >30 TPC) when running this macro out of the box

<img width="683" height="442" alt="Screenshot 2026-07-01 at 10 29 48 AM" src="https://github.com/user-attachments/assets/d1396825-4642-425b-ac10-17e0004286ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Motivation / context: Update the zero-field tracking macro so it runs out of the box on run3pp zero-field data (run 81000), using raw hits and silicon zero-field settings. The goal is to recover the expected high-quality straight tracks across MVTX, INTT, and TPC.

Key changes:
- Switched `Fun4All_ZFAllTrackers` from fixed TPC raw-hit inputs to a `filelist`-driven input model.
- Reworked input registration to build multiple `Fun4AllDstInputManager` instances from the listed files and derive run/segment metadata from the first entry.
- Updated the tracking chain to explicitly unpack MVTX/INTT/TPC data, then run zero-field seeding and Si-TPC track matching.
- Replaced the previous ACTS fit path with `WeightedFitter` when seed conversion is disabled.
- Kept the seed-conversion path available via `TrackSeedTrackMapConverter` when enabled.
- Adjusted `Tracking_Reco_TrackSeed_ZeroField` to use silicon zero-field seeding (`setIter1()`, `zeroField()`), removing the prior INTT strobe/streaming and R-phi window configuration.
- Disabled residual hit tree output in the residual module.
- Updated includes to add `WeightedFitter` and remove `AzimuthalSeeder`.

Potential risk areas:
- IO format changes from fixed filenames/dirs to file-list-based input handling.
- Reconstruction behavior changes from the new zero-field seeding and fitter configuration.
- Possible differences in track quality or cluster usage due to the altered unpacking/fitting sequence.
- Performance impact from registering multiple input managers and the new fitting path.

Possible future improvements:
- Add validation on more zero-field runs to confirm robustness.
- Document the expected file-list format and run/segment inference behavior.
- Compare outputs between the weighted-fit and ACTS-based paths for consistency.
- Revisit residual/tree outputs if they are needed for commissioning studies.

AI can make mistakes; please use best judgment when reviewing the exact macro behavior and downstream reconstruction impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->