### PR TITLE
Example macros to run TPC SA tracking

### DIFF
--- a/TpcProduction/Fun4All_TPC_Analysis.C
+++ b/TpcProduction/Fun4All_TPC_Analysis.C
@@ -68,21 +68,20 @@ void Fun4All_TPC_Analysis(
     const int nEvents = 2,
     const int runnumber = 79513,
     const int segment = 0,
-    const std::string outdir = ".",
-    const std::string indir = ".",
-    const int nSkip = 0,
-    const std::string collision = "run3pp",
-    const std::string production = "ana532_nocdbtag_v001",
+    const std::string&  /*outdir*/ = ".",
+    const std::string& indir = ".",
+    const int  /*nSkip*/ = 0,
+    const std::string& collision = "run3pp",
+    const std::string& production = "ana532_nocdbtag_v001",
     const std::string& outfilename = "HITS_ppFieldOn")
 {
-  const bool convertSeeds = true;
   auto *se = Fun4AllServer::instance();
   se->Verbosity(1);
   auto *rc = recoConsts::instance();
 
 
   const std::string dsttype = "TPC";
-   std::string filename = indir+"/DST_"+dsttype+"_"+collision+"_"+production+"-"+to_string(runnumber)+"-"+to_string(segment)+".root";
+  std::string filename = indir+"/DST_"+dsttype+"_"+collision+"_"+production+"-"+std::to_string(runnumber)+"-"+std::to_string(segment)+".root";
 
   auto *hitsinclus = new Fun4AllDstInputManager("TpcInputManager");
   hitsinclus->fileopen(filename);
@@ -115,7 +114,7 @@ void Fun4All_TPC_Analysis(
 
 
   //For the module tracks display uncomment following line
-  se->registerSubsystem(new Tpc_ModuleTrackDisplay("Tpc_ModuleTrackDisplay", "tpc_moduletrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  se->registerSubsystem(new Tpc_ModuleTrackDisplay("Tpc_ModuleTrackDisplay", "tpc_moduletrack_display_" + outfilename + "_" + std::to_string(runnumber) + ".root"));
   
   //For the assembled tracks display uncomment following line
   //se->registerSubsystem(new Tpc_AssembledTrackDisplay("Tpc_AssembledTrackDisplay", "tpc_assembledtrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));

--- a/TpcProduction/Fun4All_TPC_Analysis.C
+++ b/TpcProduction/Fun4All_TPC_Analysis.C
@@ -1,0 +1,144 @@
+/*
+ * This macro shows a minimum working example of running the tracking
+ * hit unpackers with some basic seeding algorithms to try to put together
+ * tracks. There are some analysis modules run at the end which package
+ * hits, clusters, and clusters on tracks into trees for analysis.
+ */
+
+// leave the GlobalVariables.C at the beginning, an empty line afterwards
+// protects its position against reshuffling by clang-format
+#include <GlobalVariables.C>
+
+#include <G4_ActsGeom.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <G4_Mbd.C>
+#include <QA.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_LaserClustering.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/recoConsts.h>
+
+#include <tpctrackreco/Tpc_ModuleTrackReco.h>
+#include <tpctrackreco/Tpc_AssembledTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackVertexer.h>
+#include <tpctrackreco/Tpc_PolyClusterizer.h>
+
+#include <trackingdiagnostics/Tpc_ModuleTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_AssembledTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterResiduals.h>
+
+
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+R__LOAD_LIBRARY(libcdbobjects.so)
+R__LOAD_LIBRARY(libmvtx.so)
+R__LOAD_LIBRARY(libintt.so)
+R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libmicromegas.so)
+R__LOAD_LIBRARY(libtpctrackreco.so)
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
+
+
+
+void Fun4All_TPC_Analysis(
+    const int nEvents = 2,
+    const int runnumber = 79513,
+    const int segment = 0,
+    const std::string outdir = ".",
+    const std::string indir = ".",
+    const int nSkip = 0,
+    const std::string collision = "run3pp",
+    const std::string production = "ana532_nocdbtag_v001",
+    const std::string& outfilename = "HITS_ppFieldOn")
+{
+  const bool convertSeeds = true;
+  auto *se = Fun4AllServer::instance();
+  se->Verbosity(1);
+  auto *rc = recoConsts::instance();
+
+
+  const std::string dsttype = "TPC";
+   std::string filename = indir+"/DST_"+dsttype+"_"+collision+"_"+production+"-"+to_string(runnumber)+"-"+to_string(segment)+".root";
+
+  auto *hitsinclus = new Fun4AllDstInputManager("TpcInputManager");
+  hitsinclus->fileopen(filename);
+  se->registerInputManager(hitsinclus);
+
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+  rc->set_IntFlag("RUNSEGMENT", segment);
+
+  Enable::QA = false;
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+
+
+
+  TRACKING::streaming_mode = true;
+
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
+
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+
+
+  TpcReadoutInit(runnumber);
+
+
+  //For the module tracks display uncomment following line
+  se->registerSubsystem(new Tpc_ModuleTrackDisplay("Tpc_ModuleTrackDisplay", "tpc_moduletrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the assembled tracks display uncomment following line
+  //se->registerSubsystem(new Tpc_AssembledTrackDisplay("Tpc_AssembledTrackDisplay", "tpc_assembledtrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the  cluster and TPC SA tracks display uncomment following line
+  //se->registerSubsystem(new Tpc_PolyClusterDisplay("Tpc_PolyClusterDisplay", "tpc_poly_cluster_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the  residual tree output uncomment following block (options to put cuts on minimum pT and minimum number of clusters in TPC SA are available)
+  /*auto resid = new Tpc_PolyClusterResiduals("Tpc_PolyClusterResiduals",
+                                        outdir + "/tpc_poly_track_residuals"+ outfilename + "_" + to_string(runnumber) + to_string(segment) + ".root" );
+  resid->setMinPt(0);
+  resid->setMinTpcClusters(20);
+  se->registerSubsystem(resid);
+  */
+
+  se->run(nEvents);
+  se->Print("NODETREE");
+  se->End();
+  se->PrintTimer();
+
+
+  CDBInterface::instance()->Print();
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+}

--- a/TpcProduction/Fun4All_raw_hit_TPC_reco.C
+++ b/TpcProduction/Fun4All_raw_hit_TPC_reco.C
@@ -1,0 +1,314 @@
+/*
+ * This macro shows a minimum working example of running the 
+ * TPC track reconstruction starting with hit unpackers
+ */
+
+// leave the GlobalVariables.C at the beginning, an empty line afterwards
+// protects its position against reshuffling by clang-format
+#include <GlobalVariables.C>
+
+#include <G4_ActsGeom.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <G4_Mbd.C>
+#include <QA.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_LaserClustering.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+
+#include <cdbobjects/CDBTTree.h>
+
+#include <ffamodules/CDBInterface.h>
+#include <ffamodules/FlagHandler.h>
+
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllUtils.h>
+
+#include <fun4all/SubsysReco.h>
+#include <fun4all/Fun4AllReturnCodes.h>
+
+#include <phool/recoConsts.h>
+
+
+#include <tpctrackreco/Tpc_ModuleTrackReco.h>
+#include <tpctrackreco/Tpc_AssembledTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackVertexer.h>
+#include <tpctrackreco/Tpc_PolyClusterizer.h>
+
+#include <trackingdiagnostics/Tpc_ModuleTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_AssembledTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterResiduals.h>
+
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+R__LOAD_LIBRARY(libcdbobjects.so)
+R__LOAD_LIBRARY(libmvtx.so)
+R__LOAD_LIBRARY(libintt.so)
+R__LOAD_LIBRARY(libtpc.so)
+R__LOAD_LIBRARY(libmicromegas.so)
+R__LOAD_LIBRARY(libPHGarfield.so)
+R__LOAD_LIBRARY(libtpctrackreco.so)
+R__LOAD_LIBRARY(libTrackingDiagnostics.so)
+
+
+class SkipFirstN : public SubsysReco {
+ public:
+  explicit SkipFirstN(int n) : SubsysReco("SkipFirstN"), target_(n) {}
+  int process_event(PHCompositeNode*) override {
+    if (count_ < target_) { ++count_; return Fun4AllReturnCodes::ABORTEVENT; }
+    return Fun4AllReturnCodes::EVENT_OK;
+  }
+ private:
+  int target_ = 0;
+  int count_  = 0;
+};
+// 'Golden' store of p+p
+//.x Fun4All_raw_hit_TPC_reco.C(2, 79513, 0, ".", 0, "run3pp", "ana532_nocdbtag_v001","HITS_ppFieldOn")
+//.x Fun4All_raw_hit_TPC_reco.C(2, 79516, 0, ".", 0, "run3pp", "ana532_nocdbtag_v001","HITS_ppFieldOn")
+
+// 6x6       75570-75573 - 1mrad; 75574 - 0mrad
+//.x Fun4All_raw_hit_TPC_reco.C(10, 75570, 0, ".", 0, "run3auau", "ana514_nocdbtag_v001","HITS_AuAu_ZeroField_1mrad")
+//.x Fun4All_raw_hit_TPC_reco.C(10, 75574, 0, ".", 0, "run3auau", "ana514_nocdbtag_v001","HITS_AuAu_ZeroField_0mrad")
+
+//111x111 O+O
+//.x Fun4All_raw_hit_TPC_reco.C(2, 82626, 0, ".", 0, "run3oo", "ana537_nocdbtag_v001","HITS_OO")
+
+void Fun4All_raw_hit_TPC_reco(
+    const int nEvents = 2,
+    const int runnumber = 79513,
+    const int segment = 0,
+    const std::string outdir = ".",
+    const int nSkip = 0,
+    const std::string collision = "run3pp",
+    const std::string production = "ana532_nocdbtag_v001",
+    const std::string& outfilename = "HITS_ppFieldOn",
+    const std::string datatype = "physics")
+{
+  const bool convertSeeds = true;
+  auto *se = Fun4AllServer::instance();
+  se->Verbosity(1);
+  auto *rc = recoConsts::instance();
+  se->registerSubsystem(new SkipFirstN(nSkip));
+
+  const std::string dsttype = "STREAMING_EVENT";
+  const std::string dsttype_to_save = "TPC";
+
+
+  std::ostringstream runstr;
+  runstr << std::setw(8) << std::setfill('0') << runnumber;
+
+  std::ostringstream segstr;
+  segstr << std::setw(5) << std::setfill('0') << segment;
+
+  const int runbase = (runnumber / 100) * 100;
+  const int runnext = runbase + 100;
+
+  std::ostringstream rundir;
+  rundir << "run_" << std::setw(8) << std::setfill('0') << runbase << "_" << std::setw(8) << std::setfill('0') << runnext;
+
+  std::vector<std::string> streams;
+
+  // TPC EBDC streams
+  for (int ebdc = 0; ebdc < 24; ++ebdc)
+  {
+    for (int endpoint = 0; endpoint < 2; ++endpoint)
+    {
+      std::ostringstream s;
+      s << "ebdc" << std::setw(2) << std::setfill('0') << ebdc << "_" << endpoint;
+      streams.push_back(s.str());
+    }
+  }
+if(collision!="run3line_laser"&&collision!="run3cosmics")
+{
+  // TPOT
+  streams.push_back("ebdc39");
+
+  // INTT streams
+  for (int server = 0; server < 8; ++server)
+  {
+    std::ostringstream s;
+    s << "intt" << server;
+    streams.push_back(s.str());
+  }
+
+  // MVTX streams
+  for (int felix = 0; felix < 6; ++felix)
+  {
+    std::ostringstream s;
+    s << "mvtx" << felix;
+    streams.push_back(s.str());
+  }
+}
+
+  int i = 0;
+    std::stringstream nice_runnumber;
+  nice_runnumber << std::setw(8) << std::setfill('0') << std::to_string(runnumber);
+
+  int rounded_up = 100 * (std::ceil((float) runnumber / 100));
+  std::stringstream nice_rounded_up;
+  nice_rounded_up << std::setw(8) << std::setfill('0') << std::to_string(rounded_up);
+
+  int rounded_down = 100 * (std::floor((float) runnumber / 100));
+  std::stringstream nice_rounded_down;
+  nice_rounded_down << std::setw(8) << std::setfill('0') << std::to_string(rounded_down);
+
+  for (unsigned int is = 0; is < streams.size(); ++is)
+  {
+    const std::string stream = streams[is];
+
+    std::string filename = "DST_" + dsttype + "_" + stream + "_" + collision + "_" + production + "-" +  runstr.str() + "-" + segstr.str() + ".root";
+    std::string filepath = "/sphenix/lustre01/sphnxpro/production/" + collision + "/"+datatype+"/" + production + "/DST_" + dsttype + "_" + stream + "/run_" + nice_rounded_down.str()  + "_" + nice_rounded_up.str()  + "/" + filename;
+    std::cout << "Adding DST: " << filepath << std::endl;
+    if (i == 0)
+    {
+      rc->set_IntFlag("RUNNUMBER", runnumber);
+      rc->set_uint64Flag("TIMESTAMP", runnumber);
+    }
+
+    std::string inputname = "InputManager" + std::to_string(i);
+    auto *hitsin = new Fun4AllDstInputManager(inputname);
+    hitsin->fileopen(filename);
+    se->registerInputManager(hitsin);
+
+    ++i;
+  }
+
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+  rc->set_IntFlag("RUNSEGMENT", segment);
+
+  Enable::QA = false;
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+
+ 
+
+  G4TRACKING::convert_seeds_to_svtxtracks = convertSeeds;
+
+
+  std::cout << " run: " << runnumber
+            << " samples: " << TRACKING::reco_tpc_maxtime_sample
+            << " pre: " << TRACKING::reco_tpc_time_presample
+            << " vdrift: " << G4TPC::tpc_drift_velocity_reco
+            << std::endl;
+
+  TRACKING::streaming_mode = true;
+
+  FlagHandler *flag = new FlagHandler();
+  se->registerSubsystem(flag);
+
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+
+
+  TpcReadoutInit(runnumber);
+  G4TPC::REJECT_LASER_EVENTS = true;
+  // Flag for running the tpc hit unpacker with zero suppression on
+  TRACKING::tpc_zero_supp = true;
+
+  TrackingInit();
+
+  for (int felix = 0; felix < 6; felix++)
+  {
+    Mvtx_HitUnpacking(std::to_string(felix));
+  }
+  for (int server = 0; server < 8; server++)
+  {
+    Intt_HitUnpacking(std::to_string(server));
+  }
+  std::ostringstream ebdcname;
+  for (int ebdc = 0; ebdc < 24; ebdc++)
+  {
+    for (int endpoint = 0; endpoint < 2; endpoint++)
+      {
+        ebdcname.str("");
+        if (ebdc < 10)
+	  {
+	    ebdcname << "0";
+	  }
+        ebdcname << ebdc << "_" << endpoint;
+        Tpc_HitUnpacking(ebdcname.str());
+      }
+  }
+
+
+  Micromegas_HitUnpacking();
+  Micromegas_Clustering();
+  Intt_Clustering();
+
+  Tpc_LaserEventIdentifying();
+
+  Reject_Laser_Events();
+
+
+
+  se->registerSubsystem(new Tpc_ModuleTrackReco()); // makes TPC_MODULETRACKS
+  se->registerSubsystem(new Tpc_AssembledTrackReco()); // makes TPC_ASSEMBLEDTRACKS
+ 
+  auto cluster = new Tpc_PolyClusterizer(); // makes TPC_POLYCLUSTERS
+ 
+  cluster->setKEffSide0(1.0);//OO 82626 - 4.5, AuAu 6x6 76905 -0, pp 79513 - 1.0, 75391 5.8 75405 4.8
+  cluster->setKEffSide1(1.6);//OO 82626 - 5.0, AuAu 6x6 76905 -0, pp 79513 - 1.6, 75391 5.6 75408 4.8
+
+  se->registerSubsystem(cluster);
+
+  se->registerSubsystem(new Tpc_PolyTrackReco());      // makes TPC_POLYTRACKS
+  se->registerSubsystem(new Tpc_PolyTrackVertexer());  // makes TPC_POLYTRACKVERTICES
+
+  //For the module tracks display uncomment following line
+  //se->registerSubsystem(new Tpc_ModuleTrackDisplay("Tpc_ModuleTrackDisplay", "tpc_moduletrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the assembled tracks display uncomment following line
+  //se->registerSubsystem(new Tpc_AssembledTrackDisplay("Tpc_AssembledTrackDisplay", "tpc_assembledtrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the  cluster and TPC SA tracks display uncomment following line
+  se->registerSubsystem(new Tpc_PolyClusterDisplay("Tpc_PolyClusterDisplay", "tpc_poly_cluster_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  
+  //For the  residual tree output uncomment following block (options to put cuts on minimum pT and minimum number of clusters in TPC SA are available)
+  auto resid = new Tpc_PolyClusterResiduals("Tpc_PolyClusterResiduals",
+                                        outdir + "/tpc_poly_track_residuals"+ outfilename + "_" + to_string(runnumber) + to_string(segment) + ".root" );
+  resid->setMinPt(0);
+  resid->setMinTpcClusters(20);
+  se->registerSubsystem(resid);
+  
+  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", Form("%s/DST_%s_%s_%s-%d-%d.root",outdir.c_str(), dsttype_to_save.c_str(), collision.c_str(), production.c_str(), runnumber, segment));
+
+  out->AddNode("Sync");
+  out->AddNode("EventHeader");
+  out->AddRunNode("TPCGEOMCONTAINER");
+  out->AddNode("TRKR_HITSET");
+  //out->AddNode("TPC_MODULETRACKS");
+  //out->AddNode("TPC_ASSEMBLEDTRACKS");
+  out->AddNode("TPC_POLYCLUSTERS");
+  out->AddNode("TPC_POLYTRACKS");
+  out->AddNode("TPC_POLYTRACKVERTICES");
+  out->AddNode("TRKR_CLUSTER");
+
+  se->registerOutputManager(out);
+  
+  se->run(nEvents+nSkip);
+  se->Print("NODETREE");
+  se->End();
+  se->PrintTimer();
+
+
+  CDBInterface::instance()->Print();
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+}

--- a/TpcProduction/Fun4All_raw_hit_TPC_reco.C
+++ b/TpcProduction/Fun4All_raw_hit_TPC_reco.C
@@ -65,7 +65,7 @@ R__LOAD_LIBRARY(libTrackingDiagnostics.so)
 class SkipFirstN : public SubsysReco {
  public:
   explicit SkipFirstN(int n) : SubsysReco("SkipFirstN"), target_(n) {}
-  int process_event(PHCompositeNode*) override {
+  int process_event(PHCompositeNode* /*unused*/) override {
     if (count_ < target_) { ++count_; return Fun4AllReturnCodes::ABORTEVENT; }
     return Fun4AllReturnCodes::EVENT_OK;
   }
@@ -88,12 +88,12 @@ void Fun4All_raw_hit_TPC_reco(
     const int nEvents = 2,
     const int runnumber = 79513,
     const int segment = 0,
-    const std::string outdir = ".",
+    const std::string& outdir = ".",
     const int nSkip = 0,
-    const std::string collision = "run3pp",
-    const std::string production = "ana532_nocdbtag_v001",
+    const std::string& collision = "run3pp",
+    const std::string& production = "ana532_nocdbtag_v001",
     const std::string& outfilename = "HITS_ppFieldOn",
-    const std::string datatype = "physics")
+    const std::string& datatype = "physics")
 {
   const bool convertSeeds = true;
   auto *se = Fun4AllServer::instance();
@@ -132,7 +132,7 @@ void Fun4All_raw_hit_TPC_reco(
 if(collision!="run3line_laser"&&collision!="run3cosmics")
 {
   // TPOT
-  streams.push_back("ebdc39");
+  streams.emplace_back("ebdc39");
 
   // INTT streams
   for (int server = 0; server < 8; ++server)
@@ -163,10 +163,8 @@ if(collision!="run3line_laser"&&collision!="run3cosmics")
   std::stringstream nice_rounded_down;
   nice_rounded_down << std::setw(8) << std::setfill('0') << std::to_string(rounded_down);
 
-  for (unsigned int is = 0; is < streams.size(); ++is)
+  for (auto stream : streams)
   {
-    const std::string stream = streams[is];
-
     std::string filename = "DST_" + dsttype + "_" + stream + "_" + collision + "_" + production + "-" +  runstr.str() + "-" + segstr.str() + ".root";
     std::string filepath = "/sphenix/lustre01/sphnxpro/production/" + collision + "/"+datatype+"/" + production + "/DST_" + dsttype + "_" + stream + "/run_" + nice_rounded_down.str()  + "_" + nice_rounded_up.str()  + "/" + filename;
     std::cout << "Adding DST: " << filepath << std::endl;
@@ -260,7 +258,7 @@ if(collision!="run3line_laser"&&collision!="run3cosmics")
   se->registerSubsystem(new Tpc_ModuleTrackReco()); // makes TPC_MODULETRACKS
   se->registerSubsystem(new Tpc_AssembledTrackReco()); // makes TPC_ASSEMBLEDTRACKS
  
-  auto cluster = new Tpc_PolyClusterizer(); // makes TPC_POLYCLUSTERS
+  auto *cluster = new Tpc_PolyClusterizer(); // makes TPC_POLYCLUSTERS
  
   cluster->setKEffSide0(1.0);//OO 82626 - 4.5, AuAu 6x6 76905 -0, pp 79513 - 1.0, 75391 5.8 75405 4.8
   cluster->setKEffSide1(1.6);//OO 82626 - 5.0, AuAu 6x6 76905 -0, pp 79513 - 1.6, 75391 5.6 75408 4.8
@@ -277,11 +275,11 @@ if(collision!="run3line_laser"&&collision!="run3cosmics")
   //se->registerSubsystem(new Tpc_AssembledTrackDisplay("Tpc_AssembledTrackDisplay", "tpc_assembledtrack_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
   
   //For the  cluster and TPC SA tracks display uncomment following line
-  se->registerSubsystem(new Tpc_PolyClusterDisplay("Tpc_PolyClusterDisplay", "tpc_poly_cluster_display_" + outfilename + "_" + to_string(runnumber) + ".root"));
+  se->registerSubsystem(new Tpc_PolyClusterDisplay("Tpc_PolyClusterDisplay", "tpc_poly_cluster_display_" + outfilename + "_" + std::to_string(runnumber) + ".root"));
   
   //For the  residual tree output uncomment following block (options to put cuts on minimum pT and minimum number of clusters in TPC SA are available)
-  auto resid = new Tpc_PolyClusterResiduals("Tpc_PolyClusterResiduals",
-                                        outdir + "/tpc_poly_track_residuals"+ outfilename + "_" + to_string(runnumber) + to_string(segment) + ".root" );
+  auto *resid = new Tpc_PolyClusterResiduals("Tpc_PolyClusterResiduals",
+					    outdir + "/tpc_poly_track_residuals"+ outfilename + "_" + std::to_string(runnumber) + std::to_string(segment) + ".root" );
   resid->setMinPt(0);
   resid->setMinTpcClusters(20);
   se->registerSubsystem(resid);


### PR DESCRIPTION
Example macros to run TPC SA tracking
related to PR: Tpc seed tracking#4354 `https://github.com/sPHENIX-Collaboration/coresoftware/pull/4354`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Adds example macros for TPC single-arm tracking and minimum-working-example reconstruction, related to coresoftware PR `#4354`.

## Key changes

- Added `Fun4All_TPC_Analysis.C` for running TPC tracking analysis on DST input.
- Added `Fun4All_raw_hit_TPC_reco.C` for reconstruction from raw TPC hits.
- Configured streaming input, CDB constants, tracking geometry, readout, clustering, tracking, vertexing, displays, residual output, and DST output.
- Added event-skipping support and configurable run, segment, collision, production, and output parameters.
- Applied clang-tidy-related updates to the macros.

## Potential risk areas

- Reconstruction behavior depends on CDB configuration, hardcoded clustering efficiencies, input naming, and available geometry.
- The raw-hit macro changes the produced DST content and may affect downstream I/O compatibility.
- Missing-input or subsystem-registration failures are not explicitly handled.
- Event-loop performance and resource usage may vary with enabled tracking, displays, and residual output.

## Possible future improvements

- Add validation and error handling for input files, CDB geometry, and subsystem registration.
- Move reconstruction constants and stream configuration to external configuration.
- Add usage documentation and automated smoke tests.
- Review output-node compatibility and performance for larger production workflows.

*AI-generated summaries can contain mistakes; please use best judgment when reviewing the implementation.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->