### PR TITLE
Variable electric field

### DIFF
--- a/TpcProduction/GarfieldProduction/GasModel_condor3D.job
+++ b/TpcProduction/GarfieldProduction/GasModel_condor3D.job
@@ -12,4 +12,4 @@ request_memory     = 8GB
 Priority           = 20
 job_lease_duration = 3600
 Arguments          = $(process)
-Queue 336
+Queue 697

--- a/TpcProduction/GarfieldProduction/StartScript3D.sh
+++ b/TpcProduction/GarfieldProduction/StartScript3D.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Electric field grid
-emin=360
-emax=440
-ne=21
+emin=320
+emax=480
+ne=41
 
 # Magnetic field grid
 bmin=1.15
@@ -17,50 +17,57 @@ amin=0.0
 amax=0.2
 na=20
 
-jobid=$1
+jobid="${1:?Usage: $0 jobid}"
+normal_jobs=$(( ne * nb ))
+total_jobs=$(( normal_jobs + ne ))
 
-ie=$(( jobid / nb ))
-ib=$(( jobid % nb ))
-
-if (( jobid < 0 || jobid >= ne * nb )); then
-  echo "ERROR: jobid=$jobid outside allowed range 0 to $((ne * nb - 1))"
-  exit 1
+if (( jobid < 0 || jobid >= total_jobs )); then
+    echo "ERROR: jobid=$jobid outside allowed range 0 to $((total_jobs - 1))"
+    exit 1
 fi
 
-enow=$(( emin + 4 * ie ))
-#enow=$(awk -v emin="$emin" \
-#             -v emax="$emax" \
-#             -v ne="$ne" \
-#             -v i="$ie" \
-#'BEGIN {
-#   if (ne == 1) print emin;
-#   else print emin + (emax - emin) * i / (ne - 1);
-#}')
+# Interpret the process ID to define the GasModel arguments.
+if (( jobid < normal_jobs )); then
+    ie=$(( jobid / nb ))
+    ib=$(( jobid % nb ))
 
-bnow=$(awk -v ib="$ib" 'BEGIN { printf "%.2f", 1.15 + 0.02 * ib }')
-#bnow=$(awk -v bmin="$bmin" \
-#             -v bmax="$bmax" \
-#             -v nb="$nb" \
-#             -v i="$ib" \
-#'BEGIN {
-#   if (nb == 1) print bmin;
-#   else print bmin + (bmax - bmin) * i / (nb - 1);
-#}')
+    enow=$(( emin + 4 * ie ))
+    bnow=$(awk -v ib="$ib" \
+        'BEGIN { printf "%.2f", 1.15 + 0.02 * ib }')
 
-echo "jobid=$jobid ie=$ie ib=$ib enow=$enow bnow=$bnow"
+    efile=$(printf "E%03d_B%03d.gas" "$ie" "$ib")
 
+    echo "jobid=$jobid ie=$ie ib=$ib enow=$enow bnow=$bnow"
+else
+    ie=$(( jobid - normal_jobs ))
+
+    enow=$(( emin + 4 * ie ))
+    bnow="0.00"
+
+    efile=$(printf "ZERO_E%03d.gas" "$ie")
+
+    echo "jobid=$jobid ie=$ie ZERO_B enow=$enow bnow=$bnow"
+fi
+
+# Determine the output location and launch GasModel.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ ! -d "${script_dir}/gasfiles" ]]; then
-  echo "ERROR: ${script_dir}/gasfiles does not exist."
-  echo "Create it or make it a symbolic link before launching jobs."
-  exit 1
+    echo "ERROR: ${script_dir}/gasfiles does not exist."
+    echo "Create it or make it a symbolic link before launching jobs."
+    exit 1
 fi
 
-efile=$(printf "E%03d_B%03d.gas" "$ie" "$ib")
 output="${script_dir}/gasfiles/${efile}"
 
