### PR TITLE
code to check mbd zvtx against trkr zvtx

### DIFF
--- a/calibrations/mbd/DumpMbdCalibs.C
+++ b/calibrations/mbd/DumpMbdCalibs.C
@@ -5,6 +5,8 @@
 #ifndef DUMPMBDCALIBS_C
 #define DUMPMBDCALIBS_C
 
+#include <TSystem.h>
+
 #include <ffamodules/CDBInterface.h>
 
 #include <fun4all/Fun4AllServer.h>

--- a/calibrations/mbd/DumpMbdCalibs.C
+++ b/calibrations/mbd/DumpMbdCalibs.C
@@ -1,0 +1,59 @@
+// This example runs the CDBInterface like in the real reconstruction
+// once the CDBInterface instance is created it registers itself with the 
+// Fun4AllServer and creates (or adds to) the CdbUrl Node which contains a 
+// record of the files and timestamps which were used
+#ifndef DUMPMBDCALIBS_C
+#define DUMPMBDCALIBS_C
+
+#include <ffamodules/CDBInterface.h>
+
+#include <fun4all/Fun4AllServer.h>
+#include <fun4all/Fun4AllDummyInputManager.h>
+
+#include <phool/recoConsts.h>
+#include "mbd/MbdCalib.h"
+
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libmbd_io.so)
+
+// pcdb001
+void DumpMbdCalibs(const int runno, const char* dbtag = "newcdbtag")
+{
+  recoConsts *rc = recoConsts::instance();
+  rc->set_StringFlag("CDB_GLOBALTAG",dbtag); 
+  rc->set_uint64Flag("TIMESTAMP",runno);
+  rc->set_uint64Flag("RUNNUMBER",runno);
+  Fun4AllServer *se = Fun4AllServer::instance();
+  se->Verbosity(1);
+
+  /*
+  CDBInterface *cdb = CDBInterface::instance();
+  std::string timecorr_url = cdb->getUrl("MBD_TIMECORR");
+  std::string slewcorr_url = cdb->getUrl("MBD_SLEWCORR");
+  cout << "xxxurl: " << cdb->getUrl("MBD_SAMPMAX") << endl;
+  cout << "xxxurl: " << cdb->getUrl("MBD_QFIT") << endl;
+  cout << "xxxurl: " << cdb->getUrl("MBD_T0CORR") << endl;
+  std::string t0corr_url = cdb->getUrl("MBD_T0CORR");
+  cout << t0corr_url.size() << endl;
+  */
+
+  MbdCalib *mcal = new MbdCalib();
+  mcal->Verbosity(1);
+  mcal->Download_All();
+  mcal->Write_All();
+  //mcal->Download_TimeCorr(timecorr_url);
+  //mcal->Write_TimeCorr("tcorr.calib");
+  //mcal->Download_SlewCorr(slewcorr_url);
+  //mcal->Write_SlewCorr("slewcorr.calib");
+  //mcal->Write_TQT0("a.calib");
+
+  std::cout << "All done" << std::endl;
+
+  gSystem->Exit(0);
+  return;
+}
+
+#endif  // DUMPMBDCALIBS_C
+

