### PR TITLE
Modify Fun4All_raw_hit_TPC_Matched_reco.C  to use new seed matching 

### DIFF
--- a/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
+++ b/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
@@ -342,7 +342,10 @@ void Fun4All_raw_hit_TPC_Matched_reco(
   silicon_match->set_crossing_deltaz_max(10);
   silicon_match->set_crossing_deltaz_min(0);
   silicon_match->set_test_windows_printout(false);
-  silicon_match->set_use_tpc_crossing(true);  // use crossing information from TPC SA seed
+  silicon_match->set_max_crossing_diff(10); // good for poly seeding case  
+  // these are for testing. and default to false. The seed matcher will choose the crossing that works best
+  //  silicon_match->set_use_tpc_crossing_only(false);  // use crossing information from TPC SA seed
+  //  silicon_match->set_use_silicon_crossing_only(false);  // use crossing information from silicon seed
   se->registerSubsystem(silicon_match);
 
   auto *deltazcorr = new PHTpcDeltaZCorrection;


### PR DESCRIPTION
Adds two flags to allow new seed matching to force the use of tpc crossings or silicon crossings. 

By default the matcher chooses the best crossing. I changed the names of the setters to make clear that the flag causes the seed matcher to use ONLY that subsystem crossing and not the best one.

The older setter  "set_use_tpc_crossing()"  still works so as not to break existing macros, but please use the new name for clarity. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Update TPC–silicon seed matching for the new matching behavior. The default behavior selects the best crossing from the TPC or INTT.

## Key changes

- Add a maximum crossing difference of 10 for poly-seeding.
- Support TPC-only and silicon-only crossing matching for testing.
- Keep `set_use_tpc_crossing()` for compatibility.
- Document subsystem-restricted options as disabled alternatives.

## Potential risk areas

- Reconstruction behavior can change because the matcher now selects crossings differently.
- No I/O format or thread-safety changes are expected.
- Matching performance may change slightly due to the crossing selection logic.

## Possible future improvements

- Validate the new behavior with representative collision samples.
- Remove or formalize the testing-only subsystem restrictions after validation.
- Add automated coverage for best-crossing, TPC-only, and silicon-only matching.

AI-generated summaries can contain errors. Please verify the implementation and reconstruction results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->