### PR TITLE
Fix sc use micromegas

### DIFF
--- a/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
+++ b/TrackingProduction/Fun4All_raw_hit_TPC_Matched_reco.C
@@ -342,11 +342,14 @@ void Fun4All_raw_hit_TPC_Matched_reco(
   silicon_match->set_crossing_deltaz_max(10);
   silicon_match->set_crossing_deltaz_min(0);
   silicon_match->set_test_windows_printout(false);
-  silicon_match->set_max_crossing_diff(10); // good for poly seeding case  
+  silicon_match->set_max_crossing_diff(10); // good for poly seeding case
   // these are for testing. and default to false. The seed matcher will choose the crossing that works best
   //  silicon_match->set_use_tpc_crossing_only(false);  // use crossing information from TPC SA seed
   //  silicon_match->set_use_silicon_crossing_only(false);  // use crossing information from silicon seed
   se->registerSubsystem(silicon_match);
+
+  // TPOT matching
+  Tracking_Reco_TpcTpotTrackMatching_run2pp();
 
   auto *deltazcorr = new PHTpcDeltaZCorrection;
   deltazcorr->Verbosity(0);
@@ -358,9 +361,9 @@ void Fun4All_raw_hit_TPC_Matched_reco(
   actsFit->setTrkrClusterContainerName("TRKR_CLUSTER");
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
+  actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
   actsFit->set_pp_mode(TRACKING::streaming_mode);
-  actsFit->setUseMicromegas(false);
-  actsFit->set_use_clustermover(false);  // default is true for now
+  actsFit->set_use_clustermover(false);
   actsFit->useActsEvaluator(false);
   actsFit->useOutlierFinder(false);
   actsFit->setFieldMap(G4MAGNET::magfield_tracking);

--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -229,8 +229,8 @@ namespace G4TPC
 namespace G4TRACKING
 {
   // Space Charge calibration flag
-  bool SC_CALIBMODE = false;  // this is anded with G4TPC::ENABLE_DISTORTIONS in TrackingInit()
-  bool SC_USE_MICROMEGAS = true;
+  bool SC_CALIBMODE = false;
+  bool SC_USE_MICROMEGAS = false;
   double SC_COLLISIONRATE = 50e3;                                      // leave at 50 KHz for now, scaling of distortion map not implemented yet
   std::string SC_ROOTOUTPUT_FILENAME = "TpcSpaceChargeMatrices.root";  // space charge calibration output file
 

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -105,11 +105,8 @@ void Tracking_Reco_TrackFit_run2pp(const std::string &outfile = "run2pptrackfit.
 
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
-  actsFit->set_pp_mode(TRACKING::streaming_mode);
-
-  // always disable micromegas from fit
   actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
-
+  actsFit->set_pp_mode(TRACKING::streaming_mode);
   actsFit->set_use_clustermover(true);  // default is true for now
   actsFit->useActsEvaluator(false);
   actsFit->useOutlierFinder(false);
@@ -712,6 +709,7 @@ void Tracking_Reco_TrackFit()
     auto *genfitFit = new PHGenFitTrkFitter;
     genfitFit->Verbosity(verbosity);
     genfitFit->set_fit_silicon_mms(G4TRACKING::SC_CALIBMODE);
+    genfitFit->set_use_micromegas(G4TRACKING::SC_USE_MICROMEGAS);
     se->registerSubsystem(genfitFit);
 
     if (G4TRACKING::SC_CALIBMODE)

--- a/common/Trkr_Reco.C
+++ b/common/Trkr_Reco.C
@@ -102,10 +102,14 @@ void Tracking_Reco_TrackFit_run2pp(const std::string &outfile = "run2pptrackfit.
   actsFit->Verbosity(0);
   actsFit->commissioning(G4TRACKING::use_alignment);
   actsFit->setTrkrClusterContainerName(clusterMapName);
+
   // in calibration mode, fit only Silicons and Micromegas hits
   actsFit->fitSiliconMMs(G4TRACKING::SC_CALIBMODE);
   actsFit->set_pp_mode(TRACKING::streaming_mode);
-  actsFit->setUseMicromegas(false);
+
+  // always disable micromegas from fit
+  actsFit->setUseMicromegas(G4TRACKING::SC_USE_MICROMEGAS);
+
   actsFit->set_use_clustermover(true);  // default is true for now
   actsFit->useActsEvaluator(false);
   actsFit->useOutlierFinder(false);
@@ -213,15 +217,15 @@ void Tracking_Reco_SiliconSeed_run2pp()
       silicon_Seeding->set_beamSpotXY(0,0);
     }
   se->registerSubsystem(silicon_Seeding);
-  
+
   TrackingIterationCounter* counter = new TrackingIterationCounter("TrkrIter1");
   counter->Verbosity(verbosity);
   counter->iteration(1);
   counter->setTrackMapName("SiliconTrackSeedContainer");
   counter->seedIterations();
   se->registerSubsystem(counter);
-      
-      
+
+
   auto *silicon_Seeding2 = new PHActsSiliconSeeding("ActsSeedingIt1");
   silicon_Seeding2->Verbosity(verbosity);
   silicon_Seeding2->setIter2();
@@ -230,8 +234,8 @@ void Tracking_Reco_SiliconSeed_run2pp()
       silicon_Seeding2->set_beamSpotXY(0,0);
     }
   se->registerSubsystem(silicon_Seeding2);
-  
-  
+
+
   TrackingIterationCounter* counter2 = new TrackingIterationCounter("TrkrIter2");
   counter2->Verbosity(verbosity);
   /// Clusters already used are in the 0th iteration
@@ -239,7 +243,7 @@ void Tracking_Reco_SiliconSeed_run2pp()
   counter2->setTrackMapName("SiliconTrackSeedContainerIt1");
   counter2->seedIterations();
   se->registerSubsystem(counter2);
-  
+
   TrackContainerCombiner* combiner = new TrackContainerCombiner;
   combiner->Verbosity(verbosity);
   combiner->newContainerName("SiliconTrackSeedContainer");
@@ -251,7 +255,7 @@ void Tracking_Reco_SiliconSeed_run2pp()
   PHSiliconSeedMerger *merger = new PHSiliconSeedMerger;
   merger->Verbosity(verbosity);
   se->registerSubsystem(merger);
-  
+
 }
 void Tracking_Reco_TrackSeed_run2pp()
 {
@@ -260,7 +264,7 @@ void Tracking_Reco_TrackSeed_run2pp()
 }
 void Tracking_Reco_SiTpcTrackMatching_run2pp(const std::string& clusterMapName = "TRKR_CLUSTER")
 {
-  
+
   auto *se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
   /*
@@ -307,7 +311,7 @@ void Tracking_Reco_SiTpcTrackMatching_run2pp(const std::string& clusterMapName =
 }
 void Tracking_Reco_TpcTpotTrackMatching_run2pp(const std::string& clustermapname = "TRKR_CLUSTER")
 {
-  
+
   auto *se = Fun4AllServer::instance();
   int verbosity = std::max(Enable::VERBOSITY, Enable::TRACKING_VERBOSITY);
   // Match TPC track stubs from CA seeder to clusters in the micromegas layers


### PR DESCRIPTION
This PR makes a few changes about how MICROMEGAS are used in (still default) CASeeder and Polyseeder workflow.
- SC_USE_MICROMEGAS is now set to false by default. (was true before), to make sure that TPOT hits are _not_ included in full trackfit (ACTS or GENFIT) by default. This is the intended behavior after discussion with Christof and other tracking experts. 
- Genfit now also uses SC_USE_MICROMEGAS to decide whether TPOT should be included in the fit or not. 
- in Tracking_Reco_TrackFit_run2pp() rather than hardcoding actsFit->setUseMicromegas() to false, restore using SC_USE_MICROMEGAS. This does not change the now default behavior, but would allow user to re-enable it by changing the flag in the steering macro; something that is not possible for now, and creates inconsistencies when SC_CALIB_MODE is turned on. @jdosbo can you confirm that you are ok with this change ? 
- Finally, in the steering Polyseeder macro provided by Mariia and SBU: re-add TPC-TPOT matching, and use SC_USE_MICROMEGAS to decide whether TPOT hits should be included in the full track fit. 

This should essentially make all macros consistent, while keeping the default behavior unchanged.

Comments welcome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / Context

This update makes MICROMEGAS/TPOT handling consistent across the CASeeder and Polyseeder workflows. TPOT hits are excluded from full ACTS and GENFIT fits by default, while steering macros can enable them.

## Key Changes

- Set `G4TRACKING::SC_USE_MICROMEGAS` to `false` by default.
- Use `SC_USE_MICROMEGAS` to control MICROMEGAS inclusion in ACTS and GENFIT fits.
- Restore the steering-controlled ACTS setting in `Tracking_Reco_TrackFit_run2pp()`.
- Re-add TPC–TPOT matching in the Polyseeder workflow.
- Use `SC_USE_MICROMEGAS` for Polyseeder full-track fitting.

## Potential Risk Areas

- Reconstruction results can change when TPOT usage is enabled or disabled.
- No input or output format changes are expected.
- Performance may change when additional TPOT measurements are included in fits.
- Matching and fitting behavior should be validated for relevant data and simulation samples.

## Possible Future Improvements

- Add regression tests for TPOT matching and fitting with both flag values.
- Document the expected physics and performance impact of enabling MICROMEGAS.
- Review default settings across all tracking workflows for consistency.

AI-generated summaries can contain mistakes. Contributors should verify these points against the code and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->