### PR TITLE
mods to work with new condor, reduce mem usage, update build to use

### DIFF
--- a/calibrations/mbd/prorun.sh
+++ b/calibrations/mbd/prorun.sh
@@ -36,6 +36,8 @@ then
 fi
 echo Processing $nevents events
 
+export USER=$(whoami)
+echo USER=$(whoami)
 
 if [[ $USER == "sphnxpro" ]]
 then
@@ -62,7 +64,7 @@ then
   then
     # 2024 Run2auau
     echo "This is run2auau"
-    build=ana.558
+    build=ana.565
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run2auau
@@ -73,7 +75,7 @@ then
   then
     # 2025 Run3auau
     echo "This is run3auau"
-    build=ana.558
+    build=ana.565
     dbtag=newcdbtag
     pass0dir=""
     outbase=DST_MBD_CALIBRATION_run3auau
@@ -193,6 +195,17 @@ then
   #  ln -sf $f .
   #done
 fi
+
+echo ./prorun_mbdcal.sh --outbase "$outbase" \
+  --outdir   "$outdir" \
+  --logbase  "$logbase" \
+  --logdir   "$logdir" \
+  --build    "$build" \
+  --pass0dir "$pass0dir" \
+  --run      "$runno" \
+  --dbtag    "$dbtag" \
+  --nevents  "$nevents" \
+  $inputs
 
 ./prorun_mbdcal.sh --outbase "$outbase" \
   --outdir   "$outdir" \

--- a/calibrations/mbd/prorun_mbdcal.sh
+++ b/calibrations/mbd/prorun_mbdcal.sh
@@ -114,6 +114,8 @@ echo $inputs
 outbase=${outbase}_${build}_${dbtag}_$(printf "%08d" ${runno})
 logbase=${logbase}_${build}_${dbtag}_$(printf "%08d" ${runno})
 
+echo outbase=${outbase}_${build}_${dbtag}_$(printf "%08d" ${runno})
+echo logbase=${logbase}_${build}_${dbtag}_$(printf "%08d" ${runno})
 
 {
 
@@ -163,13 +165,22 @@ mkdir -p ${caldir}
 # If using local files, stage PASS0 calibrations
 if [[ ! -z ${pass0dir} ]]
 then
+  echo USING calibs from $pass0dir
   #./cups.py -r ${runno} -s ${segment} -d ${outbase} message "Stage in pass0 from ${pass0dir}"
   root.exe -b -q DumpMbdCalibs.C\(${runno}\)
   mkdir -p results/${runno}
   mv *.calib results/${runno}/
   cp -p /sphenix/user/chiu/sphenix_bbc/CDB/latest_proRun3OO/results/default/mbd_timecorr.calib results/${runno}/
+  ls -l results/${runno}
 fi
 
+}  > ${logbase}.out 2> ${logbase}.err 
+
+mkdir -p $logdir
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
+
+#{
 # Flag as started
 #./cups.py -r ${runno} -s ${segment} -d ${outbase} running
 
@@ -184,6 +195,12 @@ fi
 #echo "Pass 1 calibration done"
 #ls -la *.root
 
