### PR TITLE
remove (empty) memory tracker printout

### DIFF
--- a/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
+++ b/detectors/sPHENIX/Fun4All_G4_sPHENIX.C
@@ -772,7 +772,6 @@ int Fun4All_G4_sPHENIX(
   se->End();
     
   se->PrintTimer();
-  Fun4AllServer::PrintMemoryTracker();
     
   std::cout << "All done" << std::endl;
   delete se;


### PR DESCRIPTION
The Fun4AllMemoryTracker has changed. The leftover in this macro printed out an empty message only anyway, removed this 