### PR TITLE
Work with crossings without Si vertex

### DIFF
--- a/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
+++ b/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
@@ -318,6 +318,7 @@ void Fun4All_raw_hit_TPC_Matched_reco(
   cluster->setUseSurveyGeometry(false);
   cluster->setKEffSide0(1.00);  // OO 82626 - 4.5, AuAu 6x6 76905 -0, pp 79513 - 1.0, 75391 5.8 75405 4.8
   cluster->setKEffSide1(1.60);  // OO 82626 - 5.0, AuAu 6x6 76905 -0, pp 79513 - 1.6, 75391 5.6 75408 4.8
+  cluster->setMaxAcceptedTier(2);
   se->registerSubsystem(cluster);
 
   se->registerSubsystem(new Tpc_PolyTrackReco());      // makes TPC_POLYTRACKS


### PR DESCRIPTION
Accept in the clusterizer crossings, that don't have Si vertex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Allow the clusterizer to accept crossings without a Si vertex.

## Key changes

- Configure the TPC poly-clusterizer with `setMaxAcceptedTier(2)`.
- Accept tracks through tier 2.

## Potential risks

- Reconstruction behavior may change for crossings without a Si vertex.
- No I/O format or thread-safety changes are expected.
- Performance impact should be checked in full production workflows.

## Possible future improvements

- Add validation for tier-2 track acceptance.
- Monitor reconstruction efficiency and background rates.

AI-generated summaries can contain errors. Review the implementation and physics validation results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->