### PR TITLE
add OO noise scaling

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -349,15 +349,20 @@ void CEMC_Towers()
         std::string(getenv("CALIBRATIONROOT")) +
             std::string("/CEMC/LightCollection/Prototype3Module.xml"),
         "data_grid_light_guide_efficiency", "data_grid_fiber_trans");
-    // pedestal scale down for different beam configurations according to Blair
+    
     if (Input::BEAM_CONFIGURATION == Input::pp_ZEROANGLE)
     {
       caloWaveformSim->set_pedestal_scale(0.75);
     }
-    if (Input::BEAM_CONFIGURATION == Input::pp_COLLISION)
+    else if (Input::BEAM_CONFIGURATION == Input::pp_COLLISION)
     {
       caloWaveformSim->set_pedestal_scale(0.77);
     }
+    else if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_pedestal_scale(0.73);
+    }
+
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
 

--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -350,6 +350,12 @@ void HCALInner_Towers()
     //  caloWaveformSim->set_nsamples(12); // default is 12 like in real data - if we ever want a different number of samples
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
+    
+    if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_pedestal_scale(0.73);
+    }
+
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
     //caloWaveformSim->set_calibName("HCALIN_calib_ADC_to_ETower");

--- a/common/G4_HcalOut_ref.C
+++ b/common/G4_HcalOut_ref.C
@@ -386,6 +386,12 @@ void HCALOuter_Towers()
     // caloWaveformSim->set_nsamples(12);// default is 12 like in real data - if we ever want a different number of samples
     caloWaveformSim->set_timewidth(0.2);
     caloWaveformSim->set_peakpos(6);
+    
+    if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
+    {
+      caloWaveformSim->set_pedestal_scale(0.73);
+    }
+
     // caloWaveformSim->Verbosity(2);
     // caloWaveformSim->set_noise_type(CaloWaveformSim::NOISE_NONE);
     caloWaveformSim->set_calibName("HCALOUT_calib_ADC_to_ETower");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

Add pedestal noise scaling for `OO_COLLISION` beam configurations in calorimeter waveform simulations. The scale is `0.73`.

## Key Changes

- Add `OO_COLLISION` pedestal scaling in:
  - `common/G4_CEmc_Spacal.C`
  - `common/G4_HcalIn_ref.C`
  - `common/G4_HcalOut_ref.C`
- Use an exclusive `if`/`else if` chain for CEMC beam configuration handling.

## Potential Risk Areas

- The new scale can change simulated waveform pedestals and downstream reconstruction results for `OO_COLLISION` events.
- No I/O format, thread-safety, or performance changes are indicated.
- Validate the `0.73` value against detector conditions and compare reconstructed observables before and after the change.

## Possible Future Improvements

- Centralize beam-dependent pedestal scale values to avoid duplication.
- Add regression tests for all supported beam configurations.
- Document the source and validity range of the `0.73` scale.

AI-generated summaries can contain mistakes. Review the implementation and validate the physics behavior before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->