### PR TITLE
CD: Updated macros to match new KFParticle code

### DIFF
--- a/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
+++ b/TrackingProduction/Fun4All_FieldOnAllTrackers_KFP.C
@@ -213,7 +213,7 @@ void Fun4All_FieldOnAllTrackers_KFP(
   kfparticle->useFakePrimaryVertex(); // true
 
   kfparticle->constrainToPrimaryVertex(false);
-  kfparticle->setMotherIPchi2(FLT_MAX);
+  kfparticle->setMotherPV_DCA_StdDev(FLT_MAX);
   kfparticle->setFlightDistancechi2(-1.);
   kfparticle->setMinDIRA(-1.1);
   kfparticle->setDecayLengthRange(0., FLT_MAX);
@@ -224,8 +224,8 @@ void Fun4All_FieldOnAllTrackers_KFP(
   kfparticle->setMinTPChits(20);
   kfparticle->setMinimumTrackPT(-1.);
   kfparticle->setMaximumTrackPTchi2(FLT_MAX);
-  kfparticle->setMinimumTrackIPchi2(-1.);
-  kfparticle->setMinimumTrackIP(-1.);
+  kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+  kfparticle->setMinimumTrackPV_DCA(-1.);
   kfparticle->setMaximumTrackchi2nDOF(20.);
 
   //Vertex parameters

--- a/TrackingProduction/Fun4All_KShortReco.C
+++ b/TrackingProduction/Fun4All_KShortReco.C
@@ -156,15 +156,15 @@ void Fun4All_KShortReco(
 
   // PV to SV cuts
   kfparticle->constrainToPrimaryVertex(true);
-  kfparticle->setMotherIPchi2(100);
+  kfparticle->setMotherPV_DCA_StdDev(100);
   kfparticle->setFlightDistancechi2(-1.);
   kfparticle->setMinDIRA(0.999);
   kfparticle->setDecayLengthRange(0.1, FLT_MAX);
 
   // Track parameters
   kfparticle->setMinimumTrackPT(0.0);
-  kfparticle->setMinimumTrackIPchi2(-1.);
-  kfparticle->setMinimumTrackIP(-1.);
+  kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+  kfparticle->setMinimumTrackPV_DCA(-1.);
   kfparticle->setMaximumTrackchi2nDOF(100.);
   kfparticle->setMinTPChits(25);
 

--- a/TrackingProduction/Fun4All_TrackSeeding.C
+++ b/TrackingProduction/Fun4All_TrackSeeding.C
@@ -206,7 +206,7 @@ void Fun4All_TrackSeeding(
   kfparticle->getDetectorInfo(true);
 
   kfparticle->constrainToPrimaryVertex(true);
-  kfparticle->setMotherIPchi2(FLT_MAX);
+  kfparticle->setMotherPV_DCA_StdDev(FLT_MAX);
   kfparticle->setFlightDistancechi2(-1.);
   kfparticle->setMinDIRA(-1.1);
   kfparticle->setDecayLengthRange(0., FLT_MAX);
@@ -218,8 +218,8 @@ void Fun4All_TrackSeeding(
   kfparticle->setMinTPChits(20);
   kfparticle->setMinimumTrackPT(-1.);
   kfparticle->setMaximumTrackPTchi2(FLT_MAX);
-  kfparticle->setMinimumTrackIPchi2(-1.);
-  kfparticle->setMinimumTrackIP(-1.);
+  kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+  kfparticle->setMinimumTrackPV_DCA(-1.);
   //kfparticle->setMaximumTrackchi2nDOF(20.);
   kfparticle->setMaximumTrackchi2nDOF(300.);
 

--- a/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3auau/Fun4All_raw_hit_KFP.C
@@ -657,7 +657,7 @@ void Fun4All_raw_hit_KFP(
 
     // PV to SV cuts
     kfparticle->constrainToPrimaryVertex(HeavyFlavorReco::constrain_to_primary_vertex);
-    kfparticle->setMotherIPchi2(100);
+    kfparticle->setMotherPV_DCA_StdDev(100);
     kfparticle->setFlightDistancechi2(-1.);
     kfparticle->setMinDIRA(0.88);                    // was .95
     kfparticle->setDecayLengthRange(-0.1, FLT_MAX);  // was 0.1 min
@@ -672,8 +672,8 @@ void Fun4All_raw_hit_KFP(
 
     // Track parameters
     kfparticle->setMinimumTrackPT(0.0);
-    kfparticle->setMinimumTrackIPchi2(-1.);
-    kfparticle->setMinimumTrackIP(-1.);
+    kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+    kfparticle->setMinimumTrackPV_DCA(-1.);
     kfparticle->setMaximumTrackchi2nDOF(100.);
     kfparticle->setMinINTThits(0);
     kfparticle->setMinMVTXhits(0);
@@ -713,15 +713,15 @@ void Fun4All_raw_hit_KFP(
 
     // PV to SV cuts
     kfparticle->constrainToPrimaryVertex(HeavyFlavorReco::constrain_to_primary_vertex);
-    kfparticle->setMotherIPchi2(100);
+    kfparticle->setMotherPV_DCA_StdDev(100);
     kfparticle->setFlightDistancechi2(-1.);
     kfparticle->setMinDIRA(0.88);
     kfparticle->setDecayLengthRange(0.2, FLT_MAX);
 
     // Track parameters
     kfparticle->setMinimumTrackPT(0.1);
-    kfparticle->setMinimumTrackIPchi2(-1.);
-    kfparticle->setMinimumTrackIP(-1.);
+    kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+    kfparticle->setMinimumTrackPV_DCA(-1.);
     kfparticle->setMaximumTrackchi2nDOF(100.);
     kfparticle->setMinTPChits(25);
 

--- a/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
+++ b/TrackingProduction/run3pp/Fun4All_raw_hit_KFP.C
@@ -455,7 +455,7 @@ void Fun4All_raw_hit_KFP(
 
     // PV to SV cuts
     kfparticle->constrainToPrimaryVertex(HeavyFlavorReco::constrain_to_primary_vertex);
-    kfparticle->setMotherIPchi2(100);
+    kfparticle->setMotherPV_DCA_StdDev(100);
     kfparticle->setFlightDistancechi2(-1.);
     kfparticle->setMinDIRA(0.88);                    // was .95
     kfparticle->setDecayLengthRange(-0.1, FLT_MAX);  // was 0.1 min
@@ -470,8 +470,8 @@ void Fun4All_raw_hit_KFP(
 
     // Track parameters
     kfparticle->setMinimumTrackPT(0.0);
-    kfparticle->setMinimumTrackIPchi2(-1.);
-    kfparticle->setMinimumTrackIP(-1.);
+    kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+    kfparticle->setMinimumTrackPV_DCA(-1.);
     kfparticle->setMaximumTrackchi2nDOF(100.);
     kfparticle->setMinINTThits(0);
     kfparticle->setMinMVTXhits(0);
@@ -511,15 +511,15 @@ void Fun4All_raw_hit_KFP(
 
     // PV to SV cuts
     kfparticle->constrainToPrimaryVertex(HeavyFlavorReco::constrain_to_primary_vertex);
-    kfparticle->setMotherIPchi2(100);
+    kfparticle->setMotherPV_DCA_StdDev(100);
     kfparticle->setFlightDistancechi2(-1.);
     kfparticle->setMinDIRA(0.88);
     kfparticle->setDecayLengthRange(0.2, FLT_MAX);
 
     // Track parameters
     kfparticle->setMinimumTrackPT(0.1);
-    kfparticle->setMinimumTrackIPchi2(-1.);
-    kfparticle->setMinimumTrackIP(-1.);
+    kfparticle->setMinimumTrackPV_DCA_StdDev(-1.);
+    kfparticle->setMinimumTrackPV_DCA(-1.);
     kfparticle->setMaximumTrackchi2nDOF(100.);
     kfparticle->setMinTPChits(25);
 

--- a/common/G4_KFParticle.C
+++ b/common/G4_KFParticle.C
@@ -58,7 +58,7 @@ namespace KFParticleBaseCut
 {
   float minTrackPT = 0.5;  // GeV
   float maxTrackchi2nDoF = 2;
-  float minTrackIPchi2 = 15;  // IP = DCA of track with vertex
+  float minTrackPV_DCA_StdDev = 15;  // DCA significance of track with vertex
   float maxVertexchi2nDoF = 2;
   float maxTrackTrackDCA = 0.05;  // cm
   float minMotherPT = 0;          // GeV
@@ -80,7 +80,7 @@ void KFParticle_Upsilon_Reco()
   if (Enable::KFPARTICLE_DETECTOR_INFO) kfparticle->getDetectorInfo();
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
-  kfparticle->setMinimumTrackIPchi2(0);  // Upsilon decays are prompt, tracks are more likely to point to vertex
+  kfparticle->setMinimumTrackPV_DCA_StdDev(0);  // Upsilon decays are prompt, tracks are more likely to point to vertex
   kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
 
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
@@ -116,7 +116,7 @@ void KFParticle_D0_Reco()
   if (Enable::KFPARTICLE_DETECTOR_INFO) kfparticle->getDetectorInfo();
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
-  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMinimumTrackPV_DCA_StdDev(KFParticleBaseCut::minTrackPV_DCA_StdDev);
   kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
 
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);
@@ -153,7 +153,7 @@ void KFParticle_Lambdac_Reco()
   if (Enable::KFPARTICLE_DETECTOR_INFO) kfparticle->getDetectorInfo();
 
   kfparticle->setMinimumTrackPT(KFParticleBaseCut::minTrackPT);
-  kfparticle->setMinimumTrackIPchi2(KFParticleBaseCut::minTrackIPchi2);
+  kfparticle->setMinimumTrackPV_DCA_StdDev(KFParticleBaseCut::minTrackPV_DCA_StdDev);
   kfparticle->setMaximumTrackchi2nDOF(KFParticleBaseCut::maxTrackchi2nDoF);
 
   kfparticle->setMaximumVertexchi2nDOF(KFParticleBaseCut::maxVertexchi2nDoF);


### PR DESCRIPTION
These updates should make our macros match https://github.com/sPHENIX-Collaboration/coresoftware/pull/4332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Update KFParticle macro configurations to match the new KFParticle API and behavior introduced in coresoftware PR `#4332`.

## Key changes

- Replaced mother IP χ² constraints with primary-vertex DCA significance constraints.
- Replaced track IP/IP χ² cuts with PV-DCA and PV-DCA significance cuts across tracking, K-short, lambda, and raw-hit reconstruction macros.
- Updated Upsilon, D⁰, and Λc shared cut configuration to use `minTrackPV_DCA_StdDev`.

## Potential risks

- Reconstruction selections and candidate yields may change due to the revised PV-DCA criteria.
- No I/O format, threading, or intentional performance changes are expected.
- AI-generated summaries can contain inaccuracies; the exact parameter values and reconstruction behavior should be validated against coresoftware PR `#4332` and representative validation samples.

## Possible future improvements

- Add regression comparisons of efficiencies, purities, and reconstructed yields.
- Consolidate common KFParticle cut settings to reduce duplication across macros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->