### PR TITLE
TRACKING::alignmentParamsFile

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -54,6 +54,7 @@ namespace ACTSGEOM
 
     // Geometry must be built before any Acts modules
     MakeActsGeometry *geom = new MakeActsGeometry();
+    geom->set_alignmentParamsFile( TRACKING::alignmentParamsFile );
     geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
     geom->set_apply_tpc_tzero_correction(G4TPC::apply_tpc_tzero_correction);  // set true to apply tpc tzero correction
     geom->set_tpc_tzero(G4TPC::tpc_tzero_reco);

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -91,6 +91,9 @@ namespace TRACKING
   bool tpc_zero_supp = false;
   bool tpc_baseline_corr = true;
 
+  // alignment parameter
+  std::string alignmentParamsFile = "./localAlignmentParamsFile.txt";
+
 }  // namespace TRACKING
 
 namespace G4MAGNET


### PR DESCRIPTION
This PR complements https://github.com/sPHENIX-Collaboration/coresoftware/pull/4335
It uses TRACKING::alignmentParamsFile, defined in GlobalVariables.C to specify a different local alignment file name. The filename is passed to MakeActsGeometry and from there to AlignmentObjectTransformation. If found, this file is used for alignment parameters instead of what is in the CDB.
The default value is "./localAlignmentParamsFile.txt", so that the default behavior is unchanged and the change should be transparent to users. 
If one specifies a different value for  TRACKING::alignmentParamsFile in the steering macro, this is the value that will be used. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Allow users to select a local alignment-parameter file through the steering configuration while preserving the existing default behavior.

## Key Changes

- Added `TRACKING::alignmentParamsFile`, defaulting to `./localAlignmentParamsFile.txt`.
- Passed the configured filename from `ActsGeomInit()` to `MakeActsGeometry`.
- Enables use of the local file when available instead of alignment parameters from the CDB.

## Potential Risk Areas

- Reconstruction results may change when a valid local alignment file is provided.
- Compatibility depends on the expected alignment-parameter file format.
- No notable thread-safety or performance changes are expected.

## Possible Future Improvements

- Document the configuration option and file format.
- Add validation and clearer diagnostics for missing or malformed files.
- Add tests covering local-file selection and fallback behavior.

AI-generated summaries can contain mistakes; reviewers should verify the implementation and behavior against the source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->