### PR TITLE
feat: make tpc survey default

### DIFF
--- a/common/G4_TrkrVariables.C
+++ b/common/G4_TrkrVariables.C
@@ -213,7 +213,7 @@ namespace G4TPC
   double maxDriftLength = 102.325;  // new value, CM face to top of GEM stack
   double CM_halfwidth = 0.28;  // cm
 
-  bool tpc_survey_position = false;
+  bool tpc_survey_position = true;
   double rot_x = 0.0;  // tpc default tilt angles (for tpc envelope and endcap)
   double rot_y = 0.0;
   double rot_z = 0.0;


### PR DESCRIPTION
This makes the TPC survey geometry default. Do not merge until we orchestrate the relevant changes in the CDB also, and regardless this should be tested in jenkins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation / context

Enable the TPC survey geometry by default. Coordinate the corresponding CDB changes before merging. Run Jenkins tests before merge.

## Key changes

- Set `G4TPC::tpc_survey_position` from `false` to `true` in `common/G4_TrkrVariables.C`.
- Enable the TPC survey geometry position by default.

## Potential risk areas

- Reconstruction behavior may change if the CDB configuration is not coordinated.
- No IO format, thread-safety, or performance changes are indicated.

## Possible future improvements

- Coordinate and validate the required CDB updates.
- Run Jenkins tests before merging.
- Confirm reconstruction results with the survey geometry enabled.

AI-generated summaries can contain errors. Review the source change and test results before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->