### PR TITLE
fix clang-tidy for Fun4All_raw_hit_TPC_reco.C

### DIFF
--- a/TpcProduction/Fun4All_raw_hit_TPC_reco.C
+++ b/TpcProduction/Fun4All_raw_hit_TPC_reco.C
@@ -18,6 +18,17 @@
 #include <Trkr_RecoInit.C>
 #include <Trkr_TpcReadoutInit.C>
 
+#include <tpctrackreco/Tpc_ModuleTrackReco.h>
+#include <tpctrackreco/Tpc_AssembledTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackReco.h>
+#include <tpctrackreco/Tpc_PolyTrackVertexer.h>
+#include <tpctrackreco/Tpc_PolyClusterizer.h>
+
+#include <trackingdiagnostics/Tpc_ModuleTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_AssembledTrackDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterDisplay.h>
+#include <trackingdiagnostics/Tpc_PolyClusterResiduals.h>
+
 #include <cdbobjects/CDBTTree.h>
 
 #include <ffamodules/CDBInterface.h>
@@ -36,18 +47,7 @@
 
 #include <phool/recoConsts.h>
 
-
-#include <tpctrackreco/Tpc_ModuleTrackReco.h>
-#include <tpctrackreco/Tpc_AssembledTrackReco.h>
-#include <tpctrackreco/Tpc_PolyTrackReco.h>
-#include <tpctrackreco/Tpc_PolyTrackVertexer.h>
-#include <tpctrackreco/Tpc_PolyClusterizer.h>
-
-#include <trackingdiagnostics/Tpc_ModuleTrackDisplay.h>
-#include <trackingdiagnostics/Tpc_AssembledTrackDisplay.h>
-#include <trackingdiagnostics/Tpc_PolyClusterDisplay.h>
-#include <trackingdiagnostics/Tpc_PolyClusterResiduals.h>
-
+#include <format>
 
 R__LOAD_LIBRARY(libfun4all.so)
 R__LOAD_LIBRARY(libffamodules.so)
@@ -163,10 +163,10 @@ if(collision!="run3line_laser"&&collision!="run3cosmics")
   std::stringstream nice_rounded_down;
   nice_rounded_down << std::setw(8) << std::setfill('0') << std::to_string(rounded_down);
 
-  for (auto stream : streams)
+  for (auto &stream : streams)
   {
-    std::string filename = "DST_" + dsttype + "_" + stream + "_" + collision + "_" + production + "-" +  runstr.str() + "-" + segstr.str() + ".root";
-    std::string filepath = "/sphenix/lustre01/sphnxpro/production/" + collision + "/"+datatype+"/" + production + "/DST_" + dsttype + "_" + stream + "/run_" + nice_rounded_down.str()  + "_" + nice_rounded_up.str()  + "/" + filename;
+    std::string filename = std::format("DST_{}_{}_{}_{}_{:08d}-{:05d}.root", dsttype, stream, collision, production,  runnumber, segment);
+    std::string filepath = std::format("/sphenix/lustre01/sphnxpro/production/{}/{}/{}/DST_{}_{}/run_{}_{}/{}",collision, datatype, production, dsttype, stream,  nice_rounded_down.str(), nice_rounded_up.str(),filename);
     std::cout << "Adding DST: " << filepath << std::endl;
     if (i == 0)
     {
@@ -284,7 +284,7 @@ if(collision!="run3line_laser"&&collision!="run3cosmics")
   resid->setMinTpcClusters(20);
   se->registerSubsystem(resid);
   
-  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", Form("%s/DST_%s_%s_%s-%d-%d.root",outdir.c_str(), dsttype_to_save.c_str(), collision.c_str(), production.c_str(), runnumber, segment));
+  Fun4AllOutputManager *out = new Fun4AllDstOutputManager("out", std::format("{}/DST_{}_{}_{}-{:08d}-{:05d}.root",outdir, dsttype_to_save, collision, production, runnumber, segment));
 
   out->AddNode("Sync");
   out->AddNode("EventHeader");


### PR DESCRIPTION
That one was overlooked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Fixes a previously overlooked clang-tidy issue in `Fun4All_raw_hit_TPC_reco.C`.

## Key changes

- Adds required TPC reconstruction and tracking diagnostic/display headers.
- Adds C++ `<format>` support.
- Replaces manual filename construction and ROOT `Form(...)` calls with `std::format(...)` for DST input, Lustre, and output paths.
- Preserves existing run, segment, collision, production, and DST naming components.

## Potential risk areas

- Verify that formatted paths retain the exact previous naming and padding conventions.
- Confirm compiler support for `<format>`.
- No intentional reconstruction, thread-safety, or performance changes are expected.

## Possible future improvements

- Add tests for representative input and output path formats.
- Document the required C++ standard and path-formatting conventions.

AI-generated summaries can contain mistakes; use best judgment when reviewing the implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->