### PR TITLE
G4_CEmc_Spacal.C EMCal noise scaling updated

### DIFF
--- a/common/G4_CEmc_Spacal.C
+++ b/common/G4_CEmc_Spacal.C
@@ -360,7 +360,7 @@ void CEMC_Towers()
     }
     else if (Input::BEAM_CONFIGURATION == Input::OO_COLLISION)
     {
-      caloWaveformSim->set_pedestal_scale(0.73);
+      caloWaveformSim->set_pedestal_scale(0.40);
     }
 
     // caloWaveformSim->Verbosity(2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

The EMCal pedestal scale for the OO collision beam configuration requires updated noise scaling.

## Key changes

- Change the `CaloWaveformSim` pedestal scale from `0.73` to `0.40` in `common/G4_CEmc_Spacal.C`.
- Apply the change only to the OO collision beam configuration.
- No public interfaces or I/O formats change.

## Potential risk areas

- The change may affect EMCal waveform noise and reconstructed quantities.
- No thread-safety or performance impact is expected.
- Validation should compare pedestal and noise distributions before and after the change.

## Possible future improvements

- Document the calibration basis for the `0.40` scale.
- Add a regression check for the OO pedestal and noise distributions.
- AI-generated summaries can contain mistakes. Review the code and simulation results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->