### PR TITLE
update waveform scaling api in common macros

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -358,6 +358,15 @@ void CEMC_Towers()
     {
       caloWaveformSim->set_pedestal_scale(0.77);
     }
+    // flat, collision-system dependent CEMC energy scale-up (placeholder, tune later)
+    if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: O+O HIJING CEMC scale factor
+    }
+    else if (Input::BEAM_CONFIGURATION == Input::AA_COLLISION)  // AuAu_COLLISION
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: Au+Au HIJING CEMC scale factor
+    }
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -350,6 +350,15 @@ void HCALInner_Towers()
     //  caloWaveformSim->set_nsamples(12); // default is 12 like in real data - if we ever want a different number of samples
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
+    // flat, collision-system dependent IHCal energy scale-up (placeholder, tune later)
+    if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: O+O HIJING IHCal scale factor
+    }
+    else if (Input::BEAM_CONFIGURATION == Input::AA_COLLISION)  // AuAu_COLLISION
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: Au+Au HIJING IHCal scale factor
+    }
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
     //caloWaveformSim->set_calibName("HCALIN_calib_ADC_to_ETower");

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -386,6 +386,15 @@ void HCALOuter_Towers()
     // caloWaveformSim->set_nsamples(12);// default is 12 like in real data - if we ever want a different number of samples
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
+    // flat, collision-system dependent OHCal energy scale-up (placeholder, tune later)
+    if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: O+O HIJING OHCal scale factor
+    }
+    else if (Input::BEAM_CONFIGURATION == Input::AA_COLLISION)  // AuAu_COLLISION
+    {
+      caloWaveformSim->set_energy_scale(1.0);  // TODO: Au+Au HIJING OHCal scale factor
+    }
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
     caloWaveformSim->set_calibName("HCALOUT_calib_ADC_to_ETower");


### PR DESCRIPTION
Edit necessary macros to use calowaveformsim->set_energy_scale feature. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Update common macros to use `CaloWaveformSim::set_energy_scale`. The current values are placeholders until an energy-scale value is available. The values do not yet propagate to the Fun4All steering macro.

## Key changes

- Set the waveform energy scale to `1.0` for O+O and Au+Au configurations in:
  - `common/G4_CEmc_Spacal.C`
  - `common/G4_HcalIn_ref.C`
  - `common/G4_HcalOut_ref.C`

## Potential risk areas

- The placeholder scale may affect waveform simulation and reconstructed energies if used as a physical calibration.
- No I/O format, thread-safety, or performance changes are expected.
- The current implementation does not allow energy-scale modification through the Fun4All steering macro.

## Possible future improvements

- Replace `1.0` with the validated energy-scale value.
- Propagate the value through the Fun4All steering macro.
- Validate the scale with waveform and reconstruction studies before merging.
- Keep this change open for future reference until calibration inputs are available.

AI-generated summaries can contain errors. Contributors should verify the affected macros and runtime behavior before relying on this summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->