### PR TITLE
Make the rescaling of outlier calib. factors harmless

### DIFF
--- a/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
+++ b/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
@@ -54,10 +54,11 @@ void checkCos(TH2* h){
   
   for (int ie=0; ie<24; ie++)
     for (int ip=0; ip<64; ip++)
-      if (h->GetBinContent(ie+1,ip+1) < 0.01*avg || h->GetBinContent(ie+1,ip+1) > 10*avg)
-	std::cout << "Rescaling the calib. factor to a global average. Be cautious!" << endl; 
+	double v = h->GetBinContent(ie+1,ip+1);
+        if (v < 0.01*avg || v > 10*avg){
+	std::cout << "Rescaling the calib. factor in bin (" << ie << "," << ip<< ") to a global average. Be cautious!" << endl;	
         h->SetBinContent(ie+1,ip+1,avg);
-
+     }
 }
 
 

--- a/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
+++ b/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
@@ -9,9 +9,9 @@ void checkCos(TH2* h);
 
 void tsc_cos_merge(const std::string &tsc_file, const std::string &cos_cdb_file,const std::string &output_name, int isIHcal){
   
-  // get 2024 cosmics calibration
-  std::string fieldName_in = "ohcal_cosmic_calibration";
-  if (isIHcal ==1) fieldName_in = "ihcal_cosmic_calibration";
+  // get cosmics calibration
+  std::string fieldName_in = "HCALOUT_calib_ADC_to_ETower";
+  if (isIHcal ==1) fieldName_in = "HCALIN_calib_ADC_to_ETower";
   TH2* h_ohcal = CaloCDBTreeToHist(cos_cdb_file,fieldName_in,1);
   
   // get/apply tsc fine tunning for calibration
@@ -54,7 +54,8 @@ void checkCos(TH2* h){
   
   for (int ie=0; ie<24; ie++)
     for (int ip=0; ip<64; ip++)
-      if (h->GetBinContent(ie+1,ip+1) < 0.3*avg || h->GetBinContent(ie+1,ip+1) > 2.3*avg) 
+      if (h->GetBinContent(ie+1,ip+1) < 0.01*avg || h->GetBinContent(ie+1,ip+1) > 10*avg)
+	std::cout << "Rescaling the calib. factor to a global average. Be cautious!" << endl; 
         h->SetBinContent(ie+1,ip+1,avg);
 
 }
@@ -113,9 +114,9 @@ void rescaleTSC(TH2* h_tsc,TH2* h_cos){
 
 void genCdbCorr_HH(float corr, const std::string &cos_cdb_file,const std::string &output_name, int isIHcal,std::vector<std::vector<float>> halfhighs){
   
-  // get 2024 cosmics calibration
-  std::string fieldName_in = "ohcal_abscalib_mip";
-  if (isIHcal ==1) fieldName_in = "ihcal_cosmic_calibration";
+  // get cosmics calibration
+  std::string fieldName_in = "HCALOUT_calib_ADC_to_ETower";
+  if (isIHcal ==1) fieldName_in = "HCALIN_calib_ADC_to_ETower";
   TH2* h_ohcal = CaloCDBTreeToHist(cos_cdb_file,fieldName_in,1);
 
   if (!h_ohcal){


### PR DESCRIPTION
Changed the condition for resetting the calibration factors to a global average, to avoid rescaling of real hot or cold towers. (noticed this bug during hcal calibration of run3OO dataset)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

During HCAL calibration of the run3OO dataset, outlier calibration-factor rescaling could incorrectly modify genuine hot or cold towers. This change makes the fallback to the global average less disruptive.

## Key changes

- Updated cosmics calibration histogram inputs to use the HCAL ADC-to-ETower fields for inner and outer HCAL.
- Widened the calibration-factor reset range to only replace values below `0.01 × average` or above `10 × average`.
- Added warnings identifying bins whose factors are replaced.
- Added missing braces around affected control-flow blocks.

## Potential risk areas

- The changed histogram field names may affect compatibility with existing input files or calibration-tree formats.
- The wider acceptance range changes calibration and reconstruction behavior for extreme tower factors.
- No significant performance or thread-safety impact is expected.

## Possible future improvements

- Validate the new thresholds against representative hot/cold tower distributions and independent run3OO calibration samples.
- Add regression tests covering histogram-field selection and outlier handling.
- Consider making the thresholds configurable and documenting the expected input schema.

AI-generated summaries can contain errors; the implementation should be reviewed against the source and calibration validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->