### PR TITLE
fix: geom building

### DIFF
--- a/common/Trkr_RecoInit.C
+++ b/common/Trkr_RecoInit.C
@@ -51,7 +51,10 @@ void TrackingInit()
   // G4Setup() was not run
   if(CDB::is_data_reco)
     {
-      LoadTrackingCDBGeometry();
+      if(!Enable::MVTX || !Enable::INTT || !Enable::TPC || !Enable::MICROMEGAS)
+	{
+	  LoadTrackingCDBGeometry();
+	}
     }
  
   TpcClusterZCrossingCorrection::_vdrift = G4TPC::tpc_drift_velocity_reco;


### PR DESCRIPTION
Check for the flags that are set to build geometry. If any are not set, then load the CDB geometry since a node will be missing otherwise.