+#}  >> ${logbase}.out 2>> ${logbase}.err 
+#mkdir -p $logdir
+#[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
+#[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
+
+{
 ################################################
 # Pass 2 calibrations waveforms
 #./cups.py -r ${runnumber} -s ${segment} -d ${outbase} message "Running PASS 2 calibration, process waveforms"
@@ -219,6 +236,11 @@ cp -p results/${runno}/pass0_mbd_tq_t0.calib results/${runno}/mbd_tq_t0.calib
 #mv results/${runno}/pass0_mbd_tt_t0.root results/${runno}/mbd_tt_t0-${runno}.root
 #mv results/${runno}/pass0_mbd_tq_t0.root results/${runno}/mbd_tq_t0-${runno}.root
 
+}  >> ${logbase}.out 2>>${logbase}.err 
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
+
+{
 echo "###############################################################################################################"
 echo "Running pass2.3 calibration"
 #./cups.py -r ${runnumber} -s ${segment} -d ${outbase} message "Running PASS 2.3 calibration"
@@ -232,6 +254,11 @@ root.exe -q -b pro_cal_mbd.C\(${runno},${pass}\)
 
 mv results/${runno}/mbd_qfit.root results/${runno}/mbd_qfit-${runno}.root
 
+}  >> ${logbase}.out 2>>${logbase}.err 
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
+
+{
 echo "###############################################################################################################"
 echo "Running pass2.4 calibration"
 echo root.exe -q calib_t0mean.C\(\"results/${runno}/calmbdpass2.3_q-${runno}.root\"\)
@@ -242,6 +269,11 @@ mv results/${runno}/mbd_t0corr.root results/${runno}/mbd_t0corr-${runno}.root
 #./cups.py -r ${runno} -s ${segment} -d ${outbase} message "Done"
 #./cups.py -r ${runno} -s ${segment} -d ${outbase} finished -e 0
 
+}  >> ${logbase}.out 2>>${logbase}.err 
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
+[[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
+
+{
 # Copy out files
 mkdir -p ${outdir}/${runno}
 
@@ -264,9 +296,7 @@ done
 #     ./cups.py -v -r ${runno} -s ${segment} -d ${outbase} finished -e 0 --nevents 0 --inc 
 
 
-}  > ${logbase}.out 2>${logbase}.err 
-
-mkdir -p $logdir
+}  >> ${logbase}.out 2>>${logbase}.err 
 [[ "${logdir%/}" != "." ]] && cp -p ${logbase}.out  ${logdir}
 [[ "${logdir%/}" != "." ]] && cp -p ${logbase}.err  ${logdir}
 

--- a/calibrations/mbd/submit.sh
+++ b/calibrations/mbd/submit.sh
@@ -105,11 +105,10 @@ echo "Queue" | condor_submit \
     -a "Error=$PWD/${logdir}/${log}.err" \
     -a "Initialdir=$PWD" \
     -a "PeriodicHold=(NumJobStarts>=1 && JobStatus == 1 && !(ON_EVICT_CHECK_RequestMemory_REQUIREMENTS))" \
-    -a "request_memory=4096MB" \
+    -a "request_memory=2048MB" \
     -a "retry_request_memory_increase=2048MB" \
     -a "retry_request_memory_max=16192MB" \
-    -a "request_disk=${request_disk}" \
-    -a "GetEnv=True"
+    -a "request_disk=${request_disk}"
 
 
 echo Condor submit logs are in $TMPLOG and output logs are in $logdir

--- a/calibrations/mbd/submit_mbdcalibs.sh
+++ b/calibrations/mbd/submit_mbdcalibs.sh
@@ -3,7 +3,7 @@
 
 if [[ $USER == "sphnxpro" ]]
 then
-  BUILD=pro.001
+  BUILD=ana.565
   source /opt/sphenix/core/bin/sphenix_setup.sh -n $BUILD
   TOPDIR=${PWD}
   # work area for this sub-production


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation

Update MBD calibration jobs for the new Condor environment. Reduce memory requests and use the current analysis build.

## Key changes

- Use `ana.565` for the 2024 Run2auau and 2025 Run3auau workflows.
- Select `ana.565` in `submit_mbdcalibs.sh` for the `sphnxpro` branch.
- Reduce Condor memory from 4096 MB to 2048 MB.
- Remove `GetEnv=True` from the Condor submission.
- Add command and environment logging in `prorun.sh`.
- Separate calibration phases into logged execution blocks.
- Copy phase logs after each block.
- Add diagnostics for output paths, staging directories, and calibration results.
- Ensure the log directory exists before execution.

## Potential risk areas

- The lower memory request can cause job failures if calibration memory use exceeds 2 GB.
- The new build may change reconstruction or calibration behavior.
- Removing `GetEnv=True` may change the runtime environment on Condor workers.
- The revised log redirection can affect log completeness or append duplicate output.
- No file-format or thread-safety changes are indicated.

## Possible future improvements

- Monitor memory use and confirm that 2048 MB is sufficient.
- Validate calibration results against a known reference run.
- Add shell syntax checks and a small submission-path test.
- Document the required Condor environment and build versions.

AI-generated summaries can contain mistakes. Review the scripts and job logs before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->