### PR TITLE
add Acts material map configuration flag

### DIFF
--- a/common/G4_ActsGeom.C
+++ b/common/G4_ActsGeom.C
@@ -31,6 +31,7 @@ namespace ACTSGEOM
 
   bool mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
   bool inttsurvey = Enable::INTT_USEG4SURVEYGEOM;
+  bool useActsMaterialMap = true;
 
   void ActsGeomInit()
   {
@@ -54,6 +55,7 @@ namespace ACTSGEOM
 
     // Geometry must be built before any Acts modules
     MakeActsGeometry *geom = new MakeActsGeometry();
+    geom->setUseActsMaterialMap(ACTSGEOM::useActsMaterialMap);
     geom->set_alignmentParamsFile( TRACKING::alignmentParamsFile );
     geom->set_drift_velocity(G4TPC::tpc_drift_velocity_reco);
     geom->set_apply_tpc_tzero_correction(G4TPC::apply_tpc_tzero_correction);  // set true to apply tpc tzero correction


### PR DESCRIPTION
coordinate with coresoftware PR#4349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Adds a configurable Acts material-map flag to coordinate with coresoftware PR `#4349`. Material-map usage remains enabled by default.

## Key Changes

- Introduced `ACTSGEOM::useActsMaterialMap`, defaulting to `true`.
- Applied the flag during Acts geometry initialization via `setUseActsMaterialMap`.

## Potential Risk Areas

- No I/O format changes are expected.
- Reconstruction and geometry behavior may change when the flag is set to `false`.
- No new thread-safety or significant performance concerns are apparent.

## Possible Future Improvements

- Expose the flag through the standard detector or runtime configuration.
- Add validation or tests covering geometry construction with both material-map settings.

*AI-generated summaries can contain mistakes; please use best judgment when reviewing the implementation.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->