-echo GasModel "$enow" "$enow" 1 "$bnow" "$bnow" 1 "$amin" "$amax" "$na" "$output"
-GasModel "$enow" "$enow" 1 "$bnow" "$bnow" 1 "$amin" "$amax" "$na" "$output"
+echo GasModel \
+    "$enow" "$enow" 1 \
+    "$bnow" "$bnow" 1 \
+    "$amin" "$amax" "$na" \
+    "$output"
 
-echo "all done"
+GasModel \
+    "$enow" "$enow" 1 \
+    "$bnow" "$bnow" 1 \
+    "$amin" "$amax" "$na" \
+    "$output"

--- a/TpcProduction/GarfieldProduction/TestFieldMap.C
+++ b/TpcProduction/GarfieldProduction/TestFieldMap.C
@@ -69,14 +69,14 @@ void TestFieldMap()
 {
   recoConsts* rc = recoConsts::instance();
 
-  rc->set_StringFlag("CDB_GLOBALTAG","FieldMapTest");   // Weird offset field map
-  //rc->set_StringFlag("CDB_GLOBALTAG","newcdbtag");      //sPHENIX default
-  rc->set_uint64Flag("TIMESTAMP",1);
+  //rc->set_StringFlag("CDB_GLOBALTAG","FieldMapTest");   // Weird offset field map
+  rc->set_StringFlag("CDB_GLOBALTAG","newcdbtag");      //sPHENIX default
+  rc->set_uint64Flag("TIMESTAMP",6);
 
   auto *cdb = CDBInterface::instance();
+  std::cout << cdb->getUrl("PHGARFIELD_GAS") << std::endl;
   std::string url = cdb->getUrl("FIELDMAP_TRACKING");
   std::cout << "Field map URL:\n" << url << std::endl;
-
   Fun4AllServer *se = Fun4AllServer::instance();
 
   Enable::QA  = false;

--- a/TpcProduction/GarfieldProduction/TestGarfield.C
+++ b/TpcProduction/GarfieldProduction/TestGarfield.C
@@ -1,0 +1,20 @@
+#include <phool/recoConsts.h>
+#include <ffamodules/CDBInterface.h>
+
+#include <TSystem.h>
+
+#include <iostream>
+
+R__LOAD_LIBRARY(libffamodules.so)
+R__LOAD_LIBRARY(libphool.so)
+
+void TestGarfield()
+{
+  recoConsts *rc = recoConsts::instance();
+  rc->set_StringFlag("CDB_GLOBALTAG","newcdbtag"); 
+  rc->set_uint64Flag("TIMESTAMP",6);
+  CDBInterface *cdb = CDBInterface::instance();
+  std::cout << cdb->getUrl("PHGARFIELD_GAS") << std::endl;
+  gSystem->Exit(0);
+  return;
+}


### PR DESCRIPTION
These allow the condor queue to be configured for B=0 added to the gas file creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

This PR supports a variable electric-field scan and creates gas files for both normal magnetic fields and `B=0`.

## Key changes

- Expand the electric-field scan from 360–440 to 320–480 in 41 steps.
- Submit 656 normal jobs and 41 `B=0` jobs, for 697 total jobs.
- Generate separate `ZERO_E###.gas` files for the `B=0` cases.
- Validate job IDs and require the gasfiles output directory.
- Update CDB tag and timestamp handling in `TestFieldMap()`.
- Add `TestGarfield.C` to print the `PHGARFIELD_GAS` CDB URL.

## Potential risk areas

- Incorrect job-ID mapping could associate a job with the wrong gas file.
- The expanded job set increases production time, storage use, and HTCondor load.
- CDB tag and timestamp changes can select different calibration data.
- Downstream reconstruction may need validation for `B=0` gas files.

## Possible future improvements

- Add automated tests for job mapping and gas-file names.
- Validate generated gas files before submission.
- Document the electric-field and magnetic-field job layout.

AI-generated summaries can contain errors. Review the implementation and generated gas files before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->