### PR TITLE
Implement TPC survey geometry in macros

### DIFF
--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -16,7 +16,7 @@
 #include <Trkr_Reco.C>
 #include <Trkr_RecoInit.C>
 #include <Trkr_TpcReadoutInit.C>
-
+#include <G4Setup_sPHENIX.C>
 
 #include <tpccalib/PHTpcResiduals.h>
 
@@ -57,7 +57,8 @@ void Fun4All_TrackSeeding(
     const std::string &dir = "/sphenix/lustre01/sphnxpro/production/run2pp/physics/ana517_2024p024_v001/DST_TRKR_CLUSTER/run_00053800_00053900/dst/",
     const std::string &outfilename = "clusters_seeds",
     const bool convertSeeds = false,
-    const bool doKFParticle = false)
+    const bool doKFParticle = false,
+    const int nskip = 0)
 {
   //std::string inputseedRawHitFile = dir + seedfilename;
   std::string inputclusterRawHitFile = dir + clusterfilename;
@@ -70,12 +71,28 @@ void Fun4All_TrackSeeding(
 
   auto *rc = recoConsts::instance();
   rc->set_IntFlag("RUNNUMBER", runnumber);
+  rc->set_IntFlag("RUNSEGMENT", segment);
 
   Enable::CDB = true;
   rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
   rc->set_uint64Flag("TIMESTAMP", runnumber);
-  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
 
+
+  bool rebuild_tracking_geometry = false;
+  if(rebuild_tracking_geometry)
+    {
+      // To make simulation geometry before running reconstruction
+      
+      Enable::MVTX = true;
+      Enable::INTT = true;
+      Enable::TPC = true;
+      Enable::MICROMEGAS = true;
+      
+      G4TPC::tpc_survey_position = true; // to use TPC survey position, set to true
+      G4Init();
+      G4Setup();
+    }
+  
   TpcReadoutInit(runnumber);
  // these lines show how to override the drift velocity and time offset values set in TpcReadoutInit
   // G4TPC::tpc_drift_velocity_reco = 0.0073844; // cm/ns
@@ -114,11 +131,14 @@ void Fun4All_TrackSeeding(
   auto *se = Fun4AllServer::instance();
   se->Verbosity(1);
 
-
-  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
-  ingeo->AddFile(geofile);
-  se->registerInputManager(ingeo);
-
+  if(!rebuild_tracking_geometry)
+    {
+      std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+      Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+      ingeo->AddFile(geofile);
+      se->registerInputManager(ingeo);
+    }
+  
   G4TPC::REJECT_LASER_EVENTS=true;
   G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
 
@@ -246,7 +266,8 @@ void Fun4All_TrackSeeding(
     se->registerSubsystem(new TpcSeedsQA);
     se->registerSubsystem(new TpcSiliconQA);
   }
-  se->run(nEvents);
+ se->skip(nskip);
+ se->run(nEvents);
   se->End();
   se->PrintTimer();
   CDBInterface::instance()->Print();

--- a/common/G4_TrkrSimulation.C
+++ b/common/G4_TrkrSimulation.C
@@ -322,6 +322,12 @@ void TPC_Endcaps(PHG4Reco* g4Reco)
   tpc_endcap->set_double_param("rot_z", G4TPC::rot_z);
   std::cout << "G4_TrkrSimulation: Setting TPC endcap tilt angles to rot_x = " << G4TPC::rot_x
 	    << " roty = " << G4TPC::rot_y << " rot_z = " << G4TPC::rot_z << std::endl;
+  // set the TPC center position in sPHENIX
+  tpc_endcap->set_double_param("place_x", G4TPC::place_x);
+  tpc_endcap->set_double_param("place_y", G4TPC::place_y);
+  tpc_endcap->set_double_param("place_z", G4TPC::place_z);
+  std::cout << "G4_TrkrSimulation: Setting TPC center position to place_x = " << G4TPC::place_x
+	    << " place_y = " << G4TPC::place_y << " place_z = " << G4TPC::place_z << std::endl;
   
   g4Reco->registerSubsystem(tpc_endcap);
 
@@ -352,6 +358,25 @@ double TPC(PHG4Reco* g4Reco,
     drift_vel = G4TPC::ArCF4Isobutane_drift_velocity;
   }
 
+  if(G4TPC::tpc_survey_position)
+    {
+      // if this flag is set, place the TPC in the survey position
+      // This affects the positioning of the TPC envelope volume and the endcap volume
+
+      // set TPC tilt angles
+      G4TPC::rot_x = -0.00029817; // radians
+      G4TPC::rot_y = 0.0014833;
+      G4TPC::rot_z = 0.0;
+      // set TPC center
+      G4TPC::place_x = -1.6775/10.0; // convert mm to cm
+      G4TPC::place_y = -0.336/10.0;
+      G4TPC::place_z = -7.1365/10.0;
+    }
+  else
+    {
+      std::cout << "Not using TPC survey geometry" << std::endl;
+    }
+
   PHG4TpcSubsystem* tpc = new PHG4TpcSubsystem("TPC");
   tpc->SetActive();
   tpc->SuperDetector("TPC");
@@ -366,6 +391,12 @@ double TPC(PHG4Reco* g4Reco,
   tpc->set_double_param("rot_z", G4TPC::rot_z);
   std::cout << "G4_TrkrSimulation: Setting TPC tilt angles to rot_x = " << G4TPC::rot_x
 	    << " roty = " << G4TPC::rot_y << " rot_z = " << G4TPC::rot_z << std::endl;
+  // set the TPC center position in sPHENIX
+  tpc->set_double_param("place_x", G4TPC::place_x);
+  tpc->set_double_param("place_y", G4TPC::place_y);
+  tpc->set_double_param("place_z", G4TPC::place_z);
+  std::cout << "G4_TrkrSimulation: Setting TPC center position to place_x = " << G4TPC::place_x
+	    << " place_y = " << G4TPC::place_y << " place_z = " << G4TPC::place_z << std::endl;
   tpc->set_int_param("tpc_minlayer_inner", G4MVTX::n_maps_layer + G4INTT::n_intt_layer);
   tpc->set_int_param("ntpc_layers_inner", G4TPC::n_tpc_layer_inner);
   tpc->set_int_param("ntpc_phibins_inner", G4TPC::tpc_layer_rphi_count_inner);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -212,9 +212,15 @@ namespace G4TPC
 
   double maxDriftLength = 102.325;  // new value, CM face to top of GEM stack
   double CM_halfwidth = 0.28;  // cm
-   double rot_x = 0.0;  // tpc default tilt angles (for tpc envelope and endcap)
+
+  bool tpc_survey_position = false;
+  double rot_x = 0.0;  // tpc default tilt angles (for tpc envelope and endcap)
   double rot_y = 0.0;
   double rot_z = 0.0;
+  double place_x = 0.0;  // tpc default center position (for tpc envelope and endcap)
+  double place_y = 0.0;
+  double place_z = 0.0;
+
   double sampa_tzero_bias = -65.0; // ns, set for simulations/reco matching with new sampa response
   bool apply_tpc_tzero_correction = false;  // true to apply small correction to TPC time zero in alignment transforms
 


### PR DESCRIPTION
Modifies G4_TrkrVariables to add the flag "G4TPC::tpc_survey_position". Modifies G4_TrkrSimulation to implement the TPC survey position in simulations.

Because it is a bit fiddly, I also modified Fun4All_TrackSeeding.C to show how to optionally run the geometry building before reconstructing real data. See the flag "rebuild_tracking_geometry". If that flag is set to true, it assumes you want to use the TPC survey geometry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

AI can make mistakes, so please use best judgment when reviewing this summary.

**Motivation / context**
- Add support for placing the TPC in its survey geometry in the macros repository.
- Show how to optionally rebuild tracking geometry before reconstructing real data, with the expectation that survey geometry is used when enabled.

**Key changes**
- Added `G4TPC::tpc_survey_position` to `G4_TrkrVariables`, along with default TPC survey placement coordinates `place_x`, `place_y`, and `place_z`.
- Updated `G4_TrkrSimulation` to:
  - apply TPC survey placement values when `G4TPC::tpc_survey_position` is enabled,
  - propagate TPC position parameters to the TPC endcaps and subsystem configuration,
  - log whether survey geometry is being used.
- Updated `Fun4All_TrackSeeding.C` to:
  - accept an optional `nskip` argument and skip events before processing,
  - include `G4Setup_sPHENIX.C`,
  - add a `rebuild_tracking_geometry` switch that conditionally rebuilds geometry before reconstruction,
  - only register the run node input manager when geometry is not being rebuilt.

**Potential risk areas**
- Reconstruction behavior may change when survey geometry is enabled, especially for alignment-sensitive workflows.
- Geometry/IO handling changes could affect job setup assumptions and input manager registration.
- Added configuration paths may need verification in multi-threaded or production steering contexts.
- Survey-position constants are hard-coded, so mistakes there would directly impact detector placement.

**Possible future improvements**
- Make survey-geometry coordinates configurable via input/CDB rather than hard-coded values.
- Add validation or consistency checks for geometry rebuild and survey-position flags.
- Expand documentation/examples for when to enable `rebuild_tracking_geometry` and `tpc_survey_position`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->