--- a/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
+++ b/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
@@ -59,8 +59,8 @@ void Fun4All_MBD_TrackVertex(
     const std::string& outfilename = "mbd_trkvtx",
     const std::string& outdir = "./")
 {
-  std::string inputTrackFile = trackfilename;
-  std::string inputCaloFile = calofilename;
+  std::string& inputTrackFile = trackfilename;
+  std::string& inputCaloFile = calofilename;
 
   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(trackfilename);
   int runnumber = runseg.first;

--- a/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
+++ b/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
@@ -59,8 +59,8 @@ void Fun4All_MBD_TrackVertex(
     const std::string& outfilename = "mbd_trkvtx",
     const std::string& outdir = "./")
 {
-  std::string& inputTrackFile = trackfilename;
-  std::string& inputCaloFile = calofilename;
+  const std::string& inputTrackFile = trackfilename;
+  const std::string& inputCaloFile = calofilename;
 
   std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(trackfilename);
   int runnumber = runseg.first;

--- a/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
+++ b/calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C
@@ -1,0 +1,190 @@
+/*
+ * This macro shows a minimum working example of running over the production track and calo DSTs.
+ * You can add some analysis modules at the end which package tracks and calo clusters into trees for analysis.
+ */
+
+// leave the GlobalVariables.C at the beginning, an empty line afterwards
+// protects its position against reshuffling by clang-format
+#include <GlobalVariables.C>
+
+#include <G4_ActsGeom.C>
+#include <G4_Global.C>
+#include <G4_Magnet.C>
+#include <Trkr_Clustering.C>
+#include <Trkr_Reco.C>
+#include <Trkr_RecoInit.C>
+#include <Trkr_TpcReadoutInit.C>
+#include <QA.C>
+
+#include <trackreco/PHActsTrackProjection.h>
+
+#include <trackbase_historic/SvtxTrack.h>
+
+#include <ffamodules/CDBInterface.h>
+
+#include <fun4all/Fun4AllDstInputManager.h>
+#include <fun4all/Fun4AllDstOutputManager.h>
+#include <fun4all/Fun4AllInputManager.h>
+#include <fun4all/Fun4AllUtils.h>
+#include <fun4all/Fun4AllOutputManager.h>
+#include <fun4all/Fun4AllRunNodeInputManager.h>
+#include <fun4all/Fun4AllServer.h>
+
+#include <phool/recoConsts.h>
+
+#include <iostream>
+#include <filesystem>
+
+#include <mbd/MbdReco.h>
+#include <mbdcalib/MbdTrackVertex.h>
+
+R__LOAD_LIBRARY(libfun4all.so)
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+R__LOAD_LIBRARY(libcdbobjects.so)
+R__LOAD_LIBRARY(libtrack_reco.so)
+R__LOAD_LIBRARY(libcalo_reco.so)
+R__LOAD_LIBRARY(libcalotrigger.so)
+R__LOAD_LIBRARY(libcentrality.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libepd.so)
+R__LOAD_LIBRARY(libzdcinfo.so)
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libmbdcalib.so)
+
+void Fun4All_MBD_TrackVertex(
+    const int nEvents = 10,
+    const std::string& trackfilename = "DST_TRKR_TRACKS_run2pp_ana475_2024p017_v001-00053877-00000.root",
+    const std::string& calofilename = "DST_CALO_run2pp_ana468_2024p012_v001-00053877-00000.root",
+    const std::string& outfilename = "mbd_trkvtx",
+    const std::string& outdir = "./")
+{
+  std::string inputTrackFile = trackfilename;
+  std::string inputCaloFile = calofilename;
+
+  std::pair<int, int> runseg = Fun4AllUtils::GetRunSegment(trackfilename);
+  int runnumber = runseg.first;
+  int segment = runseg.second;
+
+  std::string theOutfileheader = outdir + outfilename + "_" + std::to_string(runnumber) + "-" + std::to_string(segment);
+
+  Enable::MVTX_APPLYMISALIGNMENT = true;
+  ACTSGEOM::mvtx_applymisalignment = Enable::MVTX_APPLYMISALIGNMENT;
+  TRACKING::streaming_mode = true;
+
+  auto *se = Fun4AllServer::instance();
+  se->Verbosity(1);
+
+  auto *rc = recoConsts::instance();
+  rc->set_IntFlag("RUNNUMBER", runnumber);
+  rc->set_IntFlag("RUNSEGMENT", segment);
+
+  Enable::CDB = true;
+  rc->set_StringFlag("CDB_GLOBALTAG", "newcdbtag");
+  rc->set_uint64Flag("TIMESTAMP", runnumber);
+  std::string geofile = CDBInterface::instance()->getUrl("Tracking_Geometry");
+
+  Fun4AllRunNodeInputManager *ingeo = new Fun4AllRunNodeInputManager("GeoIn");
+  ingeo->AddFile(geofile);
+  se->registerInputManager(ingeo);
+
+  TpcReadoutInit( runnumber );
+  std::cout << " run: " << runnumber
+            << " samples: " << TRACKING::reco_tpc_maxtime_sample
+            << " pre: " << TRACKING::reco_tpc_time_presample
+            << " vdrift: " << G4TPC::tpc_drift_velocity_reco
+            << std::endl;
+
+  G4TPC::ENABLE_MODULE_EDGE_CORRECTIONS = true;
+
+  // to turn on the default static corrections, enable the two lines below
+  G4TPC::ENABLE_STATIC_CORRECTIONS = true;
+
+  //to turn on the average corrections, enable the three lines below
+  //note: these are designed to be used only if static corrections are also applied
+  G4TPC::ENABLE_AVERAGE_CORRECTIONS = true;
+
+  G4MAGNET::magfield_rescale = 1;
+  TrackingInit();
+
+  auto *trackin = new Fun4AllDstInputManager("TrackInManager");
+  trackin->fileopen(inputTrackFile);
+  //trackin->AddListFile(inputTrackFile);
+  se->registerInputManager(trackin);
+
+  auto *caloin = new Fun4AllDstInputManager("CaloInManager");
+  caloin->fileopen(inputCaloFile);
+  //caloin->AddListFile(inputCaloFile);
+  se->registerInputManager(caloin);
+
+  /*
+  auto *projection = new PHActsTrackProjection("CaloProjection");
+  float new_cemc_rad = 99; // from DetailedCalorimeterGeometry, project to inner surface
+  bool doEMcalRadiusCorr = true;
+  if (doEMcalRadiusCorr)
+  {
+    projection->setLayerRadius(SvtxTrack::CEMC, new_cemc_rad);
+  }
+  se->registerSubsystem(projection);
+  */
+
+  // MBD/BBC Reconstruction
+  MbdReco *mbdreco = new MbdReco();
+  //const int calpass = 2;  // if we want to use local calibs
+  //mbdreco->SetCalPass(calpass);
+  rc->set_StringFlag("MBD_TT_T0", "mbd_tt_t0.calib");
+  rc->set_StringFlag("MBD_TQ_T0", "mbd_tq_t0.calib");
+  se->registerSubsystem(mbdreco);
+
+  Global_Reco();
+
+  MbdTrackVertex *mbdtrkvtx = new MbdTrackVertex();
+  se->registerSubsystem( mbdtrkvtx );
+
+  if (Enable::DSTOUT)
+  {
+    std::string dstOutputFileName= theOutfileheader + "_dst.root";
+    Fun4AllDstOutputManager *out = new Fun4AllDstOutputManager("DSTOUT", dstOutputFileName);
+    out->AddNode("Sync");
+    out->AddNode("EventHeader");
+    out->AddNode("SvtxTrackMap");
+    out->AddNode("GlobalVertexMap");
+    out->AddNode("CLUSTERINFO_CEMC");
+    se->registerOutputManager(out);
+  }
+
+  se->run(nEvents);
+  se->End();
+  se->PrintTimer();
+
+  if(Enable::QA)
+  {
+    std::string qaOutputFileName = theOutfileheader + "_qa.root";
+    QAHistManagerDef::saveQARootFile(qaOutputFileName);
+  }
+
+  CDBInterface::instance()->Print();
+  delete se;
+  std::cout << "Finished" << std::endl;
+  gSystem->Exit(0);
+
+  return;
+}
+
+std::string GetFirstLine(const std::string& listname)
+{
+  std::ifstream file(listname);
+
+  std::string firstLine;
+  if (file.is_open()) {
+      if (std::getline(file, firstLine)) {
+          std::cout << "First Line: " << firstLine << std::endl;
+      } else {
+          std::cerr << "Unable to read first line of file" << std::endl;
+      }
+      file.close();
+  } else {
+      std::cerr << "Unable to open file" << std::endl;
+  }
+  return firstLine;
+}

--- a/calibrations/mbd/MBDTRKZ/make_mbdtrkz_lists.py
+++ b/calibrations/mbd/MBDTRKZ/make_mbdtrkz_lists.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+make_mbdtrkz_lists.py <runnumber> [--nevents N] [--trkseg S] [--trkdst clus|tracks]
+                      [--listdir DIR]
+
+Writes clus.list or tracks.list (controlled by --trkdst), and fit.list covering
+N events starting at block S (each block is N events).
+
+  --nevents N          events per block (default 1000, must be a multiple of
+                       EVT_PER_SEED=1000)
+  --skip S             number of N-event blocks to skip (default 0)
+  --trkdst clus|tracks source DST type: 'clus' reads from dst_clus/<runnumber>.list
+                       and writes clus.list; 'tracks' reads from dst_tracks/<runnumber>.list
+                       and writes tracks.list (default: tracks)
+  --listdir DIR        base directory containing dst_clus/, dst_tracks/, dst_fit/
+                       (default: ~/sphenix/sphenix_bbc/run2025/lists/run3pp)
+
+Example:
+  --nevents 100000 --skip 0 --trkdst clus    ->  clus segs   0-99,  fit seg 0
+  --nevents 100000 --skip 1 --trkdst tracks  ->  tracks segs 100-199, fit seg 1
+  --nevents 200000 --skip 1                  ->  tracks segs 200-399, fit segs 2-3
+
+Returns 0 on success, 1 if any expected DSTs are missing.
+"""
+
+import os
+import re
+import sys
+
+EVT_PER_SEED =   1000   # events per track/clus/track DST file
+EVT_PER_FIT  = 100000   # events per fit DST file
+SEEDS_PER_FIT = EVT_PER_FIT // EVT_PER_SEED   # = 100
+
+
+def get_seg(filename):
+    """Return the 5-digit trailing segment number from a DST filename, or None."""
+    m = re.search(r'-(\d{5})\.root', filename)
+    return int(m.group(1)) if m else None
+
+
+def lines_in_range(listfile, lo, hi):
+    """Return stripped non-empty lines whose segment number is in [lo, hi]."""
+    result = []
+    with open(listfile) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            seg = get_seg(line)
+            if seg is not None and lo <= seg <= hi:
+                result.append(line)
+    return result
+
+
+def parse_args():
+    args = sys.argv[1:]
+    runnumber  = None
+    nevents    = EVT_PER_FIT   # default: one fit-file block
+    trkseg     = 0
+    trkdst     = 'tracks'      # default DST type
+    listdir    = os.path.expanduser('~/sphenix/sphenix_bbc/run2025/lists/run3pp')
+    i = 0
+    while i < len(args):
+        if args[i] in ('--nevents', '-nevents'):
+            if i + 1 >= len(args):
+                print('ERROR: --nevents requires an argument', file=sys.stderr)
+                sys.exit(1)
+            nevents = int(args[i + 1])
+            i += 2
+        elif args[i] in ('--trkseg', '-trkseg'):
+            if i + 1 >= len(args):
+                print('ERROR: --trkseg requires an argument', file=sys.stderr)
+                sys.exit(1)
+            trkseg = int(args[i + 1])
+            i += 2
+        elif args[i] in ('--trkdst', '-trkdst'):
+            if i + 1 >= len(args):
+                print('ERROR: --trkdst requires an argument', file=sys.stderr)
+                sys.exit(1)
+            trkdst = args[i + 1]
+            if trkdst not in ('clus', 'tracks'):
+                print(f'ERROR: --trkdst must be "clus" or "tracks", got "{trkdst}"',
+                      file=sys.stderr)
+                sys.exit(1)
+            i += 2
+        elif args[i] in ('--listdir', '-listdir'):
+            if i + 1 >= len(args):
+                print('ERROR: --listdir requires an argument', file=sys.stderr)
+                sys.exit(1)
+            listdir = os.path.expanduser(args[i + 1])
+            i += 2
+        elif not args[i].startswith('-'):
+            if runnumber is not None:
+                print('ERROR: unexpected argument', file=sys.stderr)
+                sys.exit(1)
+            runnumber = int(args[i])
+            i += 1
+        else:
+            print(f'ERROR: unknown option {args[i]}', file=sys.stderr)
+            sys.exit(1)
+
+    if runnumber is None:
+        print(f'Usage: {sys.argv[0]} <runnumber> [--nevents N] [--trkseg S] [--trkdst clus|tracks] [--listdir DIR]',
+              file=sys.stderr)
+        sys.exit(1)
+
+    if nevents <= 0 or nevents % EVT_PER_SEED != 0:
+        print(f'ERROR: --nevents must be a positive multiple of {EVT_PER_SEED}',
+              file=sys.stderr)
+        sys.exit(1)
+
+    return runnumber, nevents, trkseg, trkdst, listdir
+
+
+def main():
+    runnumber, nevents, trkseg, trkdst, listdir = parse_args()
+
+    tracks_per_block = nevents // EVT_PER_SEED
+    fits_per_block  = (nevents + EVT_PER_FIT - 1) // EVT_PER_FIT  # ceiling div
+
+    src_dir  = 'dst_clus' if trkdst == 'clus' else 'dst_tracks'
+    out_name = 'clus.list' if trkdst == 'clus' else 'tracks.list'
+
+    trk_list = os.path.join(listdir, src_dir, f'{runnumber}.list')
+    fit_list = os.path.join(listdir, 'dst_fit', f'{runnumber}.list')
+
+    for f in (trk_list, fit_list):
+        if not os.path.isfile(f):
+            print(f'ERROR: list file not found: {f}', file=sys.stderr)
+            sys.exit(1)
+
+    # segment starts
+    trk_start = trkseg
+    trk_end   = trk_start + tracks_per_block - 1
+    fit_lo    = trk_start // SEEDS_PER_FIT
+    fit_hi    = trk_end   // SEEDS_PER_FIT
+
+    trk_lines = lines_in_range(trk_list, trk_start, trk_end)
+    fit_lines = lines_in_range(fit_list, fit_lo,    fit_hi)
+
+    trk_segs = len({get_seg(l) for l in trk_lines})
+    fit_segs = len({get_seg(l) for l in fit_lines})
+
+    rc = 0
+    if trk_segs != tracks_per_block:
+        print(f'ERROR: need {tracks_per_block} {trkdst} segments [{trk_start},{trk_end}], '
+              f'found {trk_segs}', file=sys.stderr)
+        rc = 1
+    if fit_segs != fits_per_block:
+        print(f'ERROR: need {fits_per_block} fit file(s) for segments [{fit_lo},{fit_hi}], '
+              f'found {fit_segs}', file=sys.stderr)
+        rc = 1
+    if rc:
+        sys.exit(1)
+
+    with open(out_name, 'w') as f:
+        f.write('\n'.join(trk_lines) + '\n')
+    with open('fit.list', 'w') as f:
+        f.write('\n'.join(fit_lines) + '\n')
+
+    print(f'{out_name}: {len(trk_lines)} files ({trk_segs} unique segments)')
+    print(f'fit.list:  {len(fit_lines)} files (segs {fit_lo}-{fit_hi})')
+
+
+if __name__ == '__main__':
+    main()

--- a/calibrations/mbd/MBDTRKZ/make_mbdtrkz_lists.py
+++ b/calibrations/mbd/MBDTRKZ/make_mbdtrkz_lists.py
@@ -8,7 +8,6 @@ N events starting at block S (each block is N events).
 
   --nevents N          events per block (default 1000, must be a multiple of
                        EVT_PER_SEED=1000)
-  --skip S             number of N-event blocks to skip (default 0)
   --trkdst clus|tracks source DST type: 'clus' reads from dst_clus/<runnumber>.list
                        and writes clus.list; 'tracks' reads from dst_tracks/<runnumber>.list
                        and writes tracks.list (default: tracks)
@@ -16,9 +15,9 @@ N events starting at block S (each block is N events).
                        (default: ~/sphenix/sphenix_bbc/run2025/lists/run3pp)
 
 Example:
-  --nevents 100000 --skip 0 --trkdst clus    ->  clus segs   0-99,  fit seg 0
-  --nevents 100000 --skip 1 --trkdst tracks  ->  tracks segs 100-199, fit seg 1
-  --nevents 200000 --skip 1                  ->  tracks segs 200-399, fit segs 2-3
+  --nevents 100000 --trkdst clus    ->  clus segs   0-99,  fit seg 0
+  --nevents 100000 --trkdst tracks  ->  tracks segs 100-199, fit seg 1
+  --nevents 200000                  ->  tracks segs 200-399, fit segs 2-3
 
 Returns 0 on success, 1 if any expected DSTs are missing.
 """

--- a/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
+++ b/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
@@ -174,7 +174,7 @@ void plot_mbdtrkzdiff(const std::string &filelist = "MBDTRKZ/f.list")
   TLatex tex;
   tex.SetNDC();
   tex.SetTextSize(0.035);
-  tex.DrawLatex(0.15, 0.85, Form("pol0 fit: %.3f #pm %.3f cm", fpol0->GetParameter(0), fpol0->GetParError(0)));
+  tex.DrawLatex(0.15, 0.85, Form("pol0 fit: %.3f #pm %.3f cm", fpol0->GetParameter(0), fpol0->GetParError(0)));  // NOLINT(cppcoreguidelines-pro-type-vararg)
 
   c->SaveAs("mbdtrkzdiff.pdf");
   std::cout << "Saved mbdtrkzdiff.pdf" << std::endl;

--- a/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
+++ b/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <format>
 
 #include <TCanvas.h>
 #include <TF1.h>

--- a/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
+++ b/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
@@ -1,0 +1,181 @@
+// plot_mbdtrkzdiff.C
+//
+// Reads a list of mbdtrk_vertex.root files, fits the highest peak in
+// h_mbdtrkz with a Gaussian, and plots the mean vs run number.
+// Run number is extracted from the parent directory name (<run>_<skip>).
+//
+// Usage:
+//   root -b -q 'plot_mbdtrkzdiff.C("MBDTRKZ/f.list")'
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TGraphErrors.h>
+#include <TH1F.h>
+#include <TLatex.h>
+#include <TStyle.h>
+
+// Extract the run number from a path of the form .../MBDTRKZ/<run>_<skip>/filename
+// Returns -1 on failure.
+int run_from_path(const std::string &path)
+{
+  // find last two '/' to get the directory name
+  size_t slash2 = path.rfind('/');
+  if (slash2 == std::string::npos) return -1;
+  size_t slash1 = path.rfind('/', slash2 - 1);
+  std::string rundir = (slash1 != std::string::npos)
+                       ? path.substr(slash1 + 1, slash2 - slash1 - 1)
+                       : path.substr(0, slash2);
+  // rundir is "<run>_<skip>"
+  size_t us = rundir.find('_');
+  if (us == std::string::npos) return -1;
+  try { return std::stoi(rundir.substr(0, us)); }
+  catch (...) { return -1; }
+}
+
+void plot_mbdtrkzdiff(const std::string &filelist = "MBDTRKZ/f.list")
+{
+  gStyle->SetOptStat(0);
+  gStyle->SetOptFit(111111);
+
+  // --- read file list ---
+  std::vector<std::string> files;
+  {
+    std::ifstream ifs(filelist);
+    if (!ifs)
+    {
+      std::cerr << "Cannot open " << filelist << std::endl;
+      return;
+    }
+    std::string line;
+    while (std::getline(ifs, line))
+    {
+      if (!line.empty()) files.push_back(line);
+    }
+  }
+
+  if (files.empty())
+  {
+    std::cerr << "No files in " << filelist << std::endl;
+    return;
+  }
+
+  auto *g_mbdtrkzdiff = new TGraphErrors();
+  g_mbdtrkzdiff->SetName("g_mbdtrkzdiff");
+  g_mbdtrkzdiff->SetTitle("MBD - Tracker z-vertex;run;#Deltaz [cm]");
+
+  int ipt = 0;
+  for (const auto &fname : files)
+  {
+    int runnumber = run_from_path(fname);
+    if (runnumber < 0)
+    {
+      std::cerr << "WARNING: cannot parse run number from: " << fname << std::endl;
+      continue;
+    }
+
+    TFile *f = TFile::Open(fname.c_str(), "READ");
+    if (!f || f->IsZombie())
+    {
+      std::cerr << "WARNING: cannot open " << fname << std::endl;
+      continue;
+    }
+
+    auto *h = dynamic_cast<TH1F *>(f->Get("h_mbdtrkz"));
+    if (!h)
+    {
+      std::cerr << "WARNING: h_mbdtrkz not found in " << fname << std::endl;
+      f->Close();
+      continue;
+    }
+    h->SetDirectory(nullptr);
+    f->Close();
+
+    if (h->GetEntries() == 0)
+    {
+      std::cerr << "WARNING: h_mbdtrkz empty in " << fname << std::endl;
+      delete h;
+      continue;
+    }
+
+    // locate highest peak
+    int    peak_bin = h->GetMaximumBin();
+    double peak_x   = h->GetBinCenter(peak_bin);
+
+    // first pass: rough Gaussian fit ±3 cm around peak
+    TF1 gfit("gfit", "gaus", peak_x - 3.0, peak_x + 3.0);
+    int status = h->Fit(&gfit, "RQ0");
+    if (status != 0)
+    {
+      std::cerr << "WARNING: initial fit failed for run " << runnumber << std::endl;
+      delete h;
+      continue;
+    }
+
+    double sigma = gfit.GetParameter(2);
+    if (sigma <= 0)
+    {
+      std::cerr << "WARNING: bad sigma from initial fit for run " << runnumber << std::endl;
+      delete h;
+      continue;
+    }
+
+    // second pass: refit within ±2σ of first-pass mean
+    double mean1 = gfit.GetParameter(1);
+    gfit.SetRange(mean1 - 2.0 * sigma, mean1 + 2.0 * sigma);
+    status = h->Fit(&gfit, "RQ0");
+    if (status != 0)
+    {
+      std::cerr << "WARNING: second fit failed for run " << runnumber << std::endl;
+      delete h;
+      continue;
+    }
+
+    double mean     = gfit.GetParameter(1);
+    double mean_err = gfit.GetParError(1);
+
+    g_mbdtrkzdiff->SetPoint(ipt, runnumber, mean);
+    g_mbdtrkzdiff->SetPointError(ipt, 0., mean_err);
+    ++ipt;
+
+    delete h;
+  }
+
+  if (g_mbdtrkzdiff->GetN() == 0)
+  {
+    std::cerr << "No points in graph — nothing to plot." << std::endl;
+    return;
+  }
+
+  g_mbdtrkzdiff->Sort();
+
+  // pol0 fit
+  TF1 *fpol0 = new TF1("fpol0", "pol0", g_mbdtrkzdiff->GetX()[0]-10, g_mbdtrkzdiff->GetX()[g_mbdtrkzdiff->GetN() - 1]+10);
+  fpol0->SetLineColor(kRed);
+  fpol0->SetLineWidth(2);
+  g_mbdtrkzdiff->Fit(fpol0, "QR");
+
+  // draw
+  auto *c = new TCanvas("c_mbdtrkzdiff", "MBD-Tracker dz", 900, 600);
+  c->SetLeftMargin(0.12);
+  c->SetBottomMargin(0.12);
+
+  g_mbdtrkzdiff->SetMarkerStyle(20);
+  g_mbdtrkzdiff->SetMarkerSize(0.8);
+  g_mbdtrkzdiff->Draw("AP");
+
+  fpol0->Draw("same");
+
+  TLatex tex;
+  tex.SetNDC();
+  tex.SetTextSize(0.035);
+  tex.DrawLatex(0.15, 0.85, Form("pol0 fit: %.3f #pm %.3f cm", fpol0->GetParameter(0), fpol0->GetParError(0)));
+
+  c->SaveAs("mbdtrkzdiff.pdf");
+  std::cout << "Saved mbdtrkzdiff.pdf" << std::endl;
+}

--- a/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
+++ b/calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C
@@ -2,7 +2,7 @@
 //
 // Reads a list of mbdtrk_vertex.root files, fits the highest peak in
 // h_mbdtrkz with a Gaussian, and plots the mean vs run number.
-// Run number is extracted from the parent directory name (<run>_<skip>).
+// Run number is extracted from the parent directory name
 //
 // Usage:
 //   root -b -q 'plot_mbdtrkzdiff.C("MBDTRKZ/f.list")'
@@ -20,7 +20,7 @@
 #include <TLatex.h>
 #include <TStyle.h>
 
-// Extract the run number from a path of the form .../MBDTRKZ/<run>_<skip>/filename
+// Extract the run number from a path of the form .../MBDTRKZ/<run>/<seg>/filename
 // Returns -1 on failure.
 int run_from_path(const std::string &path)
 {
@@ -31,7 +31,6 @@ int run_from_path(const std::string &path)
   std::string rundir = (slash1 != std::string::npos)
                        ? path.substr(slash1 + 1, slash2 - slash1 - 1)
                        : path.substr(0, slash2);
-  // rundir is "<run>_<skip>"
   size_t us = rundir.find('_');
   if (us == std::string::npos) return -1;
   try { return std::stoi(rundir.substr(0, us)); }
@@ -174,7 +173,7 @@ void plot_mbdtrkzdiff(const std::string &filelist = "MBDTRKZ/f.list")
   TLatex tex;
   tex.SetNDC();
   tex.SetTextSize(0.035);
-  tex.DrawLatex(0.15, 0.85, Form("pol0 fit: %.3f #pm %.3f cm", fpol0->GetParameter(0), fpol0->GetParError(0)));  // NOLINT(cppcoreguidelines-pro-type-vararg)
+  tex.DrawLatex(0.15, 0.85, std::format("pol0 fit: {:.3f} #pm {:.3f} cm", fpol0->GetParameter(0), fpol0->GetParError(0)).c_str() );
 
   c->SaveAs("mbdtrkzdiff.pdf");
   std::cout << "Saved mbdtrkzdiff.pdf" << std::endl;

--- a/calibrations/mbd/MBDTRKZ/prorun_mbdtrkz.sh
+++ b/calibrations/mbd/MBDTRKZ/prorun_mbdtrkz.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# prorun_mbdtrkz.sh <runnumber> [--skip S] [--nevents N] [-n fun4all_nevents]
+# prorun_mbdtrkz.sh <runnumber> [--nevents N] [-n fun4all_nevents]
 #                               [--trkdst clus|tracks] [--listdir DIR]
 #
-# Creates MBDTRKZ/<runnumber>_<skip>/, generates seed/clus/fit lists there,
+# Creates MBDTRKZ/<runnumber>/<zero-padded trkseg>/, generates seed/clus/fit lists there,
 # and runs Fun4All_MBD_TrackVertex.C (tracks mode) or Fun4All_MBD_TrackFitting.C
 # once per clus file (clus mode).
 #
@@ -18,7 +18,8 @@
 #
 
 usage() {
-  echo "Usage: $0 <runnumber> [--skip S] [--nevents N] [-n fun4all_nevents] [--trkdst clus|tracks] [--listdir DIR]" >&2
+  #echo "Usage: $0 <runnumber> [--skip S] [--nevents N] [-n fun4all_nevents] [--trkdst clus|tracks] [--listdir DIR]" >&2
+  echo "Usage: $0 <runnumber> [--nevents N] [-n fun4all_nevents] [--trkdst clus|tracks] [--listdir DIR]" >&2
   exit 1
 }
 
@@ -31,7 +32,7 @@ ulimit -c 0   # no core files
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 runnumber=""
-skip=0
+#skip=0
 trkseg=0
 list_nevents=1000
 nevents=0
@@ -40,9 +41,9 @@ listdir=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --skip|--skip=*)
-      if [[ "$1" == *=* ]]; then skip="${1#*=}"; shift
-      else [[ $# -lt 2 ]] && usage; skip=$2; shift 2; fi ;;
+#    --skip|--skip=*)
+#      if [[ "$1" == *=* ]]; then skip="${1#*=}"; shift
+#      else [[ $# -lt 2 ]] && usage; skip=$2; shift 2; fi ;;
     --trkseg|--trkseg=*)
       if [[ "$1" == *=* ]]; then trkseg="${1#*=}"; shift
       else [[ $# -lt 2 ]] && usage; trkseg=$2; shift 2; fi ;;
@@ -110,10 +111,13 @@ else
   fi
 fi
 
+[[ -s tracks.list ]] || { echo "ERROR: tracks.list is empty" >&2; exit 1; }
+[[ -s fit.list ]] || { echo "ERROR: fit.list is empty" >&2; exit 1; }
+
 tracks_dst_file=$(head -1 tracks.list)
 mbd_dst_file=$(head -1 fit.list)
 echo root.exe -b -q Fun4All_MBD_TrackVertex.C\(${nevents},\"${tracks_dst_file}\",\"${mbd_dst_file}\"\)
-root.exe -b -q Fun4All_MBD_TrackVertex.C\(${nevents},\"${tracks_dst_file}\",\"${mbd_dst_file}\"\)
+root.exe -b -q Fun4All_MBD_TrackVertex.C\(${nevents},\"${tracks_dst_file}\",\"${mbd_dst_file}\"\) || exit 1
 
 if [[ -n "${_CONDOR_SCRATCH_DIR}" ]]; then
   pwd

--- a/calibrations/mbd/MBDTRKZ/prorun_mbdtrkz.sh
+++ b/calibrations/mbd/MBDTRKZ/prorun_mbdtrkz.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# prorun_mbdtrkz.sh <runnumber> [--skip S] [--nevents N] [-n fun4all_nevents]
+#                               [--trkdst clus|tracks] [--listdir DIR]
+#
+# Creates MBDTRKZ/<runnumber>_<skip>/, generates seed/clus/fit lists there,
+# and runs Fun4All_MBD_TrackVertex.C (tracks mode) or Fun4All_MBD_TrackFitting.C
+# once per clus file (clus mode).
+#
+#   --trkseg S           segment of track dst (default 0)
+#   --nevents N          events per block passed to make_mbdtrkz_lists.py (default 100000)
+#   -n fun4all_n         nEvents passed to Fun4All (default 0 = all)
+#   --trkdst clus|tracks DST type (default: tracks)
+#   --listdir DIR        base list directory passed to make_mbdtrkz_lists.py
+#
+# Under condor: stages files to _CONDOR_SCRATCH_DIR, runs there, copies
+# output back to the MBDTRKZ subdir.
+#
+
+usage() {
+  echo "Usage: $0 <runnumber> [--skip S] [--nevents N] [-n fun4all_nevents] [--trkdst clus|tracks] [--listdir DIR]" >&2
+  exit 1
+}
+
+echo "PWD=${PWD}"
+echo "HOST=$(hostname)"
+ORIG_DIR="${PWD}"
+
+ulimit -c 0   # no core files
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+runnumber=""
+skip=0
+trkseg=0
+list_nevents=1000
+nevents=0
+trkdst="tracks"
+listdir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip|--skip=*)
+      if [[ "$1" == *=* ]]; then skip="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; skip=$2; shift 2; fi ;;
+    --trkseg|--trkseg=*)
+      if [[ "$1" == *=* ]]; then trkseg="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; trkseg=$2; shift 2; fi ;;
+    --nevents|--nevents=*)
+      if [[ "$1" == *=* ]]; then nevents="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; nevents=$2; shift 2; fi ;;
+    --trkdst|--trkdst=*)
+      if [[ "$1" == *=* ]]; then trkdst="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; trkdst=$2; shift 2; fi
+      [[ "$trkdst" == "clus" || "$trkdst" == "tracks" ]] || { echo "ERROR: --trkdst must be clus or tracks" >&2; exit 1; } ;;
+    --listdir|--listdir=*)
+      if [[ "$1" == *=* ]]; then listdir="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; listdir=$2; shift 2; fi ;;
+    --nevtperjob|--nevtperjob=*)
+      if [[ "$1" == *=* ]]; then list_nevents="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && usage; list_nevents=$2; shift 2; fi ;;
+    -*)    usage ;;
+    *)     [[ -n "$runnumber" ]] && usage; runnumber=$1; shift ;;
+  esac
+done
+
+[[ -z "$runnumber" ]] && usage
+
+subdir="${ORIG_DIR}/MBDTRKZ/${runnumber}/$(printf '%04d' ${trkseg})"
+echo $subdir
+mkdir -p "${subdir}"
+
+cd "${subdir}"
+
+ln -sf "${SCRIPTDIR}/Fun4All_MBD_TrackVertex.C" .
+ln -sf "${SCRIPTDIR}/Fun4All_MBD_TrackSeeding.C" .
+ln -sf "${SCRIPTDIR}/Fun4All_MBD_TrackFitting.C" .
+ln -sf /pdata/chiu/25_CALIBPRODUCTION/results/ .
+
+python3 "${SCRIPTDIR}/make_mbdtrkz_lists.py" "$runnumber" --trkseg "$trkseg" --nevents "$list_nevents" --trkdst "$trkdst" \
+  ${listdir:+--listdir "$listdir"} || exit 1
+
+# tracks mode: stage files and run Fun4All_MBD_TrackVertex.C as before
+if [[ -n "${_CONDOR_SCRATCH_DIR}" ]]; then
+  mkdir -p "${_CONDOR_SCRATCH_DIR}"
+  cp -p *.C *.list "${_CONDOR_SCRATCH_DIR}/"
+  cd "${_CONDOR_SCRATCH_DIR}"
+  ln -sf /pdata/chiu/25_CALIBPRODUCTION/results/ .
+  time getinputfiles.pl --filelist fit.list
+  [[ -f clus.list ]] && time getinputfiles.pl --filelist clus.list
+  [[ -f seed.list ]] && time getinputfiles.pl --filelist seed.list  # never used
+  [[ -f tracks.list ]] && time getinputfiles.pl --filelist tracks.list
+fi
+
+if [[ "$trkdst" == "clus" ]]; then
+  # Run Fun4All_MBD_TrackFitting.C once per file in clus.list
+  while IFS= read -r clusfile; do
+    [[ -z "$clusfile" ]] && continue
+    echo root.exe -b -q "Fun4All_MBD_TrackSeeding.C(${nevents},\"${clusfile}\")"
+    root.exe -b -q "Fun4All_MBD_TrackSeeding.C(${nevents},\"${clusfile}\")" || exit 1
+    seedfile=DST_TRKR_SEED${clusfile#DST_TRKR_CLUSTER}
+    echo root.exe -b -q "Fun4All_MBD_TrackFitting.C(${nevents},\"${seedfile}\")"
+    root.exe -b -q "Fun4All_MBD_TrackFitting.C(${nevents},\"${seedfile}\")" || exit 1
+  done < clus.list
+
+  ls DST_TRKR_TRACK*.root > tracks.list
+else
+  if [[ -n "${_CONDOR_SCRATCH_DIR}" ]]; then
+    time getinputfiles.pl --filelist tracks.list
+  fi
+fi
+
+tracks_dst_file=$(head -1 tracks.list)
+mbd_dst_file=$(head -1 fit.list)
+echo root.exe -b -q Fun4All_MBD_TrackVertex.C\(${nevents},\"${tracks_dst_file}\",\"${mbd_dst_file}\"\)
+root.exe -b -q Fun4All_MBD_TrackVertex.C\(${nevents},\"${tracks_dst_file}\",\"${mbd_dst_file}\"\)
+
+if [[ -n "${_CONDOR_SCRATCH_DIR}" ]]; then
+  pwd
+  df -h
+  ls -l
+  cp -p mbdtrk_*.root "${subdir}/"
+  cd "${ORIG_DIR}"
+fi

--- a/calibrations/mbd/MBDTRKZ/submit_mbdtrkz.sh
+++ b/calibrations/mbd/MBDTRKZ/submit_mbdtrkz.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+trkdst="clus"
+
+# Parse --trkdst; remaining positional args are ${listdir}/${run}.list paths
+runlists=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --trkdst|--trkdst=*)
+      if [[ "$1" == *=* ]]; then trkdst="${1#*=}"; shift
+      else [[ $# -lt 2 ]] && { echo "ERROR: --trkdst requires an argument" >&2; exit 1; }
+           trkdst=$2; shift 2; fi
+      [[ "$trkdst" == "clus" || "$trkdst" == "tracks" ]] || \
+        { echo "ERROR: --trkdst must be clus or tracks" >&2; exit 1; } ;;
+    *) runlists+=("$1"); shift ;;
+  esac
+done
+
+NEVT_PER_JOB=100000      # nevt to process per list file
+EVT_PER_DST=1000         # nevt per dst_trkr_cluster or track
+EVT_PER_FIT=100000       # nevt per dst_calofit
+
+NFILES_JOB=$(( NEVT_PER_JOB / EVT_PER_DST ))
+
+for runlist in "${runlists[@]}"
+do
+  # runlist is ${base_listdir}/${dst_subdir}/${run}.list; go up two levels for base_listdir
+  base_listdir=$(dirname "$(dirname "$runlist")")
+
+  for dst in $(shuf -n ${NFILES_JOB} "$runlist")
+  do
+    echo dst $dst 
+    seg=${dst%.root}
+    seg=${seg##*-}
+
+    run=${dst%-*}
+    run=${run##*-}
+
+    log_base=${run}_${seg}
+
+    seg=$((10#$seg))  # convert to base 10
+    run=$((10#$run))
+
+    echo ./submit.sh --log ${log_base} ./prorun_mbdtrkz.sh $run --trkseg $seg --trkdst $trkdst --listdir "$base_listdir"
+    ./submit.sh --log ${log_base} ./prorun_mbdtrkz.sh $run --trkseg $seg --trkdst $trkdst --listdir "$base_listdir"
+  done
+done
+

--- a/calibrations/mbd/PLOTS/plot_calibgains.C
+++ b/calibrations/mbd/PLOTS/plot_calibgains.C
@@ -54,9 +54,9 @@ void read_calibgains(const char *flist)
   TString calrunseq;
   TString calfile;
   TString name;
-  while ( inflist >> calrunseq )
+  while ( inflist >> calrunseq >> calfile )
   {
-    calfile = "results/" + calrunseq + "/mbd_qfit.calib";
+    //calfile = "results/" + calrunseq + "/mbd_qfit.calib";
     std::cout << calfile << std::endl;
     cal_mip_file.open( calfile );
 
@@ -112,14 +112,14 @@ void read_calibgains(const char *flist)
       {
         std::cout << "BAD " << calfile << "\t" << ipmt << "\t" << best_peak
           << "\t" << integ << "\t" << bqmean[temp_pmt][nruns] << "\t" << chi2ndf << std::endl;
-        bqmean[temp_pmt][nruns] = NAN;
+        //bqmean[temp_pmt][nruns] = NAN;
       }
 
       if ( bqmeanerr[temp_pmt][nruns]>10. )
       {
         std::cout << "BADERR " << calfile << "\t" << ipmt << "\t" << best_peakerr << "\t"
           << best_peak << "\t" << bqmean[temp_pmt][nruns-1] << std::endl;
-        bqmeanerr[temp_pmt][nruns] = NAN;
+        //bqmeanerr[temp_pmt][nruns] = NAN;
       }
     }
 
@@ -181,7 +181,7 @@ void CheckForLargeDeviation( const double max_deviation = 0.10 ) // 10% deviatio
       {
         std::cout << "BADDEV " << listofruns[irun] << "\t" << ipmt << "\t" << bqmean[ipmt][irun]
           << "\t" << prevgoodmean << "\t" << deviation << std::endl;
-        bqmean[ipmt][irun] = NAN;
+        //bqmean[ipmt][irun] = NAN;
       }
     }
   }

--- a/calibrations/mbd/TIMING/comp_timecorr.C
+++ b/calibrations/mbd/TIMING/comp_timecorr.C
@@ -1,0 +1,521 @@
+#include <mbd/MbdCalib.h>
+
+#include <TH1D.h>
+#include <TCanvas.h>
+#include <TLine.h>
+#include <TStyle.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <string>
+#include <cmath>
+
+#include <fun4all/Fun4AllUtils.h>
+
+#include <mbd/MbdGeomV2.h>
+#include <mbd/MbdCalib.h>
+#include "get_runstr.h"
+
+R__LOAD_LIBRARY(libmbd.so)
+R__LOAD_LIBRARY(libmbd_io.so)
+
+
+// For each run in listfile, load the timecorr LUT and compute the per-TDC-bin ratio
+// relative to the first run for each channel.  The mean ratio over all TDC bins is
+// stored as one TTree entry per (run, channel) in timecorr_avg.root.
+void average_timecorr(const std::string& listfile = "tcorr.list")
+{
+  constexpr int NPMT = 128;
+
+  MbdGeom* mbdgeom = new MbdGeomV2();
+
+  // Read file list
+  std::vector<std::string> files;
+  std::vector<int>         runs;
+  {
+    std::ifstream lf(listfile);
+    if (!lf.is_open())
+    {
+      std::cerr << "Error: Could not open " << listfile << std::endl;
+      return;
+    }
+    // Parse run number from the directory component: 000<run>-0000
+    auto parse_run = [](const std::string& path) -> int
+    {
+      size_t slash2 = path.rfind('/');
+      size_t slash1 = (slash2 == std::string::npos) ? std::string::npos : path.rfind('/', slash2 - 1);
+      size_t start  = (slash1 == std::string::npos) ? 0 : slash1 + 1;
+      std::string dir = path.substr(start, (slash2 == std::string::npos ? path.size() : slash2) - start);
+      size_t dash = dir.find('-');
+      if (dash == std::string::npos) return -1;
+      try { return std::stoi(dir.substr(0, dash)); }
+      catch (...) { return -1; }
+    };
+
+    std::string path;
+    while (lf >> path)
+    {
+      int runno = parse_run(path);
+      if (runno < 0)
+      {
+        std::cerr << "Warning: Could not parse run number from: " << path << std::endl;
+        continue;
+      }
+      files.push_back(path);
+      runs.push_back(runno);
+    }
+  }
+
+  if (files.empty())
+  {
+    std::cerr << "Error: no valid files in " << listfile << std::endl;
+    return;
+  }
+
+  int nruns = (int)files.size();
+
+  // Load all calibrations
+  std::vector<MbdCalib*> calibs(files.size());
+  for (size_t i = 0; i < files.size(); i++)
+  {
+    std::cout << "Loading " << files[i] << std::endl;
+    calibs[i] = new MbdCalib();
+    calibs[i]->Download_TimeCorr(files[i]);
+  }
+
+  // Determine LUT size from first file
+  int min_tdc, max_tdc, step;
+  calibs[0]->get_tcorr_range(0, min_tdc, max_tdc, step);
+  int ntdc = (max_tdc - min_tdc) / step + 1;
+  std::cout << "LUT size: " << ntdc << " bins  [" << min_tdc << ", " << max_tdc << "]  step=" << step << std::endl;
+
+  // TTree output
+  TFile* fout = new TFile("timecorr_avg.root", "RECREATE");
+  TTree* t = new TTree("t", "TimCorr LUT ratios vs first run");
+  int    t_run;
+  int    t_ch;
+  double t_ratio;
+  double t_delta;
+  t->Branch("run",   &t_run,   "run/I");
+  t->Branch("ch",    &t_ch,    "ch/I");
+  t->Branch("ratio", &t_ratio, "ratio/D");
+  t->Branch("delta", &t_delta, "delta/D");
+
+  // ratio_by_ch / delta_by_ch [ch][run_index] — filled alongside TTree for the PDF
+  std::vector<std::vector<double>> ratio_by_ch(NPMT, std::vector<double>(files.size(), 0.));
+  std::vector<std::vector<double>> delta_by_ch(NPMT, std::vector<double>(files.size(), 0.));
+
+  // lut_sum[ch][ilut]: sum of val across all runs for every bin (all tdc range)
+  std::vector<std::vector<double>> lut_sum(NPMT, std::vector<double>(ntdc, 0.));
+
+  // For each run and channel, compute mean(LUT[run][ch][tdc] / LUT[ref][ch][tdc]) over all tdc bins
+  for (size_t irun = 0; irun < files.size(); irun++)
+  {
+    t_run = runs[irun];
+    for (int ipmt = 0; ipmt < NPMT; ipmt++)
+    {
+      int ifeech = mbdgeom->get_feech(ipmt, 0);
+
+      double sum       = 0.;
+      double sum_delta = 0.;
+      int    ngood     = 0;
+      for (int ilut = 0; ilut < ntdc; ilut++)
+      {
+        int itdc = ilut*step;
+        float val = calibs[irun]->get_tcorr(ifeech, itdc);
+        lut_sum[ipmt][ilut] += val; // accumulate over all bins for avg LUT
+
+        // select good region of itdc (13450 is min good tdc, in ch116)
+        if ( itdc<1400. || itdc>13450. )
+        {
+          continue;
+        }
+
+        float ref = calibs[0]->get_tcorr(ifeech, itdc);
+        //if (std::abs(ref) < 1e-9) continue; // skip zero reference bins
+        sum       += val / ref;
+        sum_delta += val - ref;
+        ngood++;
+      }
+
+      t_ch    = ipmt;
+      t_ratio = (ngood > 0) ? sum       / ngood : 0.;
+      t_delta = (ngood > 0) ? sum_delta / ngood : 0.;
+      ratio_by_ch[ipmt][irun] = t_ratio;
+      delta_by_ch[ipmt][irun] = t_delta;
+      t->Fill();
+    }
+  }
+
+  fout->cd();
+  t->Write();
+  std::cout << "Saved " << t->GetEntries() << " entries to timecorr_avg.root" << std::endl;
+
+  // Per-channel mean delta: <delta>[ch] = mean over runs of delta_by_ch[ch][irun]
+  std::vector<double> mean_delta(NPMT, 0.);
+  for (int ipmt = 0; ipmt < NPMT; ipmt++)
+  {
+    for (int ir = 0; ir < nruns; ir++) mean_delta[ipmt] += delta_by_ch[ipmt][ir];
+    mean_delta[ipmt] /= nruns;
+  }
+
+  // avg_lut[ch][ilut] = mean(val) - <delta>[ch]  (shift whole LUT by mean offset)
+  std::vector<std::vector<double>> avg_lut(NPMT, std::vector<double>(ntdc, 0.));
+  for (int ipmt = 0; ipmt < NPMT; ipmt++)
+  {
+    for (int ilut = 0; ilut < ntdc; ilut++)
+    {
+      avg_lut[ipmt][ilut] = lut_sum[ipmt][ilut] / nruns - mean_delta[ipmt];
+    }
+  }
+
+  // Write average calibration file in same format as mbd_timecorr.calib
+  {
+    std::ofstream calout("avg_mbd_timecorr.calib");
+    calout << std::fixed << std::setprecision(5);
+    for (int ipmt = 0; ipmt < NPMT; ipmt++)
+    {
+      int ifeech = mbdgeom->get_feech(ipmt,0);
+      calout << ifeech << "\t" << ntdc << "\t" << min_tdc << "\t" << max_tdc << "\n";
+      for (int ilut = 0; ilut < ntdc; ilut++)
+      {
+        calout << avg_lut[ipmt][ilut];
+        calout << ((ilut % 10 == 9) ? "\n" : " ");
+      }
+      if (ntdc % 10 != 0) calout << "\n";
+    }
+    std::cout << "Wrote avg_mbd_timecorr.calib" << std::endl;
+  }
+
+  // PDF: two pages per channel
+  //   Page A: ratio vs run index
+  //   Page B: corrected LUT overlays (all runs shifted by -t_delta, plus reference)
+  TCanvas* cpdf = new TCanvas("cpdf", "TimCorr Average", 1000, 500);
+  cpdf->Divide(2, 1);
+  const TString pdfname = "timecorr_average.pdf";
+  cpdf->Print(pdfname + "[");
+
+  // colour palette cycling over runs (skip white=0)
+  const int NCOLS = 9;
+  const int cols[NCOLS] = {kBlue, kRed, kGreen+2, kMagenta, kCyan+1,
+                            kOrange+1, kViolet+1, kTeal+1, kPink+1};
+
+  for (int ipmt = 0; ipmt < NPMT; ipmt++)
+  {
+    int ifeech = mbdgeom->get_feech(ipmt, 0);
+
+    // --- Left pad: ratio vs run ---
+    TGraph* gratio = new TGraph(nruns);
+    TString gname  = "g_ratio_ch"; gname += ipmt;
+    TString gtitle = "Ch "; gtitle += ipmt; gtitle += " ratio vs run;Run index;Mean LUT ratio";
+    gratio->SetName(gname);
+    gratio->SetTitle(gtitle);
+    gratio->SetMarkerStyle(20);
+    gratio->SetMarkerSize(0.7);
+    for (int ir = 0; ir < nruns; ir++)
+      gratio->SetPoint(ir, ir, ratio_by_ch[ipmt][ir]);
+
+    cpdf->cd(1);
+    gratio->Draw("AP");
+
+    // --- Right pad: corrected LUT overlay (val - <delta>) for each run + avg ---
+    // Build a multigraph so axes are set automatically
+    TMultiGraph* mg = new TMultiGraph();
+    TString mgtitle = "Ch "; mgtitle += ipmt;
+    mgtitle += " corrected LUT;TDC;Time - <#Delta> (ns)";
+    mg->SetTitle(mgtitle);
+
+    for (size_t irun = 0; irun < files.size(); irun++)
+    {
+      TGraph* glut = new TGraph();
+      for (int ilut = 0; ilut < ntdc; ilut++)
+      {
+        int itdc = ilut*step;
+        if ( itdc>14200. )
+        {
+          continue;
+        }
+        float val = calibs[irun]->get_tcorr(ifeech, itdc);
+        glut->AddPoint(itdc, val - mean_delta[ipmt]);
+      }
+      int col = cols[irun % NCOLS];
+      glut->SetLineColor(col);
+      glut->SetMarkerColor(col);
+      glut->SetMarkerStyle(1);
+      mg->Add(glut, "L");
+    }
+
+    // Average LUT overlay (bold black)
+    TGraph* gavg = new TGraph();
+    for (int ilut = 0; ilut < ntdc; ilut++)
+    {
+      int itdc = ilut*step;
+      if ( itdc>13450. ) continue;
+      gavg->AddPoint(itdc, avg_lut[ipmt][ilut]);
+    }
+    gavg->SetLineColor(kBlack);
+    gavg->SetLineWidth(2);
+    gavg->SetMarkerStyle(1);
+    mg->Add(gavg, "L");
+
+    cpdf->cd(2);
+    mg->Draw("A");
+
+    cpdf->Update();
+    cpdf->Print(pdfname);
+
+    delete gratio;
+    delete mg; // also deletes the owned TGraph children
+  }
+
+  cpdf->Print(pdfname + "]");
+  std::cout << "Created: " << pdfname << std::endl;
+  delete cpdf;
+}
+
+
+// Store the full LUT for every run, channel, and TDC entry in a flat TTree.
+void timecorr_all(const std::string& listfile = "tcorr.list")
+{
+  constexpr int NPMT = 128;
+
+  MbdGeom* mbdgeom = new MbdGeomV2();
+
+  // --- parse file list (same logic as average_timecorr) ---
+  std::vector<std::string> files;
+  std::vector<int>         runs;
+  {
+    std::ifstream lf(listfile);
+    if (!lf.is_open())
+    {
+      std::cerr << "Error: Could not open " << listfile << std::endl;
+      return;
+    }
+    auto parse_run = [](const std::string& path) -> int
+    {
+      size_t slash2 = path.rfind('/');
+      size_t slash1 = (slash2 == std::string::npos) ? std::string::npos : path.rfind('/', slash2 - 1);
+      size_t start  = (slash1 == std::string::npos) ? 0 : slash1 + 1;
+      std::string dir = path.substr(start, (slash2 == std::string::npos ? path.size() : slash2) - start);
+      size_t dash = dir.find('-');
+      if (dash == std::string::npos) return -1;
+      try { return std::stoi(dir.substr(0, dash)); }
+      catch (...) { return -1; }
+    };
+    std::string path;
+    while (lf >> path)
+    {
+      int runno = parse_run(path);
+      if (runno < 0)
+      {
+        std::cerr << "Warning: Could not parse run number from: " << path << std::endl;
+        continue;
+      }
+      files.push_back(path);
+      runs.push_back(runno);
+    }
+  }
+  if (files.empty())
+  {
+    std::cerr << "Error: no valid files in " << listfile << std::endl;
+    return;
+  }
+
+  // --- load calibrations ---
+  std::vector<MbdCalib*> calibs(files.size());
+  for (size_t i = 0; i < files.size(); i++)
+  {
+    std::cout << "Loading " << files[i] << std::endl;
+    calibs[i] = new MbdCalib();
+    calibs[i]->Download_TimeCorr(files[i]);
+  }
+
+  // --- LUT geometry from first file ---
+  int min_tdc, max_tdc, step;
+  calibs[0]->get_tcorr_range(0, min_tdc, max_tdc, step);
+  int ntdc = (max_tdc - min_tdc) / step + 1;
+  std::cout << "LUT: " << ntdc << " entries  tdc=[" << min_tdc << "," << max_tdc << "]  step=" << step << std::endl;
+
+  // --- TTree ---
+  TFile* fout = new TFile("timecorr.root", "RECREATE");
+  TTree* t    = new TTree("t", "Full timecorr LUT dump");
+
+  int      t_run;
+  Short_t  t_ch;
+  Short_t  t_index;
+  UShort_t t_tdc;
+  Float_t  t_time;
+
+  t->Branch("run",   &t_run,   "run/I");
+  t->Branch("ch",    &t_ch,    "ch/S");
+  t->Branch("index", &t_index, "index/S");
+  t->Branch("tdc",   &t_tdc,   "tdc/s");   // lowercase s = unsigned short
+  t->Branch("time",  &t_time,  "time/F");
+
+  for (size_t irun = 0; irun < files.size(); irun++)
+  {
+    t_run = runs[irun];
+    for (int ipmt = 0; ipmt < NPMT; ipmt++)
+    {
+      int ifeech = mbdgeom->get_feech(ipmt, 0);
+      t_ch = (Short_t)ipmt;
+      for (int ilut = 0; ilut < ntdc; ilut++)
+      {
+        int itdc   = min_tdc + ilut * step;
+        t_index    = (Short_t)ilut;
+        t_tdc      = (UShort_t)itdc;
+        t_time     = calibs[irun]->get_tcorr(ifeech, itdc);
+        t->Fill();
+      }
+    }
+  }
+
+  fout->cd();
+  t->Write();
+  std::cout << "Saved " << t->GetEntries() << " entries to timecorr.root" << std::endl;
+
+  for (auto* c : calibs) delete c;
+  delete fout;
+}
+
+
+void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib", const std::string &file2 = "00078986-0000/mbd_timecorr.calib")
+{
+  gStyle->SetOptStat(0);
+
+  constexpr int NPMT  = 128;   // MBD PMTs
+  constexpr int NTDC = 1000;   // 1000 values stored per channel
+  constexpr double BAD_THRESHOLD = 0.1;   // 100 ps
+
+  int verbose = 0;
+
+  // Get run numbers
+  int runno1 = Fun4AllUtils::GetRunSegment( std::filesystem::path( std::filesystem::path(file1).parent_path() ).filename().append(".root") ).first;
+  int runno2 = Fun4AllUtils::GetRunSegment( std::filesystem::path( std::filesystem::path(file2).parent_path() ).filename().append(".root") ).first;
+  std::cout << "Processing " << runno1 << "\t" << runno2 << std::endl;
+
+  MbdGeom *mbdgeom = new MbdGeomV2();
+  // ------------------------------------------------------------
+  // Load calibrations
+  // ------------------------------------------------------------
+  MbdCalib *calib1 = new MbdCalib();
+  MbdCalib *calib2 = new MbdCalib();
+
+  std::cout << "Downloading time corrections from:\n" << "  " << file1 << "\n" << "  " << file2 << std::endl;
+
+  calib1->Download_TimeCorr(file1);
+  calib2->Download_TimeCorr(file2);
+
+  int step1, min1, max1;
+  int step2, min2, max2;
+  calib1->get_tcorr_range(0,min1,max1,step1);
+  calib2->get_tcorr_range(0,min2,max2,step2);
+  if ( (step1 != step2) || (min1!=min2) || (max1!=max2) )
+  {
+    std::cerr << "timecorr shape differs" << std::endl;
+    std::cerr << "min: " << min1 << "\t" << min2 << std::endl;
+    std::cerr << "max: " << max1 << "\t" << max2 << std::endl;
+    std::cerr << "steps: " << step1 << "\t" << step2 << std::endl;
+    return;
+  }
+
+  // ------------------------------------------------------------
+  // Histograms
+  // ------------------------------------------------------------
+  TH1 *h_tdiff[NPMT];
+  TH1 *h_tdifftot;
+  TString name;
+  TString title;
+
+  int nbins = static_cast<int>( ((max1-min1)/step1) + 1 );
+  std::cout << nbins << std::endl;
+  for (int ipmt = 0; ipmt < NPMT; ++ipmt)
+  {
+    name = "h_tdiff"; name += ipmt;
+    title = name; title += ", runs "; title += runno1; title += "-"; title += runno2;
+    h_tdiff[ipmt] = new TH1F( name, title, nbins, min1-0.5, max1+0.5);
+    h_tdiff[ipmt]->SetXTitle("TDC");
+    h_tdiff[ipmt]->SetYTitle("tdiff [ns]");
+  }
+  title = "time diffs, all channels and TDCs, runs "; title += runno1; title += "-"; title += runno2;
+  h_tdifftot = new TH1F( "h_tdifftot", title, 1000, -0.2, 0.2);
+  h_tdifftot->SetXTitle("tdiff [ns]");
+
+  // ------------------------------------------------------------
+  // Comparison
+  // ------------------------------------------------------------
+  if ( verbose )
+  {
+    std::cout << std::fixed << std::setprecision(4);
+    std::cout << "Ch  TDC  TimeCorr1  TimeCorr2  Diff" << std::endl;
+    std::cout << "----------------------------------------" << std::endl;
+  }
+  ofstream outfile("bad_comp_timecorr.txt");
+  outfile << std::fixed << std::setprecision(4);
+  outfile << "Ch  TDC  TimeCorr1  TimeCorr2  Diff" << std::endl;
+  outfile << "----------------------------------------" << std::endl;
+  
+  for (int ipmt = 0; ipmt < NPMT; ++ipmt)
+  {
+    int ifeech = mbdgeom->get_feech(ipmt,0);
+
+    for (int itdc = 0; itdc < NTDC; ++itdc)
+    {
+      float t1 = calib1->get_tcorr(ifeech, itdc);
+      float t2 = calib2->get_tcorr(ifeech, itdc);
+      float diff = t2 - t1;
+
+      h_tdiff[ipmt]->SetBinContent(itdc+1,diff);
+      h_tdifftot->Fill(diff);
+
+      if (std::abs(diff) > BAD_THRESHOLD)
+      {
+        if ( verbose )
+        {
+          std::cout << std::setw(3) << ipmt << "  "
+            << std::setw(3) << itdc << "  "
+            << std::setw(10) << t1 << "  "
+            << std::setw(10) << t2 << "  "
+            << std::setw(8)  << diff
+            << std::endl;
+        }
+        outfile << std::setw(3) << ipmt << "  "
+          << std::setw(3) << itdc << "  "
+          << std::setw(10) << t1 << "  "
+          << std::setw(10) << t2 << "  "
+          << std::setw(8)  << diff
+          << std::endl;
+      }
+    }
+  }
+
+  // ------------------------------------------------------------
+  // Plot
+  // ------------------------------------------------------------
+  TCanvas *ac[100];
+  int icv = 0;
+  
+  ac[icv] = new TCanvas("ac0", "MBD TimeCorr by PMT", 1200, 600);
+  TString pdfname = "comp_timecorr_"; pdfname += runno1; pdfname += "_"; pdfname += runno2; pdfname += ".pdf";
+  ac[icv]->Print(pdfname + "[");
+
+  for (int ipmt = 0; ipmt < NPMT; ++ipmt)
+  {
+    h_tdiff[ipmt]->Draw("hist");
+
+    gPad->Modified();
+    gPad->Update();
+    ac[icv]->Print(pdfname);
+  }
+
+  h_tdifftot->Draw();
+  ac[icv]->Print(pdfname);
+  ac[icv]->Print(pdfname + "]");
+
+  icv++;
+
+  outfile.close();
+}

--- a/calibrations/mbd/TIMING/comp_timecorr.C
+++ b/calibrations/mbd/TIMING/comp_timecorr.C
@@ -6,6 +6,8 @@
 #include <TStyle.h>
 #include <TFile.h>
 #include <TTree.h>
+#include <TGraph.h>
+#include <TMultiGraph.h>
 
 #include <iostream>
 #include <fstream>

--- a/calibrations/mbd/TIMING/comp_timecorr.C
+++ b/calibrations/mbd/TIMING/comp_timecorr.C
@@ -1,5 +1,3 @@
-#include <mbd/MbdCalib.h>
-
 #include <TH1D.h>
 #include <TCanvas.h>
 #include <TLine.h>
@@ -14,6 +12,7 @@
 #include <iomanip>
 #include <string>
 #include <cmath>
+#include <filesystem>
 
 #include <fun4all/Fun4AllUtils.h>
 
@@ -455,7 +454,7 @@ void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib"
     std::cout << "Ch  TDC  TimeCorr1  TimeCorr2  Diff" << std::endl;
     std::cout << "----------------------------------------" << std::endl;
   }
-  ofstream outfile("bad_comp_timecorr.txt");
+  std::ofstream outfile("bad_comp_timecorr.txt");
   outfile << std::fixed << std::setprecision(4);
   outfile << "Ch  TDC  TimeCorr1  TimeCorr2  Diff" << std::endl;
   outfile << "----------------------------------------" << std::endl;

--- a/calibrations/mbd/TIMING/comp_timecorr.C
+++ b/calibrations/mbd/TIMING/comp_timecorr.C
@@ -15,8 +15,8 @@
 
 #include <fun4all/Fun4AllUtils.h>
 
-#include <mbd/MbdGeomV2.h>
 #include <mbd/MbdCalib.h>
+#include <mbd/MbdGeomV2.h>
 #include "get_runstr.h"
 
 R__LOAD_LIBRARY(libmbd.so)
@@ -87,7 +87,7 @@ void average_timecorr(const std::string& listfile = "tcorr.list")
   }
 
   // Determine LUT size from first file
-  int min_tdc, max_tdc, step;
+  int min_tdc, max_tdc, step; // NOLINT(readability-isolate-declaration)
   calibs[0]->get_tcorr_range(0, min_tdc, max_tdc, step);
   int ntdc = (max_tdc - min_tdc) / step + 1;
   std::cout << "LUT size: " << ntdc << " bins  [" << min_tdc << ", " << max_tdc << "]  step=" << step << std::endl;
@@ -334,7 +334,7 @@ void timecorr_all(const std::string& listfile = "tcorr.list")
   }
 
   // --- LUT geometry from first file ---
-  int min_tdc, max_tdc, step;
+  int min_tdc, max_tdc, step; // NOLINT(readability-isolate-declaration)
   calibs[0]->get_tcorr_range(0, min_tdc, max_tdc, step);
   int ntdc = (max_tdc - min_tdc) / step + 1;
   std::cout << "LUT: " << ntdc << " entries  tdc=[" << min_tdc << "," << max_tdc << "]  step=" << step << std::endl;
@@ -409,8 +409,8 @@ void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib"
   calib1->Download_TimeCorr(file1);
   calib2->Download_TimeCorr(file2);
 
-  int step1, min1, max1;
-  int step2, min2, max2;
+  int step1, min1, max1;  // NOLINT(readability-isolate-declaration)
+  int step2, min2, max2;  // NOLINT(readability-isolate-declaration)
   calib1->get_tcorr_range(0,min1,max1,step1);
   calib2->get_tcorr_range(0,min2,max2,step2);
   if ( (step1 != step2) || (min1!=min2) || (max1!=max2) )
@@ -430,7 +430,7 @@ void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib"
   TString name;
   TString title;
 
-  int nbins = static_cast<int>( ((max1-min1)/step1) + 1 );
+  int nbins = ((max1-min1)/step1) + 1;
   std::cout << nbins << std::endl;
   for (int ipmt = 0; ipmt < NPMT; ++ipmt)
   {
@@ -502,6 +502,7 @@ void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib"
   TString pdfname = "comp_timecorr_"; pdfname += runno1; pdfname += "_"; pdfname += runno2; pdfname += ".pdf";
   ac[icv]->Print(pdfname + "[");
 
+  // NOLINTBEGIN(modernize-loop-convert)
   for (int ipmt = 0; ipmt < NPMT; ++ipmt)
   {
     h_tdiff[ipmt]->Draw("hist");
@@ -510,6 +511,7 @@ void comp_timecorr(const std::string &file1 = "00065735-0000/mbd_timecorr.calib"
     gPad->Update();
     ac[icv]->Print(pdfname);
   }
+  // NOLINTEND(modernize-loop-convert)
 
   h_tdifftot->Draw();
   ac[icv]->Print(pdfname);

--- a/calibrations/mbd/TIMING/make_timecorr.C
+++ b/calibrations/mbd/TIMING/make_timecorr.C
@@ -29,6 +29,7 @@ Double_t maxtdc[MbdDefs::MBD_N_FEECH];
 Double_t mintime[MbdDefs::MBD_N_FEECH];  // min time in range
 Double_t maxtime[MbdDefs::MBD_N_FEECH];  // max time in range
 Double_t timecorr[MbdDefs::MBD_N_FEECH][NPOINTS];
+TGraph *g_interp[MbdDefs::MBD_N_FEECH];
 
 /*
 void gpr_interpolate_timecorr( const int ifeech, TGraphErrors *g )
@@ -129,8 +130,6 @@ void interpolate_timecorr(const int ifeech, TGraphErrors *g, TF1 *f)
   g->Fit(f, "R");
 
   g->Draw("ap");
-  gPad->Modified();
-  gPad->Update();
 
   float mintimelocal = TMath::MinElement(n, y);
   float maxtimelocal = TMath::MaxElement(n, y);
@@ -155,8 +154,16 @@ void interpolate_timecorr(const int ifeech, TGraphErrors *g, TF1 *f)
   double tdc = 0;
   for (int istep = 0; istep < NPOINTS; istep++)
   {
-    // timecorr[ifeech][istep] = f->Eval(tdc) - mintimelocal;
-    timecorr[ifeech][istep] = g->Eval(tdc) - mintimelocal;
+    if ( tdc<maxtdclocal )
+    {
+      timecorr[ifeech][istep] = g->Eval(tdc) - mintimelocal;  // use root's spline fit
+    }
+    else
+    {
+      timecorr[ifeech][istep] = f->Eval(tdc) - mintimelocal;
+    }
+
+    g_interp[ifeech]->AddPoint( tdc, timecorr[ifeech][istep]+mintimelocal );
 
     if (istep == 0 || istep == NPOINTS - 1)
     {
@@ -165,6 +172,10 @@ void interpolate_timecorr(const int ifeech, TGraphErrors *g, TF1 *f)
 
     tdc += dstep;
   }
+
+  g_interp[ifeech]->Draw("lp");
+  gPad->Modified();
+  gPad->Update();
 }
 
 void make_timecorr(const char *rootfname = "calib_seb18-00029705-0000_mbdtimecalib.root")
@@ -208,10 +219,13 @@ void make_timecorr(const char *rootfname = "calib_seb18-00029705-0000_mbdtimecal
       g_delaytime[ifeech]->Fit(fpoly, "R");
     }
 
-    // if ( ifeech!=118)
-    //{
+    // create interpolation graph
+    g_interp[ifeech] = new TGraph();
+    name = "interp_"; name += g_delaytime[ifeech]->GetName();
+    g_interp[ifeech]->SetName( name );
+    g_interp[ifeech]->SetMarkerColor( 2 );
+    g_interp[ifeech]->SetMarkerSize( 0.2 );
     interpolate_timecorr(ifeech, g_delaytime[ifeech], fpoly);
-    //}
 
     // if ( ifeech>4 ) break;
   }

--- a/calibrations/mbd/TIMING/make_timecorr.C
+++ b/calibrations/mbd/TIMING/make_timecorr.C
@@ -10,6 +10,7 @@
 
 #include <TF1.h>
 #include <TFile.h>
+#include <TGraph.h>
 #include <TGraphErrors.h>
 #include <TPad.h>
 #include <TSystem.h>

--- a/calibrations/mbd/prorun.sh
+++ b/calibrations/mbd/prorun.sh
@@ -23,6 +23,7 @@ runno=${inputs##*/}
 runno=${runno#*-}
 runno=${runno%-*}
 runno=${runno%.list}
+runno=${runno%_trim}
 runno=${runno%.root}
 runno=${runno%.prdf}
 runno=$((10#${runno}))  # convert to decimal number
@@ -35,9 +36,6 @@ then
 fi
 echo Processing $nevents events
 
-build=none          # use current environment
-dbtag=newcdbtag
-#dbtag=""
 
 if [[ $USER == "sphnxpro" ]]
 then
@@ -53,57 +51,57 @@ then
   then
     # 2024 Run2pp
     echo "This is run2pp"
-    build=ana.554
+    build=ana.558
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run2pp
     outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/Run2pp/${build}/$(get_rundirname ${runno})/
     logbase=DST_MBD_CALIBRATION_run2pp
-    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/${build}/$(get_rundirname ${runno})/
+    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/Run2pp/${build}/$(get_rundirname ${runno})/
   elif [[ $runno -le 54962 ]]
   then
     # 2024 Run2auau
     echo "This is run2auau"
-    build=ana.554
+    build=ana.558
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run2auau
     outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/Run2AuAu/${build}/$(get_rundirname ${runno})/
     logbase=DST_MBD_CALIBRATION_run2auau
-    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/${build}/$(get_rundirname ${runno})/
+    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/Run2AuAu/${build}/$(get_rundirname ${runno})/
   elif [[ $runno -le 78954 ]]
   then
     # 2025 Run3auau
     echo "This is run3auau"
-    build=pro.001
+    build=ana.558
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run3auau
-    outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/${build}/$(get_rundirname ${runno})/
+    outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/Run3AuAu/${build}/$(get_rundirname ${runno})/
     logbase=DST_MBD_CALIBRATION_run3auau
-    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/${build}/$(get_rundirname ${runno})/
+    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/Run3AuAu/${build}/$(get_rundirname ${runno})/
   elif [[ $runno -le 81667 ]]
   then
     # 2025 Run3pp
     echo "This is run3pp"
-    build=ana.554
+    build=ana.558
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run3pp
     outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/Run3pp/${build}/$(get_rundirname ${runno})/
     logbase=DST_MBD_CALIBRATION_run3pp
-    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/${build}/$(get_rundirname ${runno})/
+    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/Run3pp/${build}/$(get_rundirname ${runno})/
   elif [[ $runno -le 82703 ]]
   then
     # 2025 Run3oo
     echo "This is run3oo"
-    build=pro.001
+    build=ana.558
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run3oo
-    outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/pro.001/$(get_rundirname ${runno})/
+    outdir=/sphenix/lustre01/sphnxpro/physics/mbdcalib/Run3OO/${build}/$(get_rundirname ${runno})/
     logbase=DST_MBD_CALIBRATION_run3oo
-    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/pro.001/$(get_rundirname ${runno})/
+    logdir=/sphenix/data/data02/sphnxpro/mbdcalib/Run3OO/${build}/$(get_rundirname ${runno})/
   else
     echo "ERROR, run $runno invalid, aborting"
     exit 1
@@ -157,6 +155,16 @@ else  # setup for local tests
   fi
 fi
 
+#build="none"                 # use current environment
+#dbtag=""                     # uncomment dbtag and pass0dir to use local text files
+#pass0dir=results/${runno}    # if pass0dir is an absolute path, copy files, otherwise
+                              # download from cdb and modify as needed.
+if [[ "$build" != "none" ]]
+then
+  echo source /opt/sphenix/core/bin/sphenix_setup.sh -n $build
+  source /opt/sphenix/core/bin/sphenix_setup.sh -n $build
+fi
+
 ORIG_DIR=${PWD}
 
 if [[ ! -z "${_CONDOR_SCRATCH_DIR}" ]]
@@ -186,18 +194,15 @@ then
   #done
 fi
 
-#build="none"
-echo source /opt/sphenix/core/bin/sphenix_setup.sh -n $build
-source /opt/sphenix/core/bin/sphenix_setup.sh -n $build
-
 ./prorun_mbdcal.sh --outbase "$outbase" \
-  --outdir  "$outdir" \
-  --logbase "$logbase" \
-  --logdir  "$logdir" \
-  --build    $build \
-  --run      $runno \
+  --outdir   "$outdir" \
+  --logbase  "$logbase" \
+  --logdir   "$logdir" \
+  --build    "$build" \
+  --pass0dir "$pass0dir" \
+  --run      "$runno" \
   --dbtag    "$dbtag" \
-  --nevents  $nevents \
+  --nevents  "$nevents" \
   $inputs
 
 

--- a/calibrations/mbd/prorun_mbdcal.sh
+++ b/calibrations/mbd/prorun_mbdcal.sh
@@ -14,7 +14,6 @@ build="new"
 #dbtag="newcdbtag"
 #pass0dir=""      # only set if using local private pass0 calibs, otherwise use CDB
 dbtag=""
-#pass0dir="/sphenix/user/chiu/sphenix_bbc/CDB/PASS0"      # only set if using local private pass0 calibs, otherwise use CDB
 nevents=0        # by default process all events
 
 #echo $@ 
@@ -162,15 +161,14 @@ mkdir -p ${caldir}
 
 ################################################
 # If using local files, stage PASS0 calibrations
-#if [[ ! -z ${pass0dir} ]]
-#then
-#  ./cups.py -r ${runno} -s ${segment} -d ${outbase} message "Stage in pass0 from ${pass0dir}"
-#  for calib in mbd_shape.calib mbd_sherr.calib mbd_timecorr.calib mbd_slewcorr.calib mbd_tt_t0.calib mbd_tq_t0.calib mbd_pileup.calib
-#  do
-#    echo Stagein ${pass0dir}/${calib} to ${caldir}
-#    cp -p ${pass0dir}/${calib} ${caldir}/
-#  done
-#fi
+if [[ ! -z ${pass0dir} ]]
+then
+  #./cups.py -r ${runno} -s ${segment} -d ${outbase} message "Stage in pass0 from ${pass0dir}"
+  root.exe -b -q DumpMbdCalibs.C\(${runno}\)
+  mkdir -p results/${runno}
+  mv *.calib results/${runno}/
+  cp -p /sphenix/user/chiu/sphenix_bbc/CDB/latest_proRun3OO/results/default/mbd_timecorr.calib results/${runno}/
+fi
 
 # Flag as started
 #./cups.py -r ${runno} -s ${segment} -d ${outbase} running

--- a/calibrations/mbd/submit.sh
+++ b/calibrations/mbd/submit.sh
@@ -2,16 +2,80 @@
 #
 # submit jobs to condor
 # 
-# $executable the program to execute (usually a shell script)
+# $executable the program to execute
 # $arg is what is passed to the run.cmd script
-# $log is what the log file names are
-# $user is the email to send to
 #
 
+# get_ndst_needed <arg>
+#   arg: path of the form dir/<run>.list  (<run> is a zero-padded run number)
+#   reads runs_mbd.txt (columns: runnumber  mbd_nscaled  eventsinrun)
+#   returns the number of DST files needed to accumulate ~3M MBD triggers
+get_ndst_needed() {
+  local arg=$1
+
+  # Extract run number (strip directory and .list; 10# forces base-10)
+  local runfile=${arg##*/}
+  local runno=$((10#${runfile%.list}))
+
+  # Find run in runs_mbd.list and extract mbd_nscaled and eventsinrun
+  local mbdlist=runlists/runs_mbd.txt
+  local fields
+  fields=$(awk -v run="$runno" 'int($1)==run {print $2, $3; exit}' "$mbdlist")
+  if [[ -z "$fields" ]]; then
+    echo "WARNING: run $runno not found in $mbdlist" >&2
+    wc -l < "$arg"
+    return 1
+  fi
+  local mbd_nscaled eventsinrun
+  read mbd_nscaled eventsinrun <<< "$fields"
+
+  # Count DST files listed in arg
+  local num_dst_files
+  num_dst_files=$(wc -l < "$arg")
+
+  local min_mbd=3000000
+
+  # Floating-point arithmetic in awk:
+  #   frac_made    = 100000 * num_dst_files / eventsinrun
+  #   mbd_expected = mbd_nscaled * frac_made
+  #   if mbd_expected > min_mbd: ndst_needed = int((min_mbd / mbd_expected) * num_dst_files)
+  #   else:                       ndst_needed = num_dst_files
+  #   if ndst < 30 and num_dst_files >= 30: ndst = 30
+  awk -v nf="$num_dst_files" -v evts="$eventsinrun" -v mbd="$mbd_nscaled" \
+      -v min_mbd="$min_mbd" 'BEGIN {
+    frac_made    = 100000.0 * nf / evts
+    mbd_expected = mbd * frac_made
+    if (mbd_expected > min_mbd) {
+      ndst = int((min_mbd / mbd_expected) * nf)
+      if (ndst < 1) ndst = 1
+    } else {
+      ndst = nf
+    }
+    if (ndst < 30 && nf >= 30) ndst = 30
+    print ndst
+  }'
+}
+
 executable=$1
-arg=$2
-arg="${@:2}"
+listfile=$2
+arg="${@:2}"  # everything starting from 2nd arg
 logfname=${executable}
+
+# Trim the input list to only the files needed for ~3M MBD triggers
+num_dst_files=$(wc -l < "$listfile")
+final_ndst=$num_dst_files
+ndst_needed=$(get_ndst_needed "$listfile")
+if [[ $? -eq 0 && -n "$ndst_needed" && $ndst_needed -lt $num_dst_files ]]; then
+  trimfile="${listfile%.list}_trim.list"
+  trimfile=${trimfile##*/}
+  shuf -n "$ndst_needed" "$listfile" | sort > "$trimfile"
+  arg="$trimfile ${@:3}"
+  arg=${arg% }
+  final_ndst=$ndst_needed
+  echo "Trimmed $listfile to $ndst_needed/$num_dst_files files -> $trimfile"
+fi
+
+request_disk=$(( final_ndst * 4 ))GB
 
 echo $executable $arg
 
@@ -25,6 +89,7 @@ mkdir -p $logdir
 echo "Submitting Run ${ijob}"
 
 log=${arg##*/}           # log file names
+log=${log%% *}           # log file names
 
 #prepend pwd to executable if needed
 if [[ ! $executable =~ ^/ ]]
@@ -39,9 +104,11 @@ echo "Queue" | condor_submit \
     -a "Output=$PWD/${logdir}/${log}.out" \
     -a "Error=$PWD/${logdir}/${log}.err" \
     -a "Initialdir=$PWD" \
+    -a "PeriodicHold=(NumJobStarts>=1 && JobStatus == 1 && !(ON_EVICT_CHECK_RequestMemory_REQUIREMENTS))" \
     -a "request_memory=4096MB" \
-    -a "request_disk=120GB" \
-    -a "PeriodicHold=(NumJobStarts>=1 && JobStatus == 1)" \
+    -a "retry_request_memory_increase=2048MB" \
+    -a "retry_request_memory_max=16192MB" \
+    -a "request_disk=${request_disk}" \
     -a "GetEnv=True"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation / context
This PR strengthens the workflow for **cross-checking MBD-based Z-vertex** results against **tracker-based** measurements, and improves the surrounding calibration extraction and batch/Condor tooling needed to generate comparable track-vertex outputs and produce summary plots.

## Key changes
- **MBD calibration extraction**
  - Added `calibrations/mbd/DumpMbdCalibs.C` to set CDB runtime parameters (`CDB_GLOBALTAG`, `TIMESTAMP`, `RUNNUMBER`), load required libraries, then download/write all MBD calibration payloads via `MbdCalib` (`Download_All()` / `Write_All()`).
- **MBD vs tracker Z-vertex production (MBDTRKZ)**
  - Updated `calibrations/mbd/MBDTRKZ/Fun4All_MBD_TrackVertex.C` to keep behavior the same while improving argument/file handling (notably `inputTrackFile` / `inputCaloFile` are now `const std::string&` bound to the macro inputs), and still terminates the macro via `gSystem->Exit(0)`.
  - Added `calibrations/mbd/MBDTRKZ/make_mbdtrkz_lists.py` to generate consistent segmented subsets (`clus.list`/`tracks.list` plus `fit.list`) with explicit count/range validation.
  - Added orchestration scripts:
    - `calibrations/mbd/MBDTRKZ/prorun_mbdtrkz.sh`: runs the track-fitting + MBD track-vertex steps, tightens empty-list checks, validates `root.exe` success, and handles Condor staging/copyback.
    - `calibrations/mbd/MBDTRKZ/submit_mbdtrkz.sh`: submits per-run/per-destination jobs, samples destination DSTs (via `shuf`), derives run/segment tokens from filenames, and passes consistent arguments downstream.
  - Added `calibrations/mbd/MBDTRKZ/plot_mbdtrkzdiff.C` to read produced ROOT files, fit the highest peak of `h_mbdtrkz` with a Gaussian, derive a peak-mean vs run trend (constant/`pol0` fit), and save `mbdtrkzdiff.pdf`. Run number parsing is based on directory naming (expects a run prefix before an underscore).
- **Timing/LUT comparison + averaging support**
  - Added `calibrations/mbd/TIMING/comp_timecorr.C` to compare two `mbd_timecorr` calibrations and produce diffs + a PDF summary.
  - Updated `calibrations/mbd/TIMING/make_timecorr.C` to accumulate interpolation points per channel and adjust evaluation logic around a local `maxtdclocal` threshold.
- **Calibration gain plotting robustness**
  - Updated `calibrations/mbd/PLOTS/plot_calibgains.C` so failed quality/deviation checks now **log** instead of forcing `bqmean`/`bqmeanerr` to `NAN`.
- **Operational/batch workflow improvements**
  - Updated `calibrations/mbd/prorun.sh`, `calibrations/mbd/prorun_mbdcal.sh`, and `calibrations/mbd/submit.sh` for run-number normalization/mapping, improved PASS0-style staging in `prorun_mbdcal.sh`, and improved Condor efficiency (DST list trimming, dynamic `request_disk`, and more robust log naming).

## Potential risk areas
- **Macro process control:** `DumpMbdCalibs.C` and `Fun4All_MBD_TrackVertex.C` use `gSystem->Exit(0)`, which can reduce composability in interactive/multi-macro contexts.
- **CDB/I/O correctness:** `DumpMbdCalibs.C` relies on the provided `RUNNUMBER`/`TIMESTAMP` wiring and the expected set of MBD payloads retrieved by `MbdCalib`; tag/time mismatches could yield different calibration artifacts.
- **Reconstruction/list selection behavior:** MBDTRKZ job inputs depend on Python-generated segmented list filtering and filename parsing (including run extraction in `plot_mbdtrkzdiff.C`); unexpected naming/list formats could skip runs or select unintended subsets.
- **Fit/plot assumptions:** `plot_mbdtrkzdiff.C` assumes `h_mbdtrkz` exists and that the highest peak can be fit reliably; failures are skipped, which can bias coverage if many runs fail.
- **Downstream semantics change:** `plot_calibgains.C` no longer forces `NAN` for certain failures, which can change how downstream statistics/QA interpret “bad” entries.
- **Batch/IO behavior & performance:** Condor sampling/trimming (`shuf`/list slicing) and stricter empty-list/root failure handling can affect job success rates and produced outputs.

## Possible future improvements
- Add explicit **preflight validation** for list files, segment boundaries, and expected ROOT artifacts/histograms before launching large Condor campaigns.
- Add stronger **schema/format checks** for list entries and directory/file naming conventions used by the segment and run-number parsers.
- Consider replacing unconditional `gSystem->Exit(0)` with return-based control where feasible to improve macro reusability.

> AI can make mistakes—please verify the exact IO formats, CDB/tag assumptions, list/filename parsing conventions, and produced artifacts along the modified code paths before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->