### PR TITLE
Added the missing braces that broke the previous commit

### DIFF
--- a/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
+++ b/calibrations/calo/hcal_calib_year2/genFinalCalib/tsc_cos_merge.C
@@ -52,13 +52,15 @@ void checkCos(TH2* h){
   avg/=cc; 
   std::cout << "avg=" << avg << std::endl;
   
-  for (int ie=0; ie<24; ie++)
-    for (int ip=0; ip<64; ip++)
+  for (int ie=0; ie<24; ie++){
+    for (int ip=0; ip<64; ip++){
 	double v = h->GetBinContent(ie+1,ip+1);
         if (v < 0.01*avg || v > 10*avg){
 	std::cout << "Rescaling the calib. factor in bin (" << ie << "," << ip<< ") to a global average. Be cautious!" << endl;	
         h->SetBinContent(ie+1,ip+1,avg);
      }
+   }
+ }
 }
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Fix missing braces from the previous commit that could cause incorrect loop scoping in the calorimeter calibration code.

## Key changes

- Added explicit braces around the nested bin-rescaling loops in `checkCos(TH2* h)`.
- Introduced a local `double v` for each bin’s content.
- Preserved the existing logic for replacing out-of-range bins with the global average calibration value.

## Potential risk areas

- No I/O format, public API, reconstruction behavior, or thread-safety changes are expected.
- Runtime and memory impact should be negligible.
- The primary risk is whether the corrected scoping changes behavior for edge-case histogram bins as intended.

## Possible future improvements

- Add a focused regression test covering the rescaling condition and loop boundaries.
- Document the expected handling of out-of-range bin values.

AI-generated summaries can contain mistakes; the code should be reviewed directly for final